### PR TITLE
Add Payload::Clone and fix NewToOldSubscriber which was cloning unsafely

### DIFF
--- a/experimental/rsocket/OldNewBridge.h
+++ b/experimental/rsocket/OldNewBridge.h
@@ -121,8 +121,7 @@ class NewToOldSubscriber : public yarpl::flowable::Subscriber<reactivesocket::Pa
   void onNext(const reactivesocket::Payload& payload) override {
     // Cloning IOBufs just shares their internal buffers, so this isn't the end
     // of the world.
-    auto clone = payload.clone();
-    inner_->onNext(std::move(clone));
+    inner_->onNext(payload.clone());
   }
 
   void onComplete() override {

--- a/experimental/rsocket/OldNewBridge.h
+++ b/experimental/rsocket/OldNewBridge.h
@@ -121,8 +121,7 @@ class NewToOldSubscriber : public yarpl::flowable::Subscriber<reactivesocket::Pa
   void onNext(const reactivesocket::Payload& payload) override {
     // Cloning IOBufs just shares their internal buffers, so this isn't the end
     // of the world.
-    reactivesocket::Payload clone(
-        payload.data->clone(), payload.metadata->clone());
+    reactivesocket::Payload clone = payload.clone();
     inner_->onNext(std::move(clone));
   }
 

--- a/experimental/rsocket/OldNewBridge.h
+++ b/experimental/rsocket/OldNewBridge.h
@@ -121,7 +121,7 @@ class NewToOldSubscriber : public yarpl::flowable::Subscriber<reactivesocket::Pa
   void onNext(const reactivesocket::Payload& payload) override {
     // Cloning IOBufs just shares their internal buffers, so this isn't the end
     // of the world.
-    reactivesocket::Payload clone = payload.clone();
+    auto clone = payload.clone();
     inner_->onNext(std::move(clone));
   }
 

--- a/src/Payload.cpp
+++ b/src/Payload.cpp
@@ -56,15 +56,15 @@ void Payload::clear() {
 }
 
 Payload Payload::clone() const {
-	Payload out;
-	if (data) {
-		out.data = data->clone();
-	}
+  Payload out;
+  if (data) {
+    out.data = data->clone();
+  }
 
-	if (metadata) {
-		out.metadata = metadata->clone();
-	}
-	return out;
+  if (metadata) {
+    out.metadata = metadata->clone();
+  }
+  return out;
 }
 
 FrameFlags Payload::getFlags() const {

--- a/src/Payload.cpp
+++ b/src/Payload.cpp
@@ -55,6 +55,18 @@ void Payload::clear() {
   metadata.reset();
 }
 
+Payload Payload::clone() const {
+	Payload out;
+	if (data) {
+		out.data = data->clone();
+	}
+
+	if (metadata) {
+		out.metadata = metadata->clone();
+	}
+	return out;
+}
+
 FrameFlags Payload::getFlags() const {
   return (metadata != nullptr ? FrameFlags::METADATA : FrameFlags::EMPTY);
 }

--- a/src/Payload.h
+++ b/src/Payload.h
@@ -34,7 +34,6 @@ struct Payload {
   std::string cloneDataToString() const;
   void clear();
 
-  // Clone this object onto the stack
   Payload clone() const;
 
   std::unique_ptr<folly::IOBuf> data;

--- a/src/Payload.h
+++ b/src/Payload.h
@@ -34,6 +34,9 @@ struct Payload {
   std::string cloneDataToString() const;
   void clear();
 
+  // Clone this object onto the stack
+  Payload clone() const;
+
   std::unique_ptr<folly::IOBuf> data;
   std::unique_ptr<folly::IOBuf> metadata;
 };

--- a/test/PayloadTest.cpp
+++ b/test/PayloadTest.cpp
@@ -34,3 +34,47 @@ TEST(PayloadTest, GiantMetadata) {
       FrameSerializerV0_1::deserializeMetadataFrom(cur, FrameFlags::METADATA),
       std::runtime_error);
 }
+
+TEST(PayloadTest, Clone) {
+  Payload orig("data", "metadata");
+
+  // Clone copies both
+  Payload clone = orig.clone();
+  EXPECT_NE(clone.data, nullptr);
+  EXPECT_NE(clone.metadata, nullptr);
+
+  EXPECT_EQ(clone.data->moveToFbString(), "data");
+  EXPECT_EQ(clone.metadata->moveToFbString(), "metadata");
+
+  // Clone now empty, orig unchanged
+  clone.clear();
+  EXPECT_EQ(clone.data, nullptr);
+  EXPECT_EQ(clone.metadata, nullptr);
+  EXPECT_NE(orig.data, nullptr);
+  EXPECT_NE(orig.metadata, nullptr);
+
+  // no data
+  Payload nodata = orig.clone();
+  nodata.data.reset();
+  clone = nodata.clone();
+  EXPECT_EQ(clone.data, nullptr);
+  EXPECT_NE(clone.metadata, nullptr);
+  // orig unchanged
+  EXPECT_NE(orig.data, nullptr);
+  EXPECT_NE(orig.metadata, nullptr);
+
+  // no metadata
+  Payload nometa("data", "");
+  // This constructor doesn't set metadata if it is empty
+  clone = nometa.clone();
+  EXPECT_NE(clone.data, nullptr);
+  EXPECT_EQ(clone.metadata, nullptr);
+
+  // neither
+  std::unique_ptr<folly::IOBuf> data_;
+  std::unique_ptr<folly::IOBuf> metadata_;
+  Payload none(std::move(data_), std::move(metadata_));
+  clone = none.clone();
+  EXPECT_EQ(clone.data, nullptr);
+  EXPECT_EQ(clone.metadata, nullptr);
+}


### PR DESCRIPTION
Added unit test for the new method - I have tested NewOldBridge manually.