### PR TITLE
Two warning fixes

### DIFF
--- a/experimental/rsocket/RSocketRequestHandler.h
+++ b/experimental/rsocket/RSocketRequestHandler.h
@@ -32,5 +32,7 @@ class RSocketRequestHandler {
   handleRequestStream(
       reactivesocket::Payload request,
       reactivesocket::StreamId streamId) = 0;
+
+  virtual ~RSocketRequestHandler() {}
 };
 }

--- a/experimental/yarpl/include/yarpl/Flowable.h
+++ b/experimental/yarpl/include/yarpl/Flowable.h
@@ -177,7 +177,7 @@ class Flowable : public virtual Refcounted {
             *this /* implicit conversion to subscriber */, current);
 
         while (true) {
-          auto current = requested_.load(std::memory_order_relaxed);
+          current = requested_.load(std::memory_order_relaxed);
           if (current == CANCELED || (current == NO_FLOW_CONTROL && !done))
             break;
 


### PR DESCRIPTION
2 things: Fix a shadowed variable warning in yarpl/Flowable.h, and add a virtual destructor to RSocketRequestHandler.