### PR TITLE
Remove unneeded uses of virtual, add override where possible

### DIFF
--- a/experimental/yarpl/include/yarpl/Observable.h
+++ b/experimental/yarpl/include/yarpl/Observable.h
@@ -68,7 +68,7 @@ class Observable : public virtual Refcounted {
     FromPublisherOperator(OnSubscribe&& function)
         : function_(std::move(function)) {}
 
-    void subscribe(Reference<Observer<T>> subscriber) {
+    void subscribe(Reference<Observer<T>> subscriber) override {
       function_(std::move(subscriber));
     }
 

--- a/experimental/yarpl/include/yarpl/flowable/Subscribers.h
+++ b/experimental/yarpl/include/yarpl/flowable/Subscribers.h
@@ -72,13 +72,13 @@ class Subscribers {
     Base(Next&& next, int64_t batch)
         : next_(std::forward<Next>(next)), batch_(batch), pending_(0) {}
 
-    virtual void onSubscribe(Reference<Subscription> subscription) override {
+    void onSubscribe(Reference<Subscription> subscription) override {
       Subscriber<T>::onSubscribe(subscription);
       pending_ += batch_;
       subscription->request(batch_);
     }
 
-    virtual void onNext(T value) override {
+    void onNext(T value) override {
       next_(std::move(value));
       if (--pending_ < batch_ / 2) {
         const auto delta = batch_ - pending_;
@@ -99,7 +99,7 @@ class Subscribers {
     WithError(Next&& next, Error&& error, int64_t batch)
         : Base<T, Next>(std::forward<Next>(next), batch), error_(error) {}
 
-    virtual void onError(std::exception_ptr error) override {
+    void onError(std::exception_ptr error) override {
       error_(error);
     }
 
@@ -121,7 +121,7 @@ class Subscribers {
               batch),
           complete_(complete) {}
 
-    virtual void onComplete() {
+    void onComplete() override {
       complete_();
     }
 

--- a/experimental/yarpl/include/yarpl/observable/Observers.h
+++ b/experimental/yarpl/include/yarpl/observable/Observers.h
@@ -68,7 +68,7 @@ class Observers {
     Base(Next&& next)
         : next_(std::forward<Next>(next)) {}
 
-    virtual void onNext(T value) override {
+    void onNext(T value) override {
       next_(std::move(value));
     }
 
@@ -82,7 +82,7 @@ class Observers {
     WithError(Next&& next, Error&& error)
         : Base<T, Next>(std::forward<Next>(next)), error_(error) {}
 
-    virtual void onError(std::exception_ptr error) override {
+    void onError(std::exception_ptr error) override {
       error_(error);
     }
 
@@ -102,7 +102,7 @@ class Observers {
               std::forward<Error>(error)),
           complete_(complete) {}
 
-    virtual void onComplete() {
+    void onComplete() override {
       complete_();
     }
 


### PR DESCRIPTION
override implies virtual.  Otherwise it doesn't compile.