### PR TITLE
Disable the racy test I just added

### DIFF
--- a/experimental/rsocket-test/RSocketClientServerTest.cpp
+++ b/experimental/rsocket-test/RSocketClientServerTest.cpp
@@ -53,7 +53,9 @@ TEST(RSocketClientServer, StartAndShutdown) {
   makeClient(randPort());
 }
 
-TEST(RSocketClientServer, SimpleConnect) {
+// TODO(alexanderm): Failing upon closing the server.  Error says we're on the
+// wrong EventBase for the AsyncSocket.
+TEST(RSocketClientServer, DISABLED_SimpleConnect) {
   auto const port = randPort();
   auto server = makeServer(port);
   auto client = makeClient(port);


### PR DESCRIPTION
It sometimes passes, sometimes it fails.  Wasn't noticed by Travis because we're
not running `rsocket_tests` on Travis.  I'll put up a separate PR for that too.