### PR TITLE
Switch {flowable,observable}::Subscriber::onNext() to take a T

### DIFF
--- a/examples/util/ExampleSubscriber.cpp
+++ b/examples/util/ExampleSubscriber.cpp
@@ -29,9 +29,9 @@ void ExampleSubscriber::onSubscribe(
   subscription_->request(initialRequest_);
 }
 
-void ExampleSubscriber::onNext(const Payload& element) noexcept {
+void ExampleSubscriber::onNext(Payload element) noexcept {
   LOG(INFO) << "ExampleSubscriber " << this
-            << " onNext as string: " << element.cloneDataToString();
+            << " onNext as string: " << element.moveDataToString();
   received_++;
   if (--requested_ == thresholdForRequest_) {
     int toRequest = (initialRequest_ - thresholdForRequest_);

--- a/examples/util/ExampleSubscriber.h
+++ b/examples/util/ExampleSubscriber.h
@@ -23,7 +23,7 @@ class ExampleSubscriber
 
   void onSubscribe(yarpl::Reference<yarpl::flowable::Subscription>
                        subscription) noexcept override;
-  void onNext(const reactivesocket::Payload& element) noexcept override;
+  void onNext(reactivesocket::Payload) noexcept override;
   void onComplete() noexcept override;
   void onError(const std::exception_ptr ex) noexcept override;
 

--- a/experimental/rsocket/OldNewBridge.h
+++ b/experimental/rsocket/OldNewBridge.h
@@ -118,10 +118,8 @@ class NewToOldSubscriber : public yarpl::flowable::Subscriber<reactivesocket::Pa
     inner_->onSubscribe(bridge_);
   }
 
-  void onNext(const reactivesocket::Payload& payload) override {
-    // Cloning IOBufs just shares their internal buffers, so this isn't the end
-    // of the world.
-    inner_->onNext(payload.clone());
+  void onNext(reactivesocket::Payload payload) override {
+    inner_->onNext(std::move(payload));
   }
 
   void onComplete() override {

--- a/experimental/yarpl/include/yarpl/Flowable.h
+++ b/experimental/yarpl/include/yarpl/Flowable.h
@@ -113,8 +113,8 @@ class Flowable : public virtual Refcounted {
       // Not actually expected to be called.
     }
 
-    virtual void onNext(const T& value) override {
-      subscriber_->onNext(value);
+    virtual void onNext(T value) override {
+      subscriber_->onNext(std::move(value));
     }
 
     virtual void onComplete() override {

--- a/experimental/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/experimental/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -120,12 +120,12 @@ class MapOperator : public FlowableOperator<U, D> {
               std::move(flowable),
               std::move(subscriber)) {}
 
-    virtual void onNext(const U& value) override {
-      auto* subscriber =
+    virtual void onNext(U value) override {
+      auto subscriber =
           FlowableOperator<U, D>::Subscription::subscriber_.get();
       auto* flowable = FlowableOperator<U, D>::Subscription::flowable_.get();
       auto* map = static_cast<MapOperator*>(flowable);
-      subscriber->onNext(map->function_(value));
+      subscriber->onNext(map->function_(std::move(value)));
     }
   };
 
@@ -156,11 +156,12 @@ class TakeOperator : public FlowableOperator<T, T> {
               std::move(subscriber)),
           limit_(limit) {}
 
-    virtual void onNext(const T& value) {
+    virtual void onNext(T value) {
       if (limit_-- > 0) {
         if (pending_ > 0)
           --pending_;
-        FlowableOperator<T, T>::Subscription::subscriber_->onNext(value);
+        FlowableOperator<T, T>::Subscription::subscriber_->onNext(
+            std::move(value));
         if (limit_ == 0) {
           FlowableOperator<T, T>::Subscription::cancel();
           FlowableOperator<T, T>::Subscription::onComplete();
@@ -219,10 +220,10 @@ class SubscribeOnOperator : public FlowableOperator<T, T> {
       worker_->schedule([this] { this->callSuperCancel(); });
     }
 
-    virtual void onNext(const T& value) override {
+    virtual void onNext(T value) override {
       auto* subscriber =
           FlowableOperator<T, T>::Subscription::subscriber_.get();
-      subscriber->onNext(value);
+      subscriber->onNext(std::move(value));
     }
 
    private:

--- a/experimental/yarpl/include/yarpl/flowable/Subscriber.h
+++ b/experimental/yarpl/include/yarpl/flowable/Subscriber.h
@@ -27,7 +27,7 @@ class Subscriber : public virtual Refcounted {
     subscription_.reset();
   }
 
-  virtual void onNext(const T&) {}
+  virtual void onNext(T) {}
 
  protected:
   Subscription* subscription() {

--- a/experimental/yarpl/include/yarpl/flowable/Subscribers.h
+++ b/experimental/yarpl/include/yarpl/flowable/Subscribers.h
@@ -20,7 +20,7 @@ class Subscribers {
       typename T,
       typename Next,
       typename = typename std::enable_if<
-          std::is_callable<Next(const T&), void>::value>::type>
+          std::is_callable<Next(T), void>::value>::type>
   static auto create(
       Next&& next,
       int64_t batch = Flowable<T>::NO_FLOW_CONTROL) {
@@ -33,7 +33,7 @@ class Subscribers {
       typename Next,
       typename Error,
       typename = typename std::enable_if<
-          std::is_callable<Next(const T&), void>::value &&
+          std::is_callable<Next(T), void>::value &&
           std::is_callable<Error(const std::exception_ptr), void>::value>::type>
   static auto create(
       Next&& next,
@@ -49,7 +49,7 @@ class Subscribers {
       typename Error,
       typename Complete,
       typename = typename std::enable_if<
-          std::is_callable<Next(const T&), void>::value &&
+          std::is_callable<Next(T), void>::value &&
           std::is_callable<Error(const std::exception_ptr), void>::value &&
           std::is_callable<Complete(), void>::value>::type>
   static auto create(
@@ -78,8 +78,8 @@ class Subscribers {
       subscription->request(batch_);
     }
 
-    virtual void onNext(const T& value) override {
-      next_(value);
+    virtual void onNext(T value) override {
+      next_(std::move(value));
       if (--pending_ < batch_ / 2) {
         const auto delta = batch_ - pending_;
         pending_ += delta;

--- a/experimental/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/experimental/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -114,12 +114,12 @@ class MapOperator : public ObservableOperator<U, D> {
               std::move(flowable),
               std::move(subscriber)) {}
 
-    virtual void onNext(const U& value) override {
+    virtual void onNext(U value) override {
       auto* subscriber =
           ObservableOperator<U, D>::Subscription::subscriber_.get();
       auto* flowable = ObservableOperator<U, D>::Subscription::flowable_.get();
       auto* map = static_cast<MapOperator*>(flowable);
-      subscriber->onNext(map->function_(value));
+      subscriber->onNext(map->function_(std::move(value)));
     }
   };
 
@@ -150,11 +150,12 @@ class TakeOperator : public ObservableOperator<T, T> {
               std::move(subscriber)),
           limit_(limit) {}
 
-    virtual void onNext(const T& value) {
+    virtual void onNext(T value) {
       if (limit_-- > 0) {
         if (pending_ > 0)
           --pending_;
-        ObservableOperator<T, T>::Subscription::subscriber_->onNext(value);
+        ObservableOperator<T, T>::Subscription::subscriber_->onNext(
+            std::move(value));
         if (limit_ == 0) {
           ObservableOperator<T, T>::Subscription::cancel();
           ObservableOperator<T, T>::Subscription::onComplete();
@@ -205,10 +206,10 @@ class SubscribeOnOperator : public ObservableOperator<T, T> {
       worker_->schedule([this] { this->callSuperCancel(); });
     }
 
-    virtual void onNext(const T& value) override {
+    virtual void onNext(T value) override {
       auto* subscriber =
           ObservableOperator<T, T>::Subscription::subscriber_.get();
-      subscriber->onNext(value);
+      subscriber->onNext(std::move(value));
     }
 
    private:

--- a/experimental/yarpl/include/yarpl/observable/Observer.h
+++ b/experimental/yarpl/include/yarpl/observable/Observer.h
@@ -26,7 +26,7 @@ class Observer : public virtual Refcounted {
     subscription_.reset();
   }
 
-  virtual void onNext(const T&) {}
+  virtual void onNext(T) {}
 
  protected:
   Subscription* subscription() {

--- a/experimental/yarpl/include/yarpl/observable/Observers.h
+++ b/experimental/yarpl/include/yarpl/observable/Observers.h
@@ -20,7 +20,7 @@ class Observers {
       typename T,
       typename Next,
       typename = typename std::enable_if<
-          std::is_callable<Next(const T&), void>::value>::type>
+          std::is_callable<Next(T), void>::value>::type>
   static auto create(
       Next&& next) {
     return Reference<Observer<T>>(
@@ -32,7 +32,7 @@ class Observers {
       typename Next,
       typename Error,
       typename = typename std::enable_if<
-          std::is_callable<Next(const T&), void>::value &&
+          std::is_callable<Next(T), void>::value &&
           std::is_callable<Error(const std::exception_ptr), void>::value>::type>
   static auto create(
       Next&& next,
@@ -47,7 +47,7 @@ class Observers {
       typename Error,
       typename Complete,
       typename = typename std::enable_if<
-          std::is_callable<Next(const T&), void>::value &&
+          std::is_callable<Next(T), void>::value &&
           std::is_callable<Error(const std::exception_ptr), void>::value &&
           std::is_callable<Complete(), void>::value>::type>
   static auto create(
@@ -72,8 +72,8 @@ class Observers {
       Observer<T>::onSubscribe(subscription);
     }
 
-    virtual void onNext(const T& value) override {
-      next_(value);
+    virtual void onNext(T value) override {
+      next_(std::move(value));
     }
 
    private:

--- a/experimental/yarpl/test/Observable_test.cpp
+++ b/experimental/yarpl/test/Observable_test.cpp
@@ -170,7 +170,7 @@ class TakeObserver : public Observer<int> {
     subscription_ = std::move(s);
   }
 
-  void onNext(const int& value) override {
+  void onNext(int value) override {
     v.push_back(value);
     if (++count >= limit) {
       //      std::cout << "Cancelling subscription after receiving " << count


### PR DESCRIPTION
Instead of a `const T&`.  `const T&` is too limited in that it will not work
with move-only types.  We tried to have separate overloads for `const T&` and
`T&&`, but ran into issues with some compilers incorrectly treating `T&&` as a
universal reference.