### PR TITLE
[rsocket-cpp] Basic cold resumption.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,8 +265,10 @@ add_executable(
   test/resumption/ResumeCacheTest.cpp
   test/StreamStateTest.cpp
   test/integration/ClientUtils.h
+  test/integration/ClientUtils.cpp
   test/integration/ServerFixture.h
   test/integration/ServerFixture.cpp
+  test/integration/ColdResumptionTest.cpp
   test/integration/WarmResumptionTest.cpp
   test/streams/Mocks.h
   test/framing/FrameTransportTest.cpp)

--- a/src/statemachine/RSocketStateMachine.cpp
+++ b/src/statemachine/RSocketStateMachine.cpp
@@ -194,7 +194,7 @@ void RSocketStateMachine::resumeStreamsFromCache() {
   for (auto const& it : resumableStreams) {
     auto sub = requestHandler_->handleResumeStream(it.second /* streamName */);
     streamsFactory_.createStreamRequester(
-        Payload(), sub, it.first /* streamId */, executor());
+        Payload(), it.first /* streamId */, sub);
     if (it.first > maxStreamId) {
       maxStreamId = it.first;
     }
@@ -942,7 +942,7 @@ void RSocketStateMachine::setStreamName(
   return resumeCache_->setStreamName(streamId, streamName);
 }
 
-StreamId ConnectionAutomaton::getStreamId(const std::string& streamName) const {
+StreamId RSocketStateMachine::getStreamId(const std::string& streamName) const {
   return resumeCache_->getStreamId(streamName);
 }
 

--- a/src/statemachine/RSocketStateMachine.cpp
+++ b/src/statemachine/RSocketStateMachine.cpp
@@ -188,6 +188,22 @@ void RSocketStateMachine::close(
   closeFrameTransport(std::move(ex), signal);
 }
 
+void RSocketStateMachine::resumeStreamsFromCache() {
+  auto resumableStreams = resumeCache_->getResumableStreams();
+  StreamId maxStreamId = 0;
+  for (auto const& it : resumableStreams) {
+    auto sub = requestHandler_->handleResumeStream(it.first);
+    streamsFactory_.createStreamRequester(
+        Payload(), sub, it.second, executor());
+    if (it.second > maxStreamId) {
+      maxStreamId = it.second;
+    }
+  }
+  if (maxStreamId != 0) {
+    streamsFactory_.setNextStreamId(maxStreamId + 2);
+  }
+}
+
 void RSocketStateMachine::closeFrameTransport(
     folly::exception_wrapper ex,
     StreamCompletionSignal signal) {
@@ -920,7 +936,21 @@ ProtocolVersion RSocketStateMachine::getSerializerProtocolVersion() {
   return frameSerializer_->protocolVersion();
 }
 
+<<<<<<< HEAD:src/statemachine/RSocketStateMachine.cpp
 void RSocketStateMachine::writeNewStream(
+=======
+void ConnectionAutomaton::setStreamId(
+    const std::string& streamName,
+    StreamId streamId) {
+  return resumeCache_->setStreamId(streamName, streamId);
+}
+
+StreamId ConnectionAutomaton::getStreamId(const std::string& streamName) const {
+  return resumeCache_->getStreamId(streamName);
+}
+
+void ConnectionAutomaton::writeNewStream(
+>>>>>>> use request handler:src/ConnectionAutomaton.cpp
     StreamId streamId,
     StreamType streamType,
     uint32_t initialRequestN,

--- a/src/statemachine/RSocketStateMachine.cpp
+++ b/src/statemachine/RSocketStateMachine.cpp
@@ -26,12 +26,13 @@ RSocketStateMachine::RSocketStateMachine(
     std::shared_ptr<RequestHandler> requestHandler,
     std::shared_ptr<Stats> stats,
     std::unique_ptr<KeepaliveTimer> keepaliveTimer,
-    ReactiveSocketMode mode)
+    ReactiveSocketMode mode,
+    std::shared_ptr<ResumeCache> resumeCache)
     : ExecutorBase(executor),
       reactiveSocket_(reactiveSocket),
       stats_(stats),
       mode_(mode),
-      resumeCache_(std::make_shared<ResumeCache>(stats)),
+      resumeCache_(std::move(resumeCache)),
       streamState_(std::make_shared<StreamState>(*stats)),
       requestHandler_(std::move(requestHandler)),
       keepaliveTimer_(std::move(keepaliveTimer)),

--- a/src/statemachine/RSocketStateMachine.cpp
+++ b/src/statemachine/RSocketStateMachine.cpp
@@ -192,11 +192,11 @@ void RSocketStateMachine::resumeStreamsFromCache() {
   auto resumableStreams = resumeCache_->getResumableStreams();
   StreamId maxStreamId = 0;
   for (auto const& it : resumableStreams) {
-    auto sub = requestHandler_->handleResumeStream(it.first);
+    auto sub = requestHandler_->handleResumeStream(it.second /* streamName */);
     streamsFactory_.createStreamRequester(
-        Payload(), sub, it.second, executor());
-    if (it.second > maxStreamId) {
-      maxStreamId = it.second;
+        Payload(), sub, it.first /* streamId */, executor());
+    if (it.first > maxStreamId) {
+      maxStreamId = it.first;
     }
   }
   if (maxStreamId != 0) {
@@ -936,21 +936,17 @@ ProtocolVersion RSocketStateMachine::getSerializerProtocolVersion() {
   return frameSerializer_->protocolVersion();
 }
 
-<<<<<<< HEAD:src/statemachine/RSocketStateMachine.cpp
-void RSocketStateMachine::writeNewStream(
-=======
-void ConnectionAutomaton::setStreamId(
-    const std::string& streamName,
-    StreamId streamId) {
-  return resumeCache_->setStreamId(streamName, streamId);
+void RSocketStateMachine::setStreamName(
+    StreamId streamId,
+    const std::string& streamName) {
+  return resumeCache_->setStreamName(streamId, streamName);
 }
 
 StreamId ConnectionAutomaton::getStreamId(const std::string& streamName) const {
   return resumeCache_->getStreamId(streamName);
 }
 
-void ConnectionAutomaton::writeNewStream(
->>>>>>> use request handler:src/ConnectionAutomaton.cpp
+void RSocketStateMachine::writeNewStream(
     StreamId streamId,
     StreamType streamType,
     uint32_t initialRequestN,

--- a/src/statemachine/RSocketStateMachine.h
+++ b/src/statemachine/RSocketStateMachine.h
@@ -210,7 +210,7 @@ class RSocketStateMachine final
     return *stats_;
   }
 
-  void setStreamId(const std::string& streamName, StreamId streamId);
+  void setStreamName(StreamId streamId, const std::string& streamName);
 
   StreamId getStreamId(const std::string& streamName) const;
 

--- a/src/statemachine/RSocketStateMachine.h
+++ b/src/statemachine/RSocketStateMachine.h
@@ -12,6 +12,7 @@
 #include "src/framing/FrameProcessor.h"
 #include "src/framing/FrameSerializer.h"
 #include "src/Payload.h"
+#include "src/temporary_home/ResumeCache.h"
 #include "src/temporary_home/StreamsFactory.h"
 #include "src/temporary_home/StreamsHandler.h"
 
@@ -65,7 +66,9 @@ class RSocketStateMachine final
       std::shared_ptr<RequestHandler> requestHandler,
       std::shared_ptr<Stats> stats,
       std::unique_ptr<KeepaliveTimer> keepaliveTimer_,
-      ReactiveSocketMode mode);
+      ReactiveSocketMode mode,
+      std::shared_ptr<ResumeCache> resumeCache = 
+          std::make_shared<ResumeCache>());
 
   void closeWithError(Frame_ERROR&& error);
   void disconnectOrCloseWithError(Frame_ERROR&& error) override;

--- a/src/statemachine/RSocketStateMachine.h
+++ b/src/statemachine/RSocketStateMachine.h
@@ -92,6 +92,8 @@ class RSocketStateMachine final
   /// StreamAutomatonBase attached to this ConnectionAutomaton.
   void close(folly::exception_wrapper, StreamCompletionSignal);
 
+  void resumeStreamsFromCache();
+
   std::shared_ptr<FrameTransport> detachFrameTransport();
 
   /// Terminate underlying connection and connect new connection
@@ -207,6 +209,10 @@ class RSocketStateMachine final
   Stats& stats() {
     return *stats_;
   }
+
+  void setStreamId(const std::string& streamName, StreamId streamId);
+
+  StreamId getStreamId(const std::string& streamName) const;
 
  private:
   /// Performs the same actions as ::endStream without propagating closure

--- a/src/statemachine/StreamRequester.h
+++ b/src/statemachine/StreamRequester.h
@@ -22,8 +22,7 @@ class StreamRequester : public ConsumerBase {
   // initialization of the ExecutorBase will be ignored for any of the
   // derived classes
   explicit StreamRequester(const Base::Parameters& params, Payload payload)
-      : ExecutorBase(params.executor),
-        Base(params),
+      : Base(params),
         initialPayload_(std::move(payload)) {}
 
   /// State of the Subscription requester.

--- a/src/statemachine/StreamRequester.h
+++ b/src/statemachine/StreamRequester.h
@@ -22,8 +22,20 @@ class StreamRequester : public ConsumerBase {
   // initialization of the ExecutorBase will be ignored for any of the
   // derived classes
   explicit StreamRequester(const Base::Parameters& params, Payload payload)
-      : Base(params),
+      : ExecutorBase(params.executor),
+        Base(params),
         initialPayload_(std::move(payload)) {}
+
+  /// State of the Subscription requester.
+  enum class State : uint8_t {
+    NEW,
+    REQUESTED,
+    CLOSED,
+  };
+
+  void setState(State state) {
+    state_ = state;
+  }
 
  private:
   // implementation from ConsumerBase::SubscriptionBase
@@ -37,18 +49,13 @@ class StreamRequester : public ConsumerBase {
 
   void endStream(StreamCompletionSignal) override;
 
-  /// State of the Subscription requester.
-  enum class State : uint8_t {
-    NEW,
-    REQUESTED,
-    CLOSED,
-  } state_{State::NEW};
-
   /// An allowance accumulated before the stream is initialised.
   /// Remaining part of the allowance is forwarded to the ConsumerBase.
   AllowanceSemaphore initialResponseAllowance_;
 
   /// Initial payload which has to be sent with 1st request.
   Payload initialPayload_;
+
+  State state_{State::NEW};
 };
 } // reactivesocket

--- a/src/temporary_home/NullRequestHandler.cpp
+++ b/src/temporary_home/NullRequestHandler.cpp
@@ -32,7 +32,7 @@ void NullRequestHandler::handleRequestStream(
   response->onError(std::make_exception_ptr(std::runtime_error("NullRequestHandler")));
 }
 
-std::shared_ptr<Subscriber<Payload>> NullRequestHandler::handleResumeStream(
+Reference<Subscriber<Payload>> NullRequestHandler::handleResumeStream(
     std::string streamName) noexcept {
   LOG(FATAL) << "handleResumeStream handler not provided";
 }

--- a/src/temporary_home/NullRequestHandler.cpp
+++ b/src/temporary_home/NullRequestHandler.cpp
@@ -32,6 +32,11 @@ void NullRequestHandler::handleRequestStream(
   response->onError(std::make_exception_ptr(std::runtime_error("NullRequestHandler")));
 }
 
+std::shared_ptr<Subscriber<Payload>> NullRequestHandler::handleResumeStream(
+    std::string streamName) noexcept {
+  LOG(FATAL) << "handleResumeStream handler not provided";
+}
+
 void NullRequestHandler::handleRequestResponse(
     Payload /*request*/,
     StreamId /*streamId*/,

--- a/src/temporary_home/NullRequestHandler.h
+++ b/src/temporary_home/NullRequestHandler.h
@@ -45,7 +45,7 @@ class NullRequestHandler : public RequestHandler {
       StreamId streamId,
       const yarpl::Reference<yarpl::flowable::Subscriber<Payload>>& response) noexcept override;
 
-  virtual std::shared_ptr<Subscriber<Payload>> handleResumeStream(
+  virtual yarpl::Reference<yarpl::flowable::Subscriber<Payload>> handleResumeStream(
       std::string streamName) noexcept override;
 
   void handleRequestResponse(

--- a/src/temporary_home/NullRequestHandler.h
+++ b/src/temporary_home/NullRequestHandler.h
@@ -45,6 +45,9 @@ class NullRequestHandler : public RequestHandler {
       StreamId streamId,
       const yarpl::Reference<yarpl::flowable::Subscriber<Payload>>& response) noexcept override;
 
+  virtual std::shared_ptr<Subscriber<Payload>> handleResumeStream(
+      std::string streamName) noexcept override;
+
   void handleRequestResponse(
       Payload request,
       StreamId streamId,

--- a/src/temporary_home/ReactiveSocket.cpp
+++ b/src/temporary_home/ReactiveSocket.cpp
@@ -40,6 +40,7 @@ ReactiveSocket::ReactiveSocket(
           std::move(resumeCache))),
       executor_(executor) {
   debugCheckCorrectExecutor();
+  connection_->resumeStreamsFromCache();
   connection_->stats().socketCreated();
 }
 

--- a/src/temporary_home/ReactiveSocket.cpp
+++ b/src/temporary_home/ReactiveSocket.cpp
@@ -40,7 +40,6 @@ ReactiveSocket::ReactiveSocket(
           std::move(resumeCache))),
       executor_(executor) {
   debugCheckCorrectExecutor();
-  connection_->resumeStreamsFromCache();
   connection_->stats().socketCreated();
 }
 
@@ -84,6 +83,7 @@ ReactiveSocket::disconnectedClient(
       protocolVersion == ProtocolVersion::Unknown
           ? FrameSerializer::createCurrentVersion()
           : FrameSerializer::createFrameSerializer(protocolVersion));
+  socket->connection_->resumeStreamsFromCache();
   return socket;
 }
 
@@ -155,7 +155,7 @@ bool ReactiveSocket::requestStream(
   if (streamId == 0) {
     // new stream
     streamId = connection_->streamsFactory().createStreamRequester(
-        std::move(request), std::move(responseSink), executor_);
+        std::move(request), std::move(responseSink));
     connection_->setStreamName(streamId, streamName);
     return true;
   } else {

--- a/src/temporary_home/ReactiveSocket.cpp
+++ b/src/temporary_home/ReactiveSocket.cpp
@@ -55,7 +55,7 @@ ReactiveSocket::fromClientConnection(
       executor,
       std::move(handler),
       std::make_shared<ResumeCache>(stats),
-      std::move(stats),
+      stats,
       std::move(keepaliveTimer),
       setupPayload.protocolVersion);
   socket->clientConnect(

--- a/src/temporary_home/ReactiveSocket.h
+++ b/src/temporary_home/ReactiveSocket.h
@@ -54,6 +54,7 @@ class ReactiveSocket {
   static std::unique_ptr<ReactiveSocket> disconnectedClient(
       folly::Executor& executor,
       std::unique_ptr<RequestHandler> handler,
+      std::shared_ptr<ResumeCache> resumeCache,
       std::shared_ptr<Stats> stats = Stats::noop(),
       std::unique_ptr<KeepaliveTimer> keepaliveTimer =
           std::unique_ptr<KeepaliveTimer>(nullptr),
@@ -79,6 +80,11 @@ class ReactiveSocket {
   void requestStream(
       Payload payload,
       yarpl::Reference<yarpl::flowable::Subscriber<Payload>> responseSink);
+
+  bool requestStream(
+      Payload payload,
+      yarpl::Reference<yarpl::flowable::Subscriber<Payload>> responseSink,
+      std::string streamName);
 
   void requestResponse(
       Payload payload,
@@ -127,6 +133,7 @@ class ReactiveSocket {
   ReactiveSocket(
       ReactiveSocketMode mode,
       std::shared_ptr<RequestHandler> handler,
+      std::shared_ptr<ResumeCache> resumeCache,
       std::shared_ptr<Stats> stats,
       std::unique_ptr<KeepaliveTimer> keepaliveTimer,
       folly::Executor& executor);

--- a/src/temporary_home/ReactiveSocket.h
+++ b/src/temporary_home/ReactiveSocket.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include "src/internal/Common.h"
 #include "src/temporary_home/ConnectionSetupPayload.h"
+#include "src/temporary_home/ResumeCache.h"
 #include "src/Payload.h"
 #include "Stats.h"
 #include "yarpl/flowable/Subscriber.h"

--- a/src/temporary_home/RequestHandler.h
+++ b/src/temporary_home/RequestHandler.h
@@ -29,6 +29,10 @@ class RequestHandler {
       StreamId streamId,
       const yarpl::Reference<yarpl::flowable::Subscriber<Payload>>& response) noexcept = 0;
 
+  /// Handles a Stream resumed after cold restart
+  virtual std::shared_ptr<Subscriber<Payload>> handleResumeStream(
+      std::string streamName) noexcept = 0;
+
   /// Handles a new inbound RequestResponse requested by the other end.
   virtual void handleRequestResponse(
       Payload request,

--- a/src/temporary_home/RequestHandler.h
+++ b/src/temporary_home/RequestHandler.h
@@ -30,7 +30,7 @@ class RequestHandler {
       const yarpl::Reference<yarpl::flowable::Subscriber<Payload>>& response) noexcept = 0;
 
   /// Handles a Stream resumed after cold restart
-  virtual std::shared_ptr<Subscriber<Payload>> handleResumeStream(
+  virtual yarpl::Reference<yarpl::flowable::Subscriber<Payload>> handleResumeStream(
       std::string streamName) noexcept = 0;
 
   /// Handles a new inbound RequestResponse requested by the other end.

--- a/src/temporary_home/ResumeCache.cpp
+++ b/src/temporary_home/ResumeCache.cpp
@@ -132,6 +132,30 @@ bool ResumeCache::isPositionAvailable(
   return result;
 }
 
+StreamId ResumeCache::getStreamId(const std::string& streamName) const {
+  auto it = streamNameMap_.find(streamName);
+  if (it == streamNameMap_.end()) {
+    return 0;
+  } else {
+    return it->second;
+  }
+}
+
+std::unordered_map<std::string /* streamName */, StreamId>
+ResumeCache::getResumableStreams() {
+  // An entry is added to streamNameMap_ when the stream is created. But the
+  // entry gets added to streamMap_ only when the frames of the stream are
+  // sent on the wire.  Check whether the stream entry exists on both to be
+  // resumable.
+  std::unordered_map<std::string, StreamId> resumableStreams;
+  for (const auto& it : streamNameMap_) {
+    if (streamMap_.find(it.second) != streamMap_.end()) {
+      resumableStreams[it.first] = it.second;
+    }
+  }
+  return resumableStreams;
+}
+
 void ResumeCache::addFrame(const folly::IOBuf& frame, size_t frameDataLength) {
   size_ += frameDataLength;
   while (size_ > capacity_) {

--- a/src/temporary_home/ResumeCache.h
+++ b/src/temporary_home/ResumeCache.h
@@ -29,7 +29,7 @@ class FrameTransport;
 class ResumeCache {
  public:
   explicit ResumeCache(
-      std::shared_ptr<Stats> stats,
+      std::shared_ptr<Stats> stats = Stats::noop(),
       size_t capacity = DEFAULT_CAPACITY)
       : stats_(std::move(stats)), capacity_(capacity) {}
   ~ResumeCache();

--- a/src/temporary_home/ResumeCache.h
+++ b/src/temporary_home/ResumeCache.h
@@ -73,6 +73,15 @@ class ResumeCache {
     return clientPosition <= impliedPosition_;
   }
 
+  void setStreamId(const std::string& streamName, StreamId streamId) {
+    streamNameMap_[streamName] = streamId;
+  }
+
+  StreamId getStreamId(const std::string& streamName) const;
+
+  std::unordered_map<std::string /* streamName */, StreamId>
+  getResumableStreams();
+
   size_t size() const {
     return size_;
   }
@@ -94,6 +103,8 @@ class ResumeCache {
   ResumePosition impliedPosition_{0};
 
   std::unordered_map<StreamId, ResumePosition> streamMap_;
+
+  std::unordered_map<std::string /* streamName */, StreamId> streamNameMap_;
 
   std::deque<std::pair<ResumePosition, std::unique_ptr<folly::IOBuf>>> frames_;
 

--- a/src/temporary_home/ResumeCache.h
+++ b/src/temporary_home/ResumeCache.h
@@ -73,13 +73,13 @@ class ResumeCache {
     return clientPosition <= impliedPosition_;
   }
 
-  void setStreamId(const std::string& streamName, StreamId streamId) {
-    streamNameMap_[streamName] = streamId;
+  void setStreamName(StreamId streamId, const std::string& streamName) {
+    streamNameMap_[streamId] = streamName;
   }
 
   StreamId getStreamId(const std::string& streamName) const;
 
-  std::unordered_map<std::string /* streamName */, StreamId>
+  std::unordered_map<StreamId, std::string /* streamName */>
   getResumableStreams();
 
   size_t size() const {
@@ -104,7 +104,7 @@ class ResumeCache {
 
   std::unordered_map<StreamId, ResumePosition> streamMap_;
 
-  std::unordered_map<std::string /* streamName */, StreamId> streamNameMap_;
+  std::unordered_map<StreamId, std::string /* streamName */> streamNameMap_;
 
   std::deque<std::pair<ResumePosition, std::unique_ptr<folly::IOBuf>>> frames_;
 

--- a/src/temporary_home/StreamsFactory.cpp
+++ b/src/temporary_home/StreamsFactory.cpp
@@ -33,6 +33,31 @@ Reference<yarpl::flowable::Subscriber<Payload>> StreamsFactory::createChannelReq
   return automaton;
 }
 
+StreamId StreamsFactory::createStreamRequester(
+    Payload request,
+    std::shared_ptr<Subscriber<Payload>> responseSink) {
+  auto nextStreamId = getNextStreamId();
+  StreamRequester::Parameters params(
+      connection_.shared_from_this(), nextStreamId);
+  auto automaton =
+      yarpl::make_ref<StreamRequester>(params, std::move(request));
+  connection_.addStream(params.streamId, automaton);
+  automaton->subscribe(std::move(responseSink));
+  return nextStreamId;
+}
+
+void StreamsFactory::createStreamRequester(
+    Payload request,
+		StreamId streamId,
+    std::shared_ptr<Subscriber<Payload>> responseSink) {
+  StreamRequester::Parameters params(connection_.shared_from_this(), streamId);
+  auto automaton =
+      yarpl::make_ref<StreamRequester>(params, std::move(request));
+  automaton->setState(StreamRequester::State::REQUESTED);
+  connection_.addStream(params.streamId, automaton);
+  automaton->subscribe(std::move(responseSink));
+}
+
 void StreamsFactory::createStreamRequester(
     Payload request,
     Reference<yarpl::flowable::Subscriber<Payload>> responseSink) {

--- a/src/temporary_home/StreamsFactory.h
+++ b/src/temporary_home/StreamsFactory.h
@@ -23,8 +23,13 @@ class StreamsFactory {
   yarpl::Reference<yarpl::flowable::Subscriber<Payload>> createChannelRequester(
       yarpl::Reference<yarpl::flowable::Subscriber<Payload>> responseSink);
 
+  StreamId createStreamRequester(
+      Payload request,
+      yarpl::Reference<yarpl::flowable::Subscriber<Payload>> responseSink);
+
   void createStreamRequester(
       Payload request,
+      StreamId streamId,
       yarpl::Reference<yarpl::flowable::Subscriber<Payload>> responseSink);
 
   void createRequestResponseRequester(
@@ -46,6 +51,7 @@ class StreamsFactory {
 
   bool registerNewPeerStreamId(StreamId streamId);
   StreamId getNextStreamId();
+  void setNextStreamId(StreamId nextStreamId);
 
  private:
   RSocketStateMachine& connection_;

--- a/test/integration/ClientUtils.cpp
+++ b/test/integration/ClientUtils.cpp
@@ -1,0 +1,57 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "test/integration/ClientUtils.h"
+
+namespace reactivesocket {
+namespace tests {
+
+// Utility function to create a FrameTransport.
+std::shared_ptr<FrameTransport> getFrameTransport(
+    folly::EventBase* eventBase,
+    folly::AsyncSocket::ConnectCallback* connectCb,
+    uint32_t port) {
+  folly::SocketAddress addr;
+  addr.setFromLocalPort(folly::to<uint16_t>(port));
+  folly::AsyncSocket::UniquePtr socket(new folly::AsyncSocket(eventBase));
+  socket->connect(connectCb, addr);
+  LOG(INFO) << "Attempting connection to " << addr.describe();
+  std::unique_ptr<DuplexConnection> connection =
+      std::make_unique<TcpDuplexConnection>(
+          std::move(socket), inlineExecutor(), Stats::noop());
+  std::unique_ptr<DuplexConnection> framedConnection =
+      std::make_unique<FramedDuplexConnection>(
+          std::move(connection), *eventBase);
+  return std::make_shared<FrameTransport>(std::move(framedConnection));
+}
+
+// Utility function to create a ReactiveSocket.
+std::unique_ptr<ReactiveSocket> getRSocket(
+    folly::EventBase* eventBase,
+    std::shared_ptr<ResumeCache> resumeCache) {
+  std::unique_ptr<ReactiveSocket> rsocket;
+  std::unique_ptr<RequestHandler> requestHandler =
+      std::make_unique<ClientRequestHandler>();
+  rsocket = ReactiveSocket::disconnectedClient(
+      *eventBase,
+      std::move(requestHandler),
+      std::move(resumeCache),
+      Stats::noop(),
+      std::make_unique<FollyKeepaliveTimer>(
+          *eventBase, std::chrono::seconds(10)));
+  rsocket->onConnected([]() { LOG(INFO) << "ClientSocket connected"; });
+  rsocket->onDisconnected([](const folly::exception_wrapper& ex) {
+    LOG(INFO) << "ClientSocket disconnected: " << ex.what();
+  });
+  rsocket->onClosed([](const folly::exception_wrapper& ex) {
+    LOG(INFO) << "ClientSocket closed: " << ex.what();
+  });
+  return rsocket;
+}
+
+// Utility function to create a SetupPayload
+ConnectionSetupPayload getSetupPayload(ResumeIdentificationToken token) {
+  return ConnectionSetupPayload(
+      "text/plain", "text/plain", Payload("meta", "data"), true, token);
+}
+}
+}

--- a/test/integration/ClientUtils.cpp
+++ b/test/integration/ClientUtils.cpp
@@ -27,10 +27,9 @@ std::shared_ptr<FrameTransport> getFrameTransport(
 // Utility function to create a ReactiveSocket.
 std::unique_ptr<ReactiveSocket> getRSocket(
     folly::EventBase* eventBase,
-    std::shared_ptr<ResumeCache> resumeCache) {
+    std::shared_ptr<ResumeCache> resumeCache, 
+    std::unique_ptr<RequestHandler> requestHandler) {
   std::unique_ptr<ReactiveSocket> rsocket;
-  std::unique_ptr<RequestHandler> requestHandler =
-      std::make_unique<ClientRequestHandler>();
   rsocket = ReactiveSocket::disconnectedClient(
       *eventBase,
       std::move(requestHandler),

--- a/test/integration/ClientUtils.h
+++ b/test/integration/ClientUtils.h
@@ -96,46 +96,16 @@ class MySubscriber : public yarpl::flowable::Subscriber<Payload> {
 std::shared_ptr<FrameTransport> getFrameTransport(
     folly::EventBase* eventBase,
     folly::AsyncSocket::ConnectCallback* connectCb,
-    uint32_t port) {
-  folly::SocketAddress addr;
-  addr.setFromLocalPort(folly::to<uint16_t>(port));
-  folly::AsyncSocket::UniquePtr socket(new folly::AsyncSocket(eventBase));
-  socket->connect(connectCb, addr);
-  LOG(INFO) << "Attempting connection to " << addr.describe();
-  std::unique_ptr<DuplexConnection> connection =
-      std::make_unique<TcpDuplexConnection>(
-          std::move(socket), inlineExecutor(), Stats::noop());
-  std::unique_ptr<DuplexConnection> framedConnection =
-      std::make_unique<FramedDuplexConnection>(
-          std::move(connection), *eventBase);
-  return std::make_shared<FrameTransport>(std::move(framedConnection));
-}
+    uint32_t port);
 
 // Utility function to create a ReactiveSocket.
-std::unique_ptr<ReactiveSocket> getRSocket(folly::EventBase* eventBase) {
-  std::unique_ptr<ReactiveSocket> rsocket;
-  std::unique_ptr<RequestHandler> requestHandler =
-      std::make_unique<ClientRequestHandler>();
-  rsocket = ReactiveSocket::disconnectedClient(
-      *eventBase,
-      std::move(requestHandler),
-      Stats::noop(),
-      std::make_unique<FollyKeepaliveTimer>(
-          *eventBase, std::chrono::seconds(10)));
-  rsocket->onConnected([]() { LOG(INFO) << "ClientSocket connected"; });
-  rsocket->onDisconnected([](const folly::exception_wrapper& ex) {
-    LOG(INFO) << "ClientSocket disconnected: " << ex.what();
-  });
-  rsocket->onClosed([](const folly::exception_wrapper& ex) {
-    LOG(INFO) << "ClientSocket closed: " << ex.what();
-  });
-  return rsocket;
-}
+std::unique_ptr<ReactiveSocket> getRSocket(
+    folly::EventBase* eventBase,
+    std::shared_ptr<ResumeCache> resumeCache =
+        std::make_shared<ResumeCache>());
 
 // Utility function to create a SetupPayload
-ConnectionSetupPayload getSetupPayload(ResumeIdentificationToken token) {
-  return ConnectionSetupPayload(
-      "text/plain", "text/plain", Payload("meta", "data"), true, token);
-}
+ConnectionSetupPayload getSetupPayload(ResumeIdentificationToken token);
+
 }
 }

--- a/test/integration/ClientUtils.h
+++ b/test/integration/ClientUtils.h
@@ -62,14 +62,14 @@ class ClientRequestHandler : public DefaultRequestHandler {
     LOG(INFO) << "Subscriber Resumed";
   }
 
-  std::shared_ptr<Subscriber<Payload>> handleResumeStream(
+  yarpl::Reference<yarpl::flowable::Subscriber<Payload>> handleResumeStream(
       std::string streamName) noexcept override {
     LOG(INFO) << "Stream Resumed - " << streamName;
     return handleResumeStream_(streamName);
   }
   MOCK_METHOD1(
       handleResumeStream_,
-      std::shared_ptr<Subscriber<Payload>>(std::string));
+      yarpl::Reference<yarpl::flowable::Subscriber<Payload>>(std::string));
 };
 
 class MySubscriber : public yarpl::flowable::Subscriber<Payload> {

--- a/test/integration/ColdResumptionTest.cpp
+++ b/test/integration/ColdResumptionTest.cpp
@@ -14,6 +14,7 @@
 using namespace std::chrono_literals;
 using namespace ::reactivesocket;
 using namespace ::testing;
+using namespace yarpl;
 
 using folly::ScopedEventBaseThread;
 
@@ -25,7 +26,7 @@ TEST_F(ServerFixture, ColdResumptionBasic) {
   tests::MyConnectCallback connectCb;
   auto token = ResumeIdentificationToken::generateNew();
   std::unique_ptr<ReactiveSocket> rsocket;
-  auto mySub1 = std::make_shared<tests::MySubscriber>();
+  auto mySub1 = make_ref<tests::MySubscriber>();
   auto resumeCache = std::make_shared<ResumeCache>();
   Sequence s;
   SCOPE_EXIT {
@@ -62,7 +63,7 @@ TEST_F(ServerFixture, ColdResumptionBasic) {
 
   // Disconnect. Simulate a cold restart
   clientEvb->runInEventBaseThreadAndWait([&]() { rsocket.reset(); });
-  auto mySub2 = std::make_shared<tests::MySubscriber>();
+  auto mySub2 = make_ref<tests::MySubscriber>();
   auto requestHandler = std::make_unique<tests::ClientRequestHandler>();
 
   // Get resume callbacks
@@ -101,8 +102,8 @@ TEST_F(ServerFixture, ColdResumption2Streams) {
   tests::MyConnectCallback connectCb;
   auto token = ResumeIdentificationToken::generateNew();
   std::unique_ptr<ReactiveSocket> rsocket;
-  auto mySub1 = std::make_shared<tests::MySubscriber>();
-  auto mySub2 = std::make_shared<tests::MySubscriber>();
+  auto mySub1 = make_ref<tests::MySubscriber>();
+  auto mySub2 = make_ref<tests::MySubscriber>();
   auto resumeCache = std::make_shared<ResumeCache>();
   Sequence s;
   SCOPE_EXIT {
@@ -154,8 +155,8 @@ TEST_F(ServerFixture, ColdResumption2Streams) {
   // Disconnect. Simulate a cold restart
   clientEvb->runInEventBaseThreadAndWait([&]() { rsocket.reset(); });
   auto requestHandler = std::make_unique<tests::ClientRequestHandler>();
-  mySub1 = std::make_shared<tests::MySubscriber>();
-  mySub2 = std::make_shared<tests::MySubscriber>();
+  mySub1 = make_ref<tests::MySubscriber>();
+  mySub2 = make_ref<tests::MySubscriber>();
   bool mySub1P2 = false;
   bool mySub2P2 = false;
 

--- a/test/integration/ColdResumptionTest.cpp
+++ b/test/integration/ColdResumptionTest.cpp
@@ -1,0 +1,192 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <chrono>
+#include <condition_variable>
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include <folly/io/async/ScopedEventBaseThread.h>
+
+#include "test/integration/ClientUtils.h"
+#include "test/integration/ServerFixture.h"
+
+using namespace std::chrono_literals;
+using namespace ::reactivesocket;
+using namespace ::testing;
+
+using folly::ScopedEventBaseThread;
+
+// A very simple test which tests a basic cold resumption workflow.
+// This setup can be used to test varying scenarious in cold resumption.
+TEST_F(ServerFixture, ColdResumptionBasic) {
+  ScopedEventBaseThread eventBaseThread;
+  auto clientEvb = eventBaseThread.getEventBase();
+  tests::MyConnectCallback connectCb;
+  auto token = ResumeIdentificationToken::generateNew();
+  std::unique_ptr<ReactiveSocket> rsocket;
+  auto mySub = std::make_shared<tests::MySubscriber>();
+  auto resumeCache = std::make_shared<ResumeCache>();
+  Sequence s;
+  SCOPE_EXIT {
+    clientEvb->runInEventBaseThreadAndWait([&]() { rsocket.reset(); });
+  };
+
+  // The thread running this test, and the thread running the clientEvb
+  // have to synchronized with a barrier.
+  std::mutex cvM;
+  std::condition_variable cv;
+  std::unique_lock<std::mutex> lk(cvM);
+
+  // Get a few subscriptions (happens right after connecting)
+  EXPECT_CALL(*mySub, onSubscribe_()).WillOnce(Invoke([&]() {
+    mySub->request(3);
+  }));
+  EXPECT_CALL(*mySub, onNext_("1"));
+  EXPECT_CALL(*mySub, onNext_("2"));
+  EXPECT_CALL(*mySub, onNext_("3")).WillOnce(Invoke([&](std::string) {
+    cv.notify_all();
+  }));
+
+  // Create a RSocket and RequestStream
+  clientEvb->runInEventBaseThreadAndWait([&]() {
+    rsocket = tests::getRSocket(clientEvb, resumeCache);
+    rsocket->requestStream(Payload("from client"), mySub);
+    rsocket->clientConnect(
+        tests::getFrameTransport(clientEvb, &connectCb, serverListenPort_),
+        tests::getSetupPayload(token));
+  });
+
+  // Wait for few packets to exchange before disconnecting OR error out.
+  EXPECT_EQ(std::cv_status::no_timeout, cv.wait_for(lk, 1s));
+
+  // Disconnect. Simulate a cold restart
+  clientEvb->runInEventBaseThreadAndWait([&]() { rsocket.reset(); });
+  mySub = std::make_shared<tests::MySubscriber>();
+
+  // Get subscriptions for buffered request (happens right after
+  // reconnecting)
+  EXPECT_CALL(*mySub, onSubscribe_()).WillOnce(Invoke([&]() {
+    mySub->request(2);
+  }));
+  EXPECT_CALL(*mySub, onNext_("4"));
+  EXPECT_CALL(*mySub, onNext_("5")).WillOnce(Invoke([&](std::string) {
+    cv.notify_all();
+  }));
+
+  // try resume
+  clientEvb->runInEventBaseThreadAndWait([&]() {
+    rsocket = tests::getRSocket(clientEvb, resumeCache);
+    rsocket->tryClientResume(
+        token,
+        tests::getFrameTransport(clientEvb, &connectCb, serverListenPort_),
+        std::make_unique<tests::ResumeCallback>());
+    rsocket->requestStream(Payload("after resume"), mySub, 1);
+  });
+
+  // Wait for the remaining frames to make it OR error out.
+  EXPECT_EQ(std::cv_status::no_timeout, cv.wait_for(lk, 1s));
+}
+
+
+// Test cold resumption with two active streams
+TEST_F(ServerFixture, ColdResumption2Streams) {
+  ScopedEventBaseThread eventBaseThread;
+  auto clientEvb = eventBaseThread.getEventBase();
+  tests::MyConnectCallback connectCb;
+  auto token = ResumeIdentificationToken::generateNew();
+  std::unique_ptr<ReactiveSocket> rsocket;
+  auto mySub1 = std::make_shared<tests::MySubscriber>();
+  auto mySub2 = std::make_shared<tests::MySubscriber>();
+  auto resumeCache = std::make_shared<ResumeCache>();
+  StreamId streamId1, streamId2;
+  Sequence s;
+  SCOPE_EXIT {
+    clientEvb->runInEventBaseThreadAndWait([&]() { rsocket.reset(); });
+  };
+
+  // The thread running this test, and the thread running the clientEvb
+  // have to synchronized with a barrier.
+  std::mutex cvM;
+  std::condition_variable cv;
+  std::unique_lock<std::mutex> lk(cvM);
+
+  bool mySub1P1 = false;
+  bool mySub2P1 = false;
+
+  // Get a few subscriptions (happens right after connecting)
+  EXPECT_CALL(*mySub1, onSubscribe_()).WillOnce(Invoke([&]() {
+    mySub1->request(3);
+  }));
+  EXPECT_CALL(*mySub1, onNext_("1"));
+  EXPECT_CALL(*mySub1, onNext_("2"));
+  EXPECT_CALL(*mySub1, onNext_("3")).WillOnce(Invoke([&](std::string) {
+    mySub1P1 = true;
+    cv.notify_all();
+  }));
+
+  EXPECT_CALL(*mySub2, onSubscribe_()).WillOnce(Invoke([&]() {
+    mySub2->request(2);
+  }));
+  EXPECT_CALL(*mySub2, onNext_("1"));
+  EXPECT_CALL(*mySub2, onNext_("2")).WillOnce(Invoke([&](std::string) {
+    mySub2P1 = true;
+    cv.notify_all();
+  }));
+
+  // Create a RSocket and request two streams 
+  clientEvb->runInEventBaseThreadAndWait([&]() {
+    rsocket = tests::getRSocket(clientEvb, resumeCache);
+    streamId1 = rsocket->requestStream(Payload("STREAM1"), mySub1);
+    streamId2 = rsocket->requestStream(Payload("STREAM2"), mySub2);
+    rsocket->clientConnect(
+        tests::getFrameTransport(clientEvb, &connectCb, serverListenPort_),
+        tests::getSetupPayload(token));
+  });
+
+  // Wait for few packets to exchange before disconnecting OR error out.
+  EXPECT_TRUE(cv.wait_for(lk, 1s, [&] { return mySub1P1 && mySub2P1; }));
+
+  // Disconnect. Simulate a cold restart
+  clientEvb->runInEventBaseThreadAndWait([&]() {
+    rsocket.reset(); });
+  mySub1 = std::make_shared<tests::MySubscriber>();
+  mySub2 = std::make_shared<tests::MySubscriber>();
+  bool mySub1P2 = false;
+  bool mySub2P2 = false;
+
+  // Get subscriptions for buffered request (happens right after
+  // reconnecting)
+  EXPECT_CALL(*mySub1, onSubscribe_()).WillOnce(Invoke([&]() {
+    mySub1->request(3);
+  }));
+  EXPECT_CALL(*mySub1, onNext_("4"));
+  EXPECT_CALL(*mySub1, onNext_("5"));
+  EXPECT_CALL(*mySub1, onNext_("6")).WillOnce(Invoke([&](std::string) {
+    mySub1P2 = true;
+    cv.notify_all();
+  }));
+
+  EXPECT_CALL(*mySub2, onSubscribe_()).WillOnce(Invoke([&]() {
+    mySub2->request(2);
+  }));
+  EXPECT_CALL(*mySub2, onNext_("3"));
+  EXPECT_CALL(*mySub2, onNext_("4")).WillOnce(Invoke([&](std::string) {
+    mySub2P2 = true;
+    cv.notify_all();
+  }));
+
+  // try resume
+  clientEvb->runInEventBaseThreadAndWait([&]() {
+    rsocket = tests::getRSocket(clientEvb, resumeCache);
+    rsocket->tryClientResume(
+        token,
+        tests::getFrameTransport(clientEvb, &connectCb, serverListenPort_),
+        std::make_unique<tests::ResumeCallback>());
+    rsocket->requestStream(Payload("after resume"), mySub1, streamId1);
+    rsocket->requestStream(Payload("after resume"), mySub2, streamId2);
+  });
+
+  // Wait for the remaining frames to make it OR error out.
+  EXPECT_TRUE(cv.wait_for(lk, 1s, [&] { return mySub1P2 && mySub2P2; }));
+}

--- a/test/integration/ServerFixture.cpp
+++ b/test/integration/ServerFixture.cpp
@@ -165,7 +165,7 @@ class MyAcceptCallback : public AsyncServerSocket::AcceptCallback {
   MyAcceptCallback(EventBase& eventBase)
       : eventBase_(eventBase),
         connectionHandler_(std::make_shared<MyConnectionHandler>(eventBase)),
-        connectionAcceptor_(ProtocolVersion::Latest) {}
+        connectionAcceptor_(FrameSerializer::getCurrentProtocolVersion()) {}
 
   virtual void connectionAccepted(
       int fd,

--- a/test/integration/WarmResumptionTest.cpp
+++ b/test/integration/WarmResumptionTest.cpp
@@ -66,7 +66,7 @@ TEST_F(ServerFixture, DISABLED_BasicWarmResumption) {
   clientEvb->runInEventBaseThreadAndWait([&]() { rsocket->disconnect(); });
 
   // This request should be buffered
-  mySub->request(2);
+  clientEvb->runInEventBaseThreadAndWait([&]() { mySub->request(2); });
 
   // Get subscriptions for buffered request (happens right after
   // reconnecting)

--- a/test/integration/WarmResumptionTest.cpp
+++ b/test/integration/WarmResumptionTest.cpp
@@ -20,7 +20,7 @@ using folly::ScopedEventBaseThread;
 
 // A very simple test which tests a basic warm resumption workflow.
 // This setup can be used to test varying scenarious in warm resumption.
-TEST_F(ServerFixture, DISABLED_BasicWarmResumption) {
+TEST_F(ServerFixture, WarmResumptionBasic) {
   ScopedEventBaseThread eventBaseThread;
   auto clientEvb = eventBaseThread.getEventBase();
   tests::MyConnectCallback connectCb;

--- a/test/resumption/TcpResumeClient.cpp
+++ b/test/resumption/TcpResumeClient.cpp
@@ -120,6 +120,7 @@ int main(int argc, char* argv[]) {
     reactiveSocket = ReactiveSocket::disconnectedClient(
         *eventBaseThread.getEventBase(),
         std::move(requestHandler),
+        std::make_shared<ResumeCache>(stats),
         stats,
         std::make_unique<FollyKeepaliveTimer>(
             *eventBaseThread.getEventBase(), std::chrono::seconds(10)));

--- a/test/test_utils/MockRequestHandler.h
+++ b/test/test_utils/MockRequestHandler.h
@@ -67,8 +67,8 @@ class MockRequestHandler : public RequestHandler {
     handleRequestResponse_(request, streamId, response);
   }
 
-  virtual std::shared_ptr<Subscriber<Payload>> handleResumeStream(
-      std::string streamName) noexcept override {
+  virtual yarpl::Reference<yarpl::flowable::Subscriber<Payload>>
+  handleResumeStream(std::string streamName) noexcept override {
     LOG(FATAL) << "handleResumeStream not implemented";
   }
 

--- a/test/test_utils/MockRequestHandler.h
+++ b/test/test_utils/MockRequestHandler.h
@@ -67,6 +67,11 @@ class MockRequestHandler : public RequestHandler {
     handleRequestResponse_(request, streamId, response);
   }
 
+  virtual std::shared_ptr<Subscriber<Payload>> handleResumeStream(
+      std::string streamName) noexcept override {
+    LOG(FATAL) << "handleResumeStream not implemented";
+  }
+
   void handleFireAndForgetRequest(
       Payload request,
       StreamId streamId) noexcept override {


### PR DESCRIPTION
This is a first stab at cold resumption.

API Changes
- It tries to reuse warm-resumption mechanics as much as possible.  The state
is preserved in ResumeCache.  ResumeCache is an optional parameter while
constructing a client ReactiveSocket.
- Streams are identified by a unique StreamName (called it StreamName to
distinguish it from StreamId).  Apps are responsible for maintaining a unique
streamName for all the streams they create (could be a simple hash of the
initialPayload).
- Introduced ReactiveSocket::requestStream() which takes an addition streamName
parameter.   A streamName must be passed by clients to ensure the streams are
resumable.  This returns error if a stream already exists with the same name.
- Introduced RequestHandler::handleResumeStream(streamName).  This method gets
called when streams are resumed after cold start.  Apps should implement this
method and return a Subscriber for this streamName.
- All other API changes should be internal to RSocket.

Tests
- I have written two integration tests - BasicColdResumtion and
2StreamColdResumption

Open to discussion
- If a stream is created without a name and a cold-resumption is attempted,
then that stream is resumed with its streamId being used as the streamName.
An alternative is to enforce all streams are created with a name (might be
too harsh).
- everything else.

TODO / Future Work

1. More sanity checks.  Eg: check RSocket::mode is same after cold-resumption.
2. Right now we FATAL if handleResumeStream() is called but not implemented.  Find a better alternative.
3. ResumeCache::streamMap_ is not accurate.  It has entries only for streams which currently have frames buffered in the cache. Also streamNameMap_ is never flushed.  We need to remove entries as streams get closed.
4. Allowance in StreamRequester needs to be persisted.
5. Change ResumeCache to an interface.  Have two sample implementations. 
 InMemResumeCache and DiskResumeCache.  InMemResumeCache will be the default and use the existing implementation of ResumeCache.  DiskResumeCache will write to disk.