### PR TITLE
[yarpl] Reduce operator for Flowable

### DIFF
--- a/experimental/yarpl/include/yarpl/Flowable.h
+++ b/experimental/yarpl/include/yarpl/Flowable.h
@@ -27,6 +27,9 @@ class Flowable : public virtual Refcounted {
   template <typename Function>
   auto map(Function&& function);
 
+  template <typename Function>
+  auto reduce(Function&& function);
+
   auto take(int64_t);
 
   auto subscribeOn(Scheduler&);
@@ -244,6 +247,13 @@ template <typename Function>
 auto Flowable<T>::map(Function&& function) {
   using D = typename std::result_of<Function(T)>::type;
   return Reference<Flowable<D>>(new MapOperator<T, D, Function>(
+      Reference<Flowable<T>>(this), std::forward<Function>(function)));
+}
+
+template <typename T>
+template <typename Function>
+auto Flowable<T>::reduce(Function&& function) {
+  return Reference<Flowable<T>>(new ReduceOperator<T, Function>(
       Reference<Flowable<T>>(this), std::forward<Function>(function)));
 }
 

--- a/experimental/yarpl/include/yarpl/Observable.h
+++ b/experimental/yarpl/include/yarpl/Observable.h
@@ -47,6 +47,9 @@ class Observable : public virtual Refcounted {
   template <typename Function>
   auto map(Function&& function);
 
+  template <typename Function>
+  auto reduce(Function&& function);
+
   auto take(int64_t);
 
   auto subscribeOn(Scheduler&);
@@ -88,6 +91,13 @@ template <typename Function>
 auto Observable<T>::map(Function&& function) {
   using D = typename std::result_of<Function(T)>::type;
   return Reference<Observable<D>>(new MapOperator<T, D, Function>(
+      Reference<Observable<T>>(this), std::forward<Function>(function)));
+}
+
+template <typename T>
+template <typename Function>
+auto Observable<T>::reduce(Function&& function) {
+  return Reference<Observable<T>>(new ReduceOperator<T, Function>(
       Reference<Observable<T>>(this), std::forward<Function>(function)));
 }
 

--- a/experimental/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/experimental/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -133,6 +133,59 @@ class MapOperator : public FlowableOperator<U, D> {
   F function_;
 };
 
+template <
+    typename U,
+    typename F,
+    typename = typename std::enable_if<std::is_callable<F(U, U), U>::value>::type>
+class ReduceOperator : public FlowableOperator<U, U> {
+public:
+  ReduceOperator(Reference<Flowable<U>> upstream, F&& function)
+      : FlowableOperator<U, U>(std::move(upstream)),
+        function_(std::forward<F>(function)) {}
+
+  void subscribe(Reference<Subscriber<U>> subscriber) override {
+    FlowableOperator<U, U>::upstream_->subscribe(
+        // Note: implicit cast to a reference to a subscriber.
+        Reference<Subscription>(new Subscription(
+            Reference<Flowable<U>>(this), std::move(subscriber))));
+  }
+
+private:
+  class Subscription : public FlowableOperator<U, U>::Subscription {
+  public:
+    Subscription(
+        Reference<Flowable<U>> flowable,
+        Reference<Subscriber<U>> subscriber)
+        : FlowableOperator<U, U>::Subscription(
+        std::move(flowable),
+        std::move(subscriber)) {}
+
+    void onNext(U value) override {
+      auto* flowable = FlowableOperator<U, U>::Subscription::flowable_.get();
+      auto* reduce = static_cast<ReduceOperator*>(flowable);
+      acc_ = reduce->function_(std::move(acc_), std::move(value));
+    }
+
+    void onComplete() override {
+      auto subscriber =
+          FlowableOperator<U, U>::Subscription::subscriber_.get();
+      subscriber->onNext(acc_);
+      callSuperOnComplete();
+    }
+
+  private:
+    // Trampoline to call superclass method; gcc bug 58972.
+    void callSuperOnComplete() {
+      FlowableOperator<U, U>::Subscription::onComplete();
+    }
+
+  private:
+    U acc_;
+  };
+
+  F function_;
+};
+
 template <typename T>
 class TakeOperator : public FlowableOperator<T, T> {
  public:

--- a/experimental/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/experimental/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -126,6 +126,59 @@ class MapOperator : public ObservableOperator<U, D> {
   F function_;
 };
 
+template<
+    typename U,
+    typename F,
+    typename = typename std::enable_if<std::is_callable<F(U, U), bool>::value>::type>
+class ReduceOperator : public ObservableOperator<U, U> {
+public:
+  ReduceOperator(Reference <Observable<U>> upstream, F &&function)
+      : ObservableOperator<U, U>(std::move(upstream)),
+        function_(std::forward<F>(function)) {}
+
+  void subscribe(Reference <Observer<U>> subscriber) override {
+    ObservableOperator<U, U>::upstream_->subscribe(
+        // Note: implicit cast to a reference to a subscriber.
+        Reference<Subscription>(new Subscription(
+            Reference<Observable<U>>(this), std::move(subscriber))));
+  }
+
+private:
+  class Subscription : public ObservableOperator<U, U>::Subscription {
+  public:
+    Subscription(
+        Reference <Observable<U>> flowable,
+        Reference <Observer<U>> subscriber)
+        : ObservableOperator<U, U>::Subscription(
+        std::move(flowable),
+        std::move(subscriber)) {}
+
+    void onNext(U value) override {
+      auto *flowable = ObservableOperator<U, U>::Subscription::flowable_.get();
+      auto *reduce = static_cast<ReduceOperator*>(flowable);
+      acc_ = reduce->function_(std::move(acc_), std::move(value));
+    }
+
+    void onComplete() override {
+      auto *subscriber =
+          ObservableOperator<U, U>::Subscription::subscriber_.get();
+      subscriber->onNext(acc_);
+      callSuperOnComplete();
+    }
+
+  private:
+    // Trampoline to call superclass method; gcc bug 58972.
+    void callSuperOnComplete() {
+      ObservableOperator<U, U>::Subscription::onComplete();
+    }
+
+  private:
+    U acc_;
+  };
+
+  F function_;
+};
+
 template <typename T>
 class TakeOperator : public ObservableOperator<T, T> {
  public:

--- a/experimental/yarpl/test/FlowableTest.cpp
+++ b/experimental/yarpl/test/FlowableTest.cpp
@@ -154,6 +154,15 @@ TEST(FlowableTest, RangeWithMap) {
   EXPECT_EQ(std::size_t{0}, Refcounted::objects());
 }
 
+TEST(FlowableTest, RangeWithReduce) {
+  ASSERT_EQ(std::size_t{0}, Refcounted::objects());
+  auto flowable = Flowables::range(0, 10)
+                      ->reduce([](int64_t acc, int64_t v) { return acc + v; });
+  EXPECT_EQ(
+      run(std::move(flowable)), std::vector<int64_t>({45}));
+  EXPECT_EQ(std::size_t{0}, Refcounted::objects());
+}
+
 TEST(FlowableTest, SimpleTake) {
   ASSERT_EQ(std::size_t{0}, Refcounted::objects());
   EXPECT_EQ(


### PR DESCRIPTION
Adding Reduce operator for Flowable
  - http://reactivex.io/documentation/operators/reduce.html

  Flowables::range(0, 10)
    ->reduce([] (int64_t acc, int64_t x) { return acc + x; })
    ->subscribe(mySubscriber);

and have `mySubscriber` get sent a single result of 45 and then get completed.

