### PR TITLE
Add ConnectionAcceptor::stop()

### DIFF
--- a/experimental/rsocket/ConnectionAcceptor.h
+++ b/experimental/rsocket/ConnectionAcceptor.h
@@ -20,6 +20,8 @@ using OnDuplexConnectionAccept = std::function<
  *
  * Built-in implementations can be found in rsocket/transports/, such as
  * rsocket/transports/TcpConnectionAcceptor.h
+ *
+ * TODO: Add way of specifying number of worker threads.
  */
 class ConnectionAcceptor {
  public:
@@ -43,6 +45,13 @@ class ConnectionAcceptor {
    */
   virtual folly::Future<folly::Unit> start(
       OnDuplexConnectionAccept onAccept) = 0;
-  // TODO need to add numThreads option (either overload or arg with default=1)
+
+  /**
+   * Stop listening for new connections.
+   *
+   * This can only be called once.  Must be called in or before
+   * the implementation's destructor.  Must be synchronous.
+   */
+  virtual void stop() = 0;
 };
 }

--- a/experimental/rsocket/transports/TcpConnectionAcceptor.h
+++ b/experimental/rsocket/transports/TcpConnectionAcceptor.h
@@ -40,13 +40,16 @@ class TcpConnectionAcceptor : public ConnectionAcceptor {
 
   /**
    * Bind an AsyncServerSocket and start accepting TCP connections.
-   *
-   * This can only be called once.
    */
   folly::Future<folly::Unit> start(
       std::function<void(
           std::unique_ptr<reactivesocket::DuplexConnection>,
           folly::EventBase&)>) override;
+
+  /**
+   * Shutdown the AsyncServerSocket and associated listener thread.
+   */
+  void stop() override;
 
  private:
   class SocketCallback;


### PR DESCRIPTION
Its behavior is to have the server stop listening, whatever server may be inside
the ConnectionAcceptor...  This is very helpful towards having sane shutdown
semantics.

Moves us closer to having ~RSocketServer not race as hard.