### PR TITLE
[yarpl] Implement the filter operator for Flowable

### DIFF
--- a/experimental/yarpl/include/yarpl/Flowable.h
+++ b/experimental/yarpl/include/yarpl/Flowable.h
@@ -27,6 +27,9 @@ class Flowable : public virtual Refcounted {
   template <typename Function>
   auto map(Function&& function);
 
+  template<typename Function>
+  auto filter(Function&& function);
+
   auto take(int64_t);
 
   auto subscribeOn(Scheduler&);
@@ -244,6 +247,13 @@ template <typename Function>
 auto Flowable<T>::map(Function&& function) {
   using D = typename std::result_of<Function(T)>::type;
   return Reference<Flowable<D>>(new MapOperator<T, D, Function>(
+      Reference<Flowable<T>>(this), std::forward<Function>(function)));
+}
+
+template<typename T>
+template<typename Function>
+auto Flowable<T>::filter(Function&& function) {
+  return Reference<Flowable<T>>(new FilterOperator<T, Function>(
       Reference<Flowable<T>>(this), std::forward<Function>(function)));
 }
 

--- a/experimental/yarpl/include/yarpl/Observable.h
+++ b/experimental/yarpl/include/yarpl/Observable.h
@@ -47,6 +47,9 @@ class Observable : public virtual Refcounted {
   template <typename Function>
   auto map(Function&& function);
 
+  template <typename Function>
+  auto filter(Function&& function);
+
   auto take(int64_t);
 
   auto subscribeOn(Scheduler&);
@@ -88,6 +91,13 @@ template <typename Function>
 auto Observable<T>::map(Function&& function) {
   using D = typename std::result_of<Function(T)>::type;
   return Reference<Observable<D>>(new MapOperator<T, D, Function>(
+      Reference<Observable<T>>(this), std::forward<Function>(function)));
+}
+
+template <typename T>
+template <typename Function>
+auto Observable<T>::filter(Function&& function) {
+  return Reference<Observable<T>>(new FilterOperator<T, Function>(
       Reference<Observable<T>>(this), std::forward<Function>(function)));
 }
 

--- a/experimental/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/experimental/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -133,6 +133,47 @@ class MapOperator : public FlowableOperator<U, D> {
   F function_;
 };
 
+template <
+    typename U,
+    typename F,
+    typename = typename std::enable_if<std::is_callable<F(U), bool>::value>::type>
+class FilterOperator : public FlowableOperator<U, U> {
+public:
+  FilterOperator(Reference<Flowable<U>> upstream, F&& function)
+      : FlowableOperator<U, U>(std::move(upstream)),
+        function_(std::forward<F>(function)) {}
+
+  virtual void subscribe(Reference<Subscriber<U>> subscriber) override {
+    FlowableOperator<U, U>::upstream_->subscribe(
+        // Note: implicit cast to a reference to a subscriber.
+        Reference<Subscription>(new Subscription(
+            Reference<Flowable<U>>(this), std::move(subscriber))));
+  }
+
+private:
+  class Subscription : public FlowableOperator<U, U>::Subscription {
+  public:
+    Subscription(
+        Reference<Flowable<U>> flowable,
+        Reference<Subscriber<U>> subscriber)
+        : FlowableOperator<U, U>::Subscription(
+        std::move(flowable),
+        std::move(subscriber)) {}
+
+    virtual void onNext(U value) override {
+      auto subscriber =
+          FlowableOperator<U, U>::Subscription::subscriber_.get();
+      auto* flowable = FlowableOperator<U, U>::Subscription::flowable_.get();
+      auto* filter = static_cast<FilterOperator*>(flowable);
+      if (filter->function_(value)) {
+        subscriber->onNext(std::move(value));
+      }
+    }
+  };
+
+  F function_;
+};
+
 template <typename T>
 class TakeOperator : public FlowableOperator<T, T> {
  public:

--- a/experimental/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/experimental/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -126,6 +126,47 @@ class MapOperator : public ObservableOperator<U, D> {
   F function_;
 };
 
+template<
+    typename U,
+    typename F,
+    typename = typename std::enable_if<std::is_callable<F(U), bool>::value>::type>
+class FilterOperator : public ObservableOperator<U, U> {
+public:
+  FilterOperator(Reference <Observable<U>> upstream, F &&function)
+      : ObservableOperator<U, U>(std::move(upstream)),
+        function_(std::forward<F>(function)) {}
+
+  virtual void subscribe(Reference <Observer<U>> subscriber) override {
+    ObservableOperator<U, U>::upstream_->subscribe(
+        // Note: implicit cast to a reference to a subscriber.
+        Reference<Subscription>(new Subscription(
+            Reference<Observable<U>>(this), std::move(subscriber))));
+  }
+
+private:
+  class Subscription : public ObservableOperator<U, U>::Subscription {
+  public:
+    Subscription(
+        Reference <Observable<U>> flowable,
+        Reference <Observer<U>> subscriber)
+        : ObservableOperator<U, U>::Subscription(
+        std::move(flowable),
+        std::move(subscriber)) {}
+
+    virtual void onNext(U value) override {
+      auto *subscriber =
+          ObservableOperator<U, U>::Subscription::subscriber_.get();
+      auto *flowable = ObservableOperator<U, U>::Subscription::flowable_.get();
+      auto *filter = static_cast<FilterOperator *>(flowable);
+      if (filter->function_(value)) {
+        subscriber->onNext(std::move(value));
+      }
+    }
+  };
+
+  F function_;
+};
+
 template <typename T>
 class TakeOperator : public ObservableOperator<T, T> {
  public:

--- a/experimental/yarpl/test/FlowableTest.cpp
+++ b/experimental/yarpl/test/FlowableTest.cpp
@@ -153,6 +153,15 @@ TEST(FlowableTest, RangeWithMap) {
   EXPECT_EQ(std::size_t{0}, Refcounted::objects());
 }
 
+TEST(FlowableTest, RangeWithFilter) {
+  ASSERT_EQ(std::size_t{0}, Refcounted::objects());
+  auto flowable = Flowables::range(0, 10)
+                      ->filter([](int64_t v) { return v % 2 != 0; });
+  EXPECT_EQ(
+      run(std::move(flowable)), std::vector<int64_t>({1, 3, 5, 7, 9}));
+  EXPECT_EQ(std::size_t{0}, Refcounted::objects());
+}
+
 TEST(FlowableTest, SimpleTake) {
   ASSERT_EQ(std::size_t{0}, Refcounted::objects());
   EXPECT_EQ(


### PR DESCRIPTION
So that we can do something like:

  Flowables::range(0, 10)
    ->filter([] (int64_t x) { return x % 2 != 0; })
    ->subscribe(mySubscriber);

and have `mySubscriber` get sent 1, 3, 5, 7, 9, and then get completed.

More info
* Filter description - http://reactivex.io/documentation/operators/filter.html