### PR TITLE
Refactor TcpConnectionFactory

### DIFF
--- a/experimental/rsocket-test/RSocketClientServerTest.cpp
+++ b/experimental/rsocket-test/RSocketClientServerTest.cpp
@@ -42,8 +42,10 @@ std::unique_ptr<RSocketServer> makeServer(uint16_t port) {
 }
 
 std::unique_ptr<RSocketClient> makeClient(uint16_t port) {
+  folly::SocketAddress address;
+  address.setFromHostPort("localhost", port);
   return RSocket::createClient(
-      std::make_unique<TcpConnectionFactory>("localhost", port));
+      std::make_unique<TcpConnectionFactory>(std::move(address)));
 }
 
 } // namespace

--- a/experimental/rsocket/transports/TcpConnectionFactory.h
+++ b/experimental/rsocket/transports/TcpConnectionFactory.h
@@ -2,46 +2,34 @@
 
 #pragma once
 
-#include <folly/io/async/AsyncSocket.h>
+#include <folly/SocketAddress.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
+
 #include "rsocket/ConnectionFactory.h"
+
 #include "src/DuplexConnection.h"
 
 namespace rsocket {
 
 /**
-* TCP implementation of ConnectionAcceptor for use with RSocket::createServer
-*
-* Creation of this does nothing. The 'start' method kicks off work.
-*
-* When started it will create a Thread and EventBase upon which
-* all AsyncSocket connections will be made.
-*/
+ * TCP implementation of ConnectionFactory for use with RSocket::createClient().
+ *
+ * Creation of this does nothing.  The `start` method kicks off work.
+ */
 class TcpConnectionFactory : public ConnectionFactory {
  public:
-  TcpConnectionFactory(std::string host, uint16_t port);
-  // TODO create variant that passes in EventBase to use
+  explicit TcpConnectionFactory(folly::SocketAddress);
   virtual ~TcpConnectionFactory();
-  TcpConnectionFactory(const TcpConnectionFactory&) = delete; // copy
-  TcpConnectionFactory(TcpConnectionFactory&&) = delete; // move
-  TcpConnectionFactory& operator=(const TcpConnectionFactory&) = delete; // copy
-  TcpConnectionFactory& operator=(TcpConnectionFactory&&) = delete; // move
-
-  static std::unique_ptr<ConnectionFactory> create(
-      std::string host,
-      uint16_t port);
 
   /**
    * Connect to server defined in constructor.
    *
-   * This creates a new AsyncSocket each time connect(...) is called.
-   *
-   * @param onConnect
+   * Each call to connect() creates a new AsyncSocket.
    */
-  void connect(OnConnect onConnect) override;
+  void connect(OnConnect) override;
 
  private:
-  folly::SocketAddress addr_;
-  std::unique_ptr<folly::ScopedEventBaseThread> eventBaseThread_;
+  folly::SocketAddress address_;
+  folly::ScopedEventBaseThread worker_;
 };
 }


### PR DESCRIPTION
* s|SocketConnectorAndCallback|ConnectCallback|g

* Construct the ConnectCallback object entirely on the worker thread.  Fixes
  TSAN warnings about the object being accessed from both the main thread and
  the worker thread.

* Use a unique_ptr deleter in both connectSuccess() and connectErr().

* Switch all the LOG(INFO)s to VLOGs.  We can opt into the terminal spam.

Tested the stream-hello-world client and server.  ASAN is happy.  TSAN is
generating a lot of noise in Flowable code, but the warnings from
TcpConnectionFactory appear to be gone.