### PR TITLE
Rename Flowables::just(initialize_list<>) to ::justN(), make it safe

### DIFF
--- a/experimental/yarpl/examples/FlowableExamples.cpp
+++ b/experimental/yarpl/examples/FlowableExamples.cpp
@@ -72,10 +72,10 @@ void FlowableExamples::run() {
   Flowables::just<long>(23)->subscribe(printer<long>());
 
   std::cout << "just: multiple values." << std::endl;
-  Flowables::just<long>({1, 4, 7, 11})->subscribe(printer<long>());
+  Flowables::justN<long>({1, 4, 7, 11})->subscribe(printer<long>());
 
   std::cout << "just: string values." << std::endl;
-  Flowables::just<std::string>({"the", "quick", "brown", "fox"})
+  Flowables::justN<std::string>({"the", "quick", "brown", "fox"})
       ->subscribe(printer<std::string>());
 
   std::cout << "range operator." << std::endl;
@@ -122,7 +122,7 @@ void FlowableExamples::run() {
   ThreadScheduler scheduler;
 
   std::cout << "subscribe_on example" << std::endl;
-  Flowables::just({"0: ", "1: ", "2: "})
+  Flowables::justN({"0: ", "1: ", "2: "})
       ->map([](const char* p) { return std::string(p); })
       ->map([](std::string log) { return log + " on " + getThreadId(); })
       ->subscribeOn(scheduler)

--- a/experimental/yarpl/include/yarpl/Flowables.h
+++ b/experimental/yarpl/include/yarpl/Flowables.h
@@ -47,8 +47,7 @@ class Flowables {
 
   template <typename T>
   static Reference<Flowable<T>> justN(std::initializer_list<T> list) {
-    std::vector<T> vec;
-    std::move(list.begin(), list.end(), std::back_inserter(vec));
+    std::vector<T> vec(list);
 
     auto lambda = [ v = std::move(vec), i = size_t{0} ](
         Subscriber<T> & subscriber, int64_t requested) mutable {

--- a/experimental/yarpl/include/yarpl/Flowables.h
+++ b/experimental/yarpl/include/yarpl/Flowables.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <algorithm>
 #include <limits>
+#include <vector>
 
 #include "Flowable.h"
 
@@ -44,23 +46,28 @@ class Flowables {
   }
 
   template <typename T>
-  static Reference<Flowable<T>> just(std::initializer_list<T> list) {
-    auto lambda = [ list, it = list.begin() ](
+  static Reference<Flowable<T>> justN(std::initializer_list<T> list) {
+    std::vector<T> vec;
+    std::move(list.begin(), list.end(), std::back_inserter(vec));
+
+    size_t i = 0;
+
+    auto lambda = [ v = std::move(vec), i ](
         Subscriber<T> & subscriber, int64_t requested) mutable {
       int64_t emitted = 0;
       bool done = false;
 
-      while (it != list.end() && emitted < requested) {
-        subscriber.onNext(*it++);
+      while (i < v.size() && emitted < requested) {
+        subscriber.onNext(v[i++]);
         ++emitted;
       }
 
-      if (it == list.end()) {
+      if (i == v.size()) {
         subscriber.onComplete();
         done = true;
       }
 
-      return std::make_tuple(static_cast<int64_t>(emitted), done);
+      return std::make_tuple(emitted, done);
     };
 
     return Flowable<T>::create(std::move(lambda));

--- a/experimental/yarpl/include/yarpl/Flowables.h
+++ b/experimental/yarpl/include/yarpl/Flowables.h
@@ -50,9 +50,7 @@ class Flowables {
     std::vector<T> vec;
     std::move(list.begin(), list.end(), std::back_inserter(vec));
 
-    size_t i = 0;
-
-    auto lambda = [ v = std::move(vec), i ](
+    auto lambda = [ v = std::move(vec), i = size_t{0} ](
         Subscriber<T> & subscriber, int64_t requested) mutable {
       int64_t emitted = 0;
       bool done = false;

--- a/experimental/yarpl/test/FlowableTest.cpp
+++ b/experimental/yarpl/test/FlowableTest.cpp
@@ -91,10 +91,10 @@ TEST(FlowableTest, JustFlowable) {
   ASSERT_EQ(std::size_t{0}, Refcounted::objects());
   EXPECT_EQ(run(Flowables::just(22)), std::vector<int>{22});
   EXPECT_EQ(
-      run(Flowables::just({12, 34, 56, 98})),
+      run(Flowables::justN({12, 34, 56, 98})),
       std::vector<int>({12, 34, 56, 98}));
   EXPECT_EQ(
-      run(Flowables::just({"ab", "pq", "yz"})),
+      run(Flowables::justN({"ab", "pq", "yz"})),
       std::vector<const char*>({"ab", "pq", "yz"}));
   EXPECT_EQ(std::size_t{0}, Refcounted::objects());
 }


### PR DESCRIPTION
Copying an initialize_list is unsafe, as it doesn't actually own the memory it
points to.  To make it safe we'll just save all the values into a vector and
keep that around.

Rename the overload to justN() to make the usage clearer.