### PR TITLE
Fix leaky Reference assignment operators

### DIFF
--- a/experimental/yarpl/include/yarpl/Refcounted.h
+++ b/experimental/yarpl/include/yarpl/Refcounted.h
@@ -98,25 +98,21 @@ class Reference {
   //////////////////////////////////////////////////////////////////////////////
 
   Reference& operator=(const Reference& other) {
-    new (this) Reference(other);
-    return *this;
+    return assign(other);
   }
 
   Reference& operator=(Reference&& other) {
-    new (this) Reference(std::move(other));
-    return *this;
+    return assign(std::move(other));
   }
 
   template <typename U>
   Reference& operator=(const Reference<U>& other) {
-    new (this) Reference<T>(other);
-    return *this;
+    return assign(other);
   }
 
   template <typename U>
   Reference& operator=(Reference<U>&& other) {
-    new (this) Reference<T>(std::move(other));
-    return *this;
+    return assign(std::move(other));
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -156,6 +152,13 @@ class Reference {
 
   void swap(Reference<T>& other) {
     std::swap(pointer_, other.pointer_);
+  }
+
+  template <typename Ref>
+  Reference& assign(Ref&& other) {
+    Reference<T> temp(std::forward<Ref>(other));
+    swap(temp);
+    return *this;
   }
 
   T* pointer_{nullptr};

--- a/experimental/yarpl/test/RefcountedTest.cpp
+++ b/experimental/yarpl/test/RefcountedTest.cpp
@@ -58,5 +58,4 @@ TEST(RefcountedTest, ReferenceCountingWorks) {
 
   EXPECT_EQ(0U, Refcounted::objects());
 }
-
 } // yarpl

--- a/experimental/yarpl/test/ReferenceTest.cpp
+++ b/experimental/yarpl/test/ReferenceTest.cpp
@@ -34,3 +34,51 @@ TEST(ReferenceTest, Upcast) {
   Reference<Subscriber<int>> base4;
   base4 = std::move(derivedCopy2);
 }
+
+TEST(RefcountedTest, CopyAssign) {
+  using Sub = Subscriber<int>;
+  Reference<Sub> a(new Sub());
+  Reference<Sub> b(a);
+  EXPECT_EQ(2, a->count());
+  Sub* ptr = nullptr;
+  Reference<Sub> c(ptr = new Sub());
+  b = c;
+  EXPECT_EQ(1, a->count());
+  EXPECT_EQ(ptr, b.get());
+}
+
+TEST(RefcountedTest, MoveAssign) {
+  using Sub = Subscriber<int>;
+  Reference<Sub> a(new Sub());
+  Reference<Sub> b(a);
+  EXPECT_EQ(2, a->count());
+  Sub* ptr = nullptr;
+  b = Reference<Sub>(ptr = new Sub());
+  EXPECT_EQ(1, a->count());
+  EXPECT_EQ(ptr, b.get());
+}
+
+TEST(RefcountedTest, CopyAssignTemplate) {
+  using Sub = Subscriber<int>;
+  Reference<Sub> a(new Sub());
+  Reference<Sub> b(a);
+  EXPECT_EQ(2, a->count());
+  using Sub2 = MySubscriber<int>;
+  Sub2* ptr = nullptr;
+  Reference<Sub2> c(ptr = new Sub2());
+  b = c;
+  EXPECT_EQ(1, a->count());
+  EXPECT_EQ(ptr, b.get());
+}
+
+TEST(RefcountedTest, MoveAssignTemplate) {
+  using Sub = Subscriber<int>;
+  Reference<Sub> a(new Sub());
+  Reference<Sub> b(a);
+  EXPECT_EQ(2, a->count());
+  using Sub2 = MySubscriber<int>;
+  Sub2* ptr = nullptr;
+  b = Reference<Sub2>(ptr = new Sub2());
+  EXPECT_EQ(1, a->count());
+  EXPECT_EQ(ptr, b.get());
+}


### PR DESCRIPTION
`Reference` assignment operators in yarpl were leaking because `new (this) Reference(other)` didn't decrement `this`'s refcount. This PR fixes the issue, simplifies assignment operators by delegating to a single function template and adds unit tests.