### PR TITLE
Silence TSAN warning in Flowable::SynchronousSubscription::process()

### DIFF
--- a/experimental/yarpl/include/yarpl/Flowable.h
+++ b/experimental/yarpl/include/yarpl/Flowable.h
@@ -155,8 +155,12 @@ class Flowable : public virtual Refcounted {
 
       while (true) {
         auto current = requested_.load(std::memory_order_relaxed);
+
+        // Subscription was canceled, completed, or had an error.
         if (current == CANCELED) {
-          // Subscription was canceled, completed, or had an error.
+          // Don't destroy a locked mutex.
+          lock.unlock();
+
           return release();
         }
 


### PR DESCRIPTION
We release the subscription when it is cancelled.  TSAN spews a warning as we're
technically destroying a locked mutex.  Unlocking it just before doing the
release() should be safe, any accesses that would happen after the release()
would already be invalid.

Running `yarpl-tests` no longer spews TSAN warnings.  There's still more
warnings from running the stream-hello-world client and server, will
investigate.