### PR TITLE
Add Flowables::repeat(T)

### DIFF
--- a/experimental/yarpl/include/yarpl/Flowables.h
+++ b/experimental/yarpl/include/yarpl/Flowables.h
@@ -104,6 +104,18 @@ class Flowables {
     return Flowable<T>::create(std::move(lambda));
   }
 
+  template <typename T>
+  static Reference<Flowable<T>> repeat(T value) {
+    auto lambda = [v = std::move(value)](
+        Subscriber<T> & subscriber, int64_t requested) mutable {
+      for (int64_t i = 0; i < requested; ++i) {
+        subscriber.onNext(v);
+      }
+      return std::make_tuple(requested, false);
+    };
+    return Flowable<T>::create(std::move(lambda));
+  }
+
  private:
   Flowables() = delete;
 };

--- a/experimental/yarpl/test/FlowableTest.cpp
+++ b/experimental/yarpl/test/FlowableTest.cpp
@@ -164,5 +164,11 @@ TEST(FlowableTest, FlowableEmpty) {
   EXPECT_EQ(collector->error(), false);
 }
 
+TEST(FlowableTest, FlowableRepeat) {
+  auto flowable = Flowables::repeat<int>(5)->take(10);
+  EXPECT_EQ(run(std::move(flowable)), std::vector<int>(10, 5));
+  EXPECT_EQ(std::size_t{0}, Refcounted::objects());
+}
+
 } // flowable
 } // yarpl


### PR DESCRIPTION
Should be useful in testing out the movability/copyability of our `T` values.
So far all our operators and `Flowables` helpers only require `T` to be movable,
repeat() will be the first use case that requires `T` to be copyable.