### PR TITLE
Remove Observers::Base::onSubscribe

### DIFF
--- a/experimental/yarpl/include/yarpl/observable/Observers.h
+++ b/experimental/yarpl/include/yarpl/observable/Observers.h
@@ -68,10 +68,6 @@ class Observers {
     Base(Next&& next)
         : next_(std::forward<Next>(next)) {}
 
-    virtual void onSubscribe(Reference<Subscription> subscription) override {
-      Observer<T>::onSubscribe(subscription);
-    }
-
     virtual void onNext(T value) override {
       next_(std::move(value));
     }


### PR DESCRIPTION
This PR gets rid of an unnecessary virtual call and refcount churn by removing `Observers::Base::onSubscribe` which was simply forwarding to the base class.