### PR TITLE
Add `Reference<T> make_ref<T, Args...>(Args&&...)`

### DIFF
--- a/experimental/yarpl/examples/FlowableExamples.cpp
+++ b/experimental/yarpl/examples/FlowableExamples.cpp
@@ -47,7 +47,7 @@ void fromPublisherExample() {
       }
     };
 
-    Reference<::yarpl::flowable::Subscription> subscription(new Subscription);
+    auto subscription = make_ref<Subscription>();
     subscriber->onSubscribe(subscription);
     subscriber->onNext(1234);
     subscriber->onNext(5678);

--- a/experimental/yarpl/include/yarpl/Refcounted.h
+++ b/experimental/yarpl/include/yarpl/Refcounted.h
@@ -161,4 +161,11 @@ class Reference {
   T* pointer_{nullptr};
 };
 
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T, typename... Args>
+Reference<T> make_ref(Args&&... args) {
+  return Reference<T>(new T(std::forward<Args>(args)...));
+}
+
 } // namespace yarpl

--- a/experimental/yarpl/test/FlowableTest.cpp
+++ b/experimental/yarpl/test/FlowableTest.cpp
@@ -67,8 +67,7 @@ class CollectingSubscriber : public Subscriber<T> {
 /// exception was sent, the exception is thrown.
 template <typename T>
 std::vector<T> run(Reference<Flowable<T>> flowable) {
-  auto collector =
-      Reference<CollectingSubscriber<T>>(new CollectingSubscriber<T>);
+  auto collector = make_ref<CollectingSubscriber<T>>();
   auto subscriber = Reference<Subscriber<T>>(collector.get());
   flowable->subscribe(std::move(subscriber));
   return collector->values();
@@ -130,8 +129,7 @@ TEST(FlowableTest, SimpleTake) {
 
 TEST(FlowableTest, FlowableError) {
   auto flowable = Flowables::error<int>(std::runtime_error("something broke!"));
-  auto collector =
-      Reference<CollectingSubscriber<int>>(new CollectingSubscriber<int>);
+  auto collector = make_ref<CollectingSubscriber<int>>();
   auto subscriber = Reference<Subscriber<int>>(collector.get());
   flowable->subscribe(std::move(subscriber));
 
@@ -143,8 +141,7 @@ TEST(FlowableTest, FlowableError) {
 TEST(FlowableTest, FlowableErrorPtr) {
   auto flowable = Flowables::error<int>(
       std::make_exception_ptr(std::runtime_error("something broke!")));
-  auto collector =
-      Reference<CollectingSubscriber<int>>(new CollectingSubscriber<int>);
+  auto collector = make_ref<CollectingSubscriber<int>>();
   auto subscriber = Reference<Subscriber<int>>(collector.get());
   flowable->subscribe(std::move(subscriber));
 
@@ -155,8 +152,7 @@ TEST(FlowableTest, FlowableErrorPtr) {
 
 TEST(FlowableTest, FlowableEmpty) {
   auto flowable = Flowables::empty<int>();
-  auto collector =
-      Reference<CollectingSubscriber<int>>(new CollectingSubscriber<int>);
+  auto collector = make_ref<CollectingSubscriber<int>>();
   auto subscriber = Reference<Subscriber<int>>(collector.get());
   flowable->subscribe(std::move(subscriber));
 


### PR DESCRIPTION
Akin to `std::make_shared`.  Makes code more concise.