### PR TITLE
Support upcasting a Reference<B> to Reference<A> where B <: A

### DIFF
--- a/experimental/yarpl/CMakeLists.txt
+++ b/experimental/yarpl/CMakeLists.txt
@@ -95,11 +95,12 @@ add_executable(
 #        test/Flowable_range_test.cpp
 #        test/Flowable_lifecycle.cpp
 #        test/FlowableChaining_test.cpp
-        test/Scheduler_test.cpp
-        test/RefcountedTest.cpp
         test/FlowableTest.cpp
-        test/Tuple.h
+        test/RefcountedTest.cpp
+        test/ReferenceTest.cpp
+        test/Scheduler_test.cpp
         test/Tuple.cpp
+        test/Tuple.h
 )
 
 target_link_libraries(

--- a/experimental/yarpl/include/yarpl/Refcounted.h
+++ b/experimental/yarpl/include/yarpl/Refcounted.h
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <cstddef>
 #include <type_traits>
+#include <utility>
 
 namespace yarpl {
 
@@ -56,50 +57,65 @@ class Refcounted {
 template <typename T>
 class Reference {
  public:
-  static_assert(
-      std::is_base_of<Refcounted, T>::value,
-      "Reference must be used with types that virtually derive Refcounted");
+  template <typename U>
+  friend class Reference;
 
-  Reference() : pointer_(nullptr) {}
+  Reference() {}
+  explicit Reference(std::nullptr_t) {}
 
   explicit Reference(T* pointer) : pointer_(pointer) {
-    if (pointer_)
-      pointer_->incRef();
+    inc();
   }
 
   ~Reference() {
-    if (pointer_)
-      pointer_->decRef();
+    dec();
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+
+  Reference(const Reference& other): pointer_(other.pointer_) {
+    inc();
+  }
+
+  Reference(Reference&& other): pointer_(other.pointer_) {
+    other.pointer_ = nullptr;
   }
 
   template <typename U>
-  friend class Reference;
+  Reference(const Reference<U>& other) : pointer_(other.pointer_) {
+    inc();
+  }
 
   template <typename U>
   Reference(Reference<U>&& other) : pointer_(other.pointer_) {
     other.pointer_ = nullptr;
   }
 
-  template <typename U>
-  Reference& operator=(Reference<U>&& other) {
-    Reference(static_cast<Reference<U>&&>(other)).swap(*this);
+  //////////////////////////////////////////////////////////////////////////////
+
+  Reference& operator=(const Reference& other) {
+    new (this) Reference(other);
     return *this;
   }
 
   Reference& operator=(Reference&& other) {
-    Reference(static_cast<Reference&&>(other)).swap(*this);
+    new (this) Reference(std::move(other));
     return *this;
   }
 
-  Reference& operator=(const Reference& other) {
-    Reference(other.pointer_).swap(*this);
+  template <typename U>
+  Reference& operator=(const Reference<U>& other) {
+    new (this) Reference<T>(other);
     return *this;
   }
 
-  Reference(const Reference& other) : pointer_(other.pointer_) {
-    if (pointer_)
-      pointer_->incRef();
+  template <typename U>
+  Reference& operator=(Reference<U>&& other) {
+    new (this) Reference<T>(std::move(other));
+    return *this;
   }
+
+  //////////////////////////////////////////////////////////////////////////////
 
   T* get() const {
     return pointer_;
@@ -114,7 +130,7 @@ class Reference {
   }
 
   void reset() {
-    Reference().swap(*this);
+    Reference{}.swap(*this);
   }
 
   explicit operator bool() const {
@@ -122,13 +138,23 @@ class Reference {
   }
 
  private:
-  void swap(Reference& other) {
-    T* temp = pointer_;
-    pointer_ = other.pointer_;
-    other.pointer_ = temp;
+  void inc() {
+    if (pointer_) {
+      pointer_->incRef();
+    }
   }
 
-  T* pointer_;
+  void dec() {
+    if (pointer_) {
+      pointer_->decRef();
+    }
+  }
+
+  void swap(Reference<T>& other) {
+    std::swap(pointer_, other.pointer_);
+  }
+
+  T* pointer_{nullptr};
 };
 
 } // yarpl

--- a/experimental/yarpl/include/yarpl/Refcounted.h
+++ b/experimental/yarpl/include/yarpl/Refcounted.h
@@ -57,6 +57,10 @@ class Refcounted {
 template <typename T>
 class Reference {
  public:
+  static_assert(
+      std::is_base_of<Refcounted, T>::value,
+      "Reference must be used with types that virtually derive Refcounted");
+
   template <typename U>
   friend class Reference;
 
@@ -73,11 +77,11 @@ class Reference {
 
   //////////////////////////////////////////////////////////////////////////////
 
-  Reference(const Reference& other): pointer_(other.pointer_) {
+  Reference(const Reference& other) : pointer_(other.pointer_) {
     inc();
   }
 
-  Reference(Reference&& other): pointer_(other.pointer_) {
+  Reference(Reference&& other) : pointer_(other.pointer_) {
     other.pointer_ = nullptr;
   }
 
@@ -157,4 +161,4 @@ class Reference {
   T* pointer_{nullptr};
 };
 
-} // yarpl
+} // namespace yarpl

--- a/experimental/yarpl/test/ReferenceTest.cpp
+++ b/experimental/yarpl/test/ReferenceTest.cpp
@@ -1,0 +1,36 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "yarpl/Flowable.h"
+#include "yarpl/Refcounted.h"
+
+using yarpl::Refcounted;
+using yarpl::Reference;
+using yarpl::flowable::Subscriber;
+
+namespace {
+
+template <class T>
+class MySubscriber : public Subscriber<T> {};
+
+}
+
+TEST(ReferenceTest, Upcast) {
+  Reference<MySubscriber<int>> derived(new MySubscriber<int>());
+  Reference<Subscriber<int>> base1(derived);
+
+  Reference<Subscriber<int>> base2;
+  base2 = derived;
+
+  Reference<MySubscriber<int>> derivedCopy1(derived);
+  Reference<MySubscriber<int>> derivedCopy2(derived);
+
+  Reference<Subscriber<int>> base3(std::move(derivedCopy1));
+
+  Reference<Subscriber<int>> base4;
+  base4 = std::move(derivedCopy2);
+}


### PR DESCRIPTION
Just a matter of adding another overload to Reference<T>'s copy/move ctors and
assignment operators that takes a Reference<U>.