### PR TITLE
Encapsulate frame management into connectionAutomaton

### DIFF
--- a/src/ConnectionAutomaton.h
+++ b/src/ConnectionAutomaton.h
@@ -186,7 +186,7 @@ class ConnectionAutomaton final
     return streamsFactory_;
   }
 
-  FrameSerializer& frameSerializer() const override;
+  FrameSerializer& frameSerializer() const;
   void setFrameSerializer(std::unique_ptr<FrameSerializer>);
 
   Stats& stats() {
@@ -212,9 +212,15 @@ class ConnectionAutomaton final
   void onTerminalImpl(folly::exception_wrapper);
   /// @}
 
-  void onConnectionFrame(std::unique_ptr<folly::IOBuf>);
+  void handleConnectionFrame(FrameType frameType,
+                             std::unique_ptr<folly::IOBuf>);
+  void handleStreamFrame(
+      StreamId streamId,
+      FrameType frameType,
+      std::unique_ptr<folly::IOBuf> frame);
   void handleUnknownStream(
       StreamId streamId,
+      FrameType frameType,
       std::unique_ptr<folly::IOBuf> frame);
 
   void closeStreams(StreamCompletionSignal);

--- a/src/StreamsHandler.h
+++ b/src/StreamsHandler.h
@@ -37,8 +37,5 @@ class StreamsWriter {
   virtual void onStreamClosed(
       StreamId streamId,
       StreamCompletionSignal signal) = 0;
-
-  // TODO: remove, this is only a temporary workaround
-  virtual FrameSerializer& frameSerializer() const = 0;
 };
 }

--- a/src/automata/ChannelRequester.h
+++ b/src/automata/ChannelRequester.h
@@ -37,10 +37,9 @@ class ChannelRequester : public ConsumerBase,
   void requestImpl(size_t) noexcept override;
   void cancelImpl() noexcept override;
 
-  using StreamAutomatonBase::onNextFrame;
-  void onNextFrame(Frame_PAYLOAD&&) override;
-  void onNextFrame(Frame_ERROR&&) override;
-  void onNextFrame(Frame_REQUEST_N&&) override;
+  void handlePayload(Payload&& payload, bool complete, bool flagsNext) override;
+  void handleRequestN(uint32_t n) override;
+  void handleError(folly::exception_wrapper errorPayload) override;
 
   void endStream(StreamCompletionSignal) override;
 

--- a/src/automata/ChannelRequester.h
+++ b/src/automata/ChannelRequester.h
@@ -4,7 +4,6 @@
 
 #include <iosfwd>
 
-#include "src/Frame.h"
 #include "src/Payload.h"
 #include "src/SubscriberBase.h"
 #include "src/SubscriptionBase.h"

--- a/src/automata/ChannelResponder.cpp
+++ b/src/automata/ChannelResponder.cpp
@@ -91,18 +91,14 @@ void ChannelResponder::processInitialFrame(Frame_REQUEST_CHANNEL&& frame) {
       true);
 }
 
-void ChannelResponder::onNextFrame(Frame_REQUEST_CHANNEL&& frame) {
-  // TODO(t16487710): remove handling this frame when we remove support for
-  // protocol version < 1.0
-  processInitialFrame(std::move(frame));
-}
-
-void ChannelResponder::onNextFrame(Frame_PAYLOAD&& frame) {
+void ChannelResponder::handlePayload(Payload&& payload,
+                                     bool complete,
+                                     bool flagsNext) {
   onNextPayloadFrame(
       0,
-      std::move(frame.payload_),
-      frame.header_.flagsComplete(),
-      frame.header_.flagsNext());
+      std::move(payload),
+      complete,
+      flagsNext);
 }
 
 void ChannelResponder::onNextPayloadFrame(
@@ -130,7 +126,7 @@ void ChannelResponder::onNextPayloadFrame(
   }
 }
 
-void ChannelResponder::onNextFrame(Frame_CANCEL&& frame) {
+void ChannelResponder::handleCancel() {
   switch (state_) {
     case State::RESPONDING:
       state_ = State::CLOSED;
@@ -141,7 +137,7 @@ void ChannelResponder::onNextFrame(Frame_CANCEL&& frame) {
   }
 }
 
-void ChannelResponder::onNextFrame(Frame_REQUEST_N&& frame) {
-  PublisherBase::processRequestN(frame.requestN_);
+void ChannelResponder::handleRequestN(uint32_t n) {
+  PublisherBase::processRequestN(n);
 }
 }

--- a/src/automata/ChannelResponder.h
+++ b/src/automata/ChannelResponder.h
@@ -4,7 +4,6 @@
 
 #include <iosfwd>
 
-#include "src/Frame.h"
 #include "src/SubscriberBase.h"
 #include "src/SubscriptionBase.h"
 #include "src/automata/ConsumerBase.h"

--- a/src/automata/ChannelResponder.h
+++ b/src/automata/ChannelResponder.h
@@ -36,11 +36,9 @@ class ChannelResponder : public ConsumerBase,
   void requestImpl(size_t n) noexcept override;
   void cancelImpl() noexcept override;
 
-  using StreamAutomatonBase::onNextFrame;
-  void onNextFrame(Frame_REQUEST_CHANNEL&&) override;
-  void onNextFrame(Frame_CANCEL&&) override;
-  void onNextFrame(Frame_REQUEST_N&&) override;
-  void onNextFrame(Frame_PAYLOAD&& frame) override;
+  void handlePayload(Payload&& payload, bool complete, bool flagsNext) override;
+  void handleRequestN(uint32_t n) override;
+  void handleCancel() override;
 
   void onNextPayloadFrame(
       uint32_t requestN,

--- a/src/automata/ConsumerBase.cpp
+++ b/src/automata/ConsumerBase.cpp
@@ -4,7 +4,6 @@
 
 #include <glog/logging.h>
 #include <algorithm>
-#include "src/Frame.h"
 #include "src/Payload.h"
 #include "src/ReactiveStreamsCompat.h"
 

--- a/src/automata/PublisherBase.h
+++ b/src/automata/PublisherBase.h
@@ -8,7 +8,6 @@
 #include "src/AllowanceSemaphore.h"
 #include "src/ConnectionAutomaton.h"
 #include "src/Executor.h"
-#include "src/Frame.h"
 #include "src/Payload.h"
 #include "src/ReactiveStreamsCompat.h"
 #include "src/RequestHandler.h"

--- a/src/automata/RequestResponseRequester.h
+++ b/src/automata/RequestResponseRequester.h
@@ -35,9 +35,9 @@ class RequestResponseRequester : public StreamAutomatonBase,
   void requestImpl(size_t) noexcept override;
   void cancelImpl() noexcept override;
 
-  using Base::onNextFrame;
-  void onNextFrame(Frame_PAYLOAD&&) override;
-  void onNextFrame(Frame_ERROR&&) override;
+  void handlePayload(Payload&& payload, bool complete, bool flagsNext) override;
+  void handleError(folly::exception_wrapper errorPayload) override;
+
   void endStream(StreamCompletionSignal signal) override;
 
   void pauseStream(RequestHandler& requestHandler) override;

--- a/src/automata/RequestResponseRequester.h
+++ b/src/automata/RequestResponseRequester.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include <iosfwd>
-#include "src/Frame.h"
+#include "src/Payload.h"
 #include "src/SubscriptionBase.h"
 #include "src/automata/StreamAutomatonBase.h"
 

--- a/src/automata/RequestResponseResponder.cpp
+++ b/src/automata/RequestResponseResponder.cpp
@@ -76,7 +76,7 @@ void RequestResponseResponder::endStream(StreamCompletionSignal signal) {
   StreamAutomatonBase::endStream(signal);
 }
 
-void RequestResponseResponder::onNextFrame(Frame_CANCEL&& frame) {
+void RequestResponseResponder::handleCancel() {
   switch (state_) {
     case State::RESPONDING:
       state_ = State::CLOSED;
@@ -87,8 +87,8 @@ void RequestResponseResponder::onNextFrame(Frame_CANCEL&& frame) {
   }
 }
 
-void RequestResponseResponder::onNextFrame(Frame_REQUEST_N&& frame) {
-  PublisherBase::processRequestN(frame.requestN_);
+void RequestResponseResponder::handleRequestN(uint32_t n) {
+  PublisherBase::processRequestN(n);
 }
 
 } // reactivesocket

--- a/src/automata/RequestResponseResponder.h
+++ b/src/automata/RequestResponseResponder.h
@@ -38,9 +38,8 @@ class RequestResponseResponder : public StreamAutomatonBase,
   void onErrorImpl(folly::exception_wrapper) noexcept override;
   /// @}
 
-  using StreamAutomatonBase::onNextFrame;
-  void onNextFrame(Frame_CANCEL&&) override;
-  void onNextFrame(Frame_REQUEST_N&&) override;
+  void handleCancel() override;
+  void handleRequestN(uint32_t n) override;
 
   void pauseStream(RequestHandler&) override;
   void resumeStream(RequestHandler&) override;

--- a/src/automata/RequestResponseResponder.h
+++ b/src/automata/RequestResponseResponder.h
@@ -4,7 +4,6 @@
 
 #include <iosfwd>
 
-#include "src/Frame.h"
 #include "src/SubscriberBase.h"
 #include "src/automata/PublisherBase.h"
 #include "src/automata/StreamAutomatonBase.h"

--- a/src/automata/StreamAutomatonBase.cpp
+++ b/src/automata/StreamAutomatonBase.cpp
@@ -8,101 +8,26 @@
 
 namespace reactivesocket {
 
-void StreamAutomatonBase::onNextFrame(std::unique_ptr<folly::IOBuf> payload) {
-  DCHECK(payload);
-
-  auto type = writer_->frameSerializer().peekFrameType(*payload);
-  switch (type) {
-    case FrameType::REQUEST_CHANNEL:
-      deserializeAndDispatch<Frame_REQUEST_CHANNEL>(std::move(payload));
-      return;
-    case FrameType::REQUEST_N:
-      deserializeAndDispatch<Frame_REQUEST_N>(std::move(payload));
-      return;
-    case FrameType::REQUEST_RESPONSE:
-      deserializeAndDispatch<Frame_REQUEST_RESPONSE>(std::move(payload));
-      return;
-    case FrameType::CANCEL:
-      deserializeAndDispatch<Frame_CANCEL>(std::move(payload));
-      return;
-    case FrameType::PAYLOAD:
-      deserializeAndDispatch<Frame_PAYLOAD>(std::move(payload));
-      return;
-    case FrameType::ERROR:
-      deserializeAndDispatch<Frame_ERROR>(std::move(payload));
-      return;
-
-    case FrameType::RESERVED:
-    case FrameType::SETUP:
-    case FrameType::LEASE:
-    case FrameType::KEEPALIVE:
-    case FrameType::REQUEST_FNF:
-    case FrameType::REQUEST_STREAM:
-    case FrameType::METADATA_PUSH:
-    case FrameType::RESUME:
-    case FrameType::RESUME_OK:
-    case FrameType::EXT:
-    default:
-      onUnknownFrame();
-      return;
-  }
+void StreamAutomatonBase::handlePayload(Payload&& payload,
+                                        bool complete,
+                                        bool flagsNext) {
+  VLOG(4) << "Unexpected handlePayload";
 }
 
-template <class Frame>
-void StreamAutomatonBase::deserializeAndDispatch(
-    std::unique_ptr<folly::IOBuf> payload) {
-  Frame frame;
-  if (writer_->frameSerializer().deserializeFrom(frame, std::move(payload))) {
-    onNextFrame(std::move(frame));
-  } else {
-    onBadFrame();
-  }
+void StreamAutomatonBase::handleRequestN(uint32_t n) {
+  VLOG(4) << "Unexpected handleRequestN";
 }
 
-template <typename T>
-static void onUnexpectedFrame(const T& frame) {
-  VLOG(4) << "Unexpected frame, ignoring: " << frame;
+void StreamAutomatonBase::handleError(folly::exception_wrapper errorPayload) {
+  VLOG(4) << "Unexpected handleError";
+}
+
+void StreamAutomatonBase::handleCancel() {
+  VLOG(4) << "Unexpected handleCancel";
 }
 
 void StreamAutomatonBase::endStream(StreamCompletionSignal) {
   isTerminated_ = true;
-}
-
-void StreamAutomatonBase::onNextFrame(Frame_REQUEST_STREAM&& f) {
-  onUnexpectedFrame(f);
-}
-
-void StreamAutomatonBase::onNextFrame(Frame_REQUEST_CHANNEL&& f) {
-  onUnexpectedFrame(f);
-}
-
-void StreamAutomatonBase::onNextFrame(Frame_REQUEST_RESPONSE&& f) {
-  onUnexpectedFrame(f);
-}
-
-void StreamAutomatonBase::onNextFrame(Frame_REQUEST_N&& f) {
-  onUnexpectedFrame(f);
-}
-
-void StreamAutomatonBase::onNextFrame(Frame_CANCEL&& f) {
-  onUnexpectedFrame(f);
-}
-
-void StreamAutomatonBase::onNextFrame(Frame_PAYLOAD&& f) {
-  onUnexpectedFrame(f);
-}
-
-void StreamAutomatonBase::onNextFrame(Frame_ERROR&& f) {
-  onUnexpectedFrame(f);
-}
-
-void StreamAutomatonBase::onBadFrame() {
-  errorStream("bad frame");
-}
-
-void StreamAutomatonBase::onUnknownFrame() {
-  // because of compatibility with future frame types we will just ignore
-  // unknown frames
 }
 
 void StreamAutomatonBase::newStream(

--- a/src/automata/StreamAutomatonBase.cpp
+++ b/src/automata/StreamAutomatonBase.cpp
@@ -3,7 +3,6 @@
 #include "src/automata/StreamAutomatonBase.h"
 #include <folly/io/IOBuf.h>
 #include "src/ConnectionAutomaton.h"
-#include "src/Frame.h"
 #include "src/StreamsHandler.h"
 
 namespace reactivesocket {

--- a/src/automata/StreamRequester.cpp
+++ b/src/automata/StreamRequester.cpp
@@ -77,7 +77,9 @@ void StreamRequester::endStream(StreamCompletionSignal signal) {
   Base::endStream(signal);
 }
 
-void StreamRequester::onNextFrame(Frame_PAYLOAD&& frame) {
+void StreamRequester::handlePayload(Payload&& payload,
+                                    bool complete,
+                                    bool flagsNext) {
   bool end = false;
   switch (state_) {
     case State::NEW:
@@ -85,7 +87,7 @@ void StreamRequester::onNextFrame(Frame_PAYLOAD&& frame) {
       CHECK(false);
       break;
     case State::REQUESTED:
-      if (frame.header_.flagsComplete()) {
+      if (complete) {
         state_ = State::CLOSED;
         end = true;
       }
@@ -94,14 +96,14 @@ void StreamRequester::onNextFrame(Frame_PAYLOAD&& frame) {
       break;
   }
 
-  processPayload(std::move(frame.payload_), frame.header_.flagsNext());
+  processPayload(std::move(payload), flagsNext);
 
   if (end) {
     closeStream(StreamCompletionSignal::COMPLETE);
   }
 }
 
-void StreamRequester::onNextFrame(Frame_ERROR&& frame) {
+void StreamRequester::handleError(folly::exception_wrapper errorPayload) {
   switch (state_) {
     case State::NEW:
       // Cannot receive a frame before sending the initial request.
@@ -109,7 +111,7 @@ void StreamRequester::onNextFrame(Frame_ERROR&& frame) {
       break;
     case State::REQUESTED:
       state_ = State::CLOSED;
-      Base::onError(std::runtime_error(frame.payload_.moveDataToString()));
+      Base::onError(errorPayload);
       closeStream(StreamCompletionSignal::ERROR);
       break;
     case State::CLOSED:

--- a/src/automata/StreamRequester.h
+++ b/src/automata/StreamRequester.h
@@ -31,9 +31,10 @@ class StreamRequester : public ConsumerBase {
   void requestImpl(size_t) noexcept override;
   void cancelImpl() noexcept override;
 
-  using Base::onNextFrame;
-  void onNextFrame(Frame_PAYLOAD&&) override;
-  void onNextFrame(Frame_ERROR&&) override;
+  void handlePayload(Payload&& payload,
+                     bool complete,
+                     bool flagsNext) override;
+  void handleError(folly::exception_wrapper errorPayload) override;
 
   void endStream(StreamCompletionSignal) override;
 

--- a/src/automata/StreamResponder.cpp
+++ b/src/automata/StreamResponder.cpp
@@ -73,7 +73,7 @@ void StreamResponder::endStream(StreamCompletionSignal signal) {
   StreamAutomatonBase::endStream(signal);
 }
 
-void StreamResponder::onNextFrame(Frame_CANCEL&& frame) {
+void StreamResponder::handleCancel() {
   switch (state_) {
     case State::RESPONDING:
       state_ = State::CLOSED;
@@ -84,7 +84,7 @@ void StreamResponder::onNextFrame(Frame_CANCEL&& frame) {
   }
 }
 
-void StreamResponder::onNextFrame(Frame_REQUEST_N&& frame) {
-  PublisherBase::processRequestN(frame.requestN_);
+void StreamResponder::handleRequestN(uint32_t n) {
+  PublisherBase::processRequestN(n);
 }
 }

--- a/src/automata/StreamResponder.h
+++ b/src/automata/StreamResponder.h
@@ -30,9 +30,8 @@ class StreamResponder : public StreamAutomatonBase,
         PublisherBase(initialRequestN) {}
 
  protected:
-  using StreamAutomatonBase::onNextFrame;
-  void onNextFrame(Frame_CANCEL&&) override;
-  void onNextFrame(Frame_REQUEST_N&&) override;
+  void handleCancel() override;
+  void handleRequestN(uint32_t n) override;
 
  private:
   void onSubscribeImpl(std::shared_ptr<Subscription>) noexcept override;


### PR DESCRIPTION
Brings frame management/serialization/de-serialization inside ConnectionAutomaton and out of the Requester/Responder classes