### PR TITLE
Make ServerConnectionAcceptor thread-safe

### DIFF
--- a/experimental/rsocket-test/RSocketClientServerTest.cpp
+++ b/experimental/rsocket-test/RSocketClientServerTest.cpp
@@ -55,9 +55,7 @@ TEST(RSocketClientServer, StartAndShutdown) {
   makeClient(randPort());
 }
 
-// TODO(alexanderm): Failing upon closing the server.  Error says we're on the
-// wrong EventBase for the AsyncSocket.
-TEST(RSocketClientServer, DISABLED_SimpleConnect) {
+TEST(RSocketClientServer, SimpleConnect) {
   auto const port = randPort();
   auto server = makeServer(port);
   auto client = makeClient(port);

--- a/experimental/rsocket/RSocketServer.h
+++ b/experimental/rsocket/RSocketServer.h
@@ -89,5 +89,7 @@ class RSocketServer {
 
   folly::Baton<> waiting_;
   folly::Optional<folly::Baton<>> shutdown_;
+
+  std::atomic_bool isShutdown_{false};
 };
 } // namespace rsocket

--- a/test/ServerConnectionAcceptorTest.cpp
+++ b/test/ServerConnectionAcceptorTest.cpp
@@ -138,18 +138,16 @@ TEST_F(ServerConnectionAcceptorTest, SetupFrame) {
 TEST_F(ServerConnectionAcceptorTest, ResumeFrameNoSession) {
   std::unique_ptr<folly::IOBuf> data;
   EXPECT_CALL(*clientInput_, onNext_(_))
-    .WillOnce(Invoke([&](std::unique_ptr<folly::IOBuf>& buffer) {
-      data = std::move(buffer);
-    }));
+      .WillOnce(Invoke([&](std::unique_ptr<folly::IOBuf>& buffer) {
+        data = std::move(buffer);
+      }));
 
+  auto const protocol = FrameSerializer::getCurrentProtocolVersion();
+  auto token = ResumeIdentificationToken::generateNew();
 
-  ResumeParameters resumeParams(
-      ResumeIdentificationToken::generateNew(),
-      1,
-      2,
-      FrameSerializer::getCurrentProtocolVersion());
-  EXPECT_CALL(*handler_, resumeSocket(_, _))
-      .WillOnce(Return(false));
+  ResumeParameters resumeParams(std::move(token), 1, 2, protocol);
+  EXPECT_CALL(*handler_, resumeSocket(_, _)).WillOnce(Return(false));
+  EXPECT_CALL(*handler_, connectionError(_, _));
 
   auto frameSerializer = FrameSerializer::createCurrentVersion();
   acceptor_.accept(std::move(serverConnection_), handler_);
@@ -157,10 +155,10 @@ TEST_F(ServerConnectionAcceptorTest, ResumeFrameNoSession) {
       resumeParams.token,
       resumeParams.serverPosition,
       resumeParams.clientPosition,
-      FrameSerializer::getCurrentProtocolVersion())));
+      protocol)));
 
   Frame_ERROR errorFrame;
-  ASSERT_TRUE(data != nullptr);
+  ASSERT_NE(data, nullptr);
   EXPECT_TRUE(frameSerializer->deserializeFrom(errorFrame, std::move(data)));
   EXPECT_EQ(errorFrame.errorCode_, ErrorCode::CONNECTION_ERROR);
 
@@ -168,11 +166,10 @@ TEST_F(ServerConnectionAcceptorTest, ResumeFrameNoSession) {
 }
 
 TEST_F(ServerConnectionAcceptorTest, ResumeFrame) {
-  ResumeParameters resumeParams(
-      ResumeIdentificationToken::generateNew(),
-      1,
-      2,
-      FrameSerializer::getCurrentProtocolVersion());
+  auto token = ResumeIdentificationToken::generateNew();
+  auto const protocol = FrameSerializer::getCurrentProtocolVersion();
+
+  ResumeParameters resumeParams(std::move(token), 1, 2, protocol);
   EXPECT_CALL(*handler_, resumeSocket(_, _))
       .WillOnce(Invoke(
           [&](std::shared_ptr<FrameTransport> transport,
@@ -191,7 +188,7 @@ TEST_F(ServerConnectionAcceptorTest, ResumeFrame) {
       resumeParams.token,
       resumeParams.serverPosition,
       resumeParams.clientPosition,
-      FrameSerializer::getCurrentProtocolVersion())));
+      protocol)));
   clientOutput_->onComplete();
 }
 
@@ -221,17 +218,16 @@ TEST_F(ServerConnectionAcceptorTest, VerifyTransport) {
       resumeParams.serverPosition,
       resumeParams.clientPosition,
       FrameSerializer::getCurrentProtocolVersion())));
-  EXPECT_TRUE(wfp.use_count() > 0);
+  EXPECT_GT(wfp.use_count(), 0);
   clientOutput_->onComplete();
   transport_->close(folly::exception_wrapper());
 }
 
 TEST_F(ServerConnectionAcceptorTest, VerifyAsyncProcessorFrame) {
-  ResumeParameters resumeParams(
-      ResumeIdentificationToken::generateNew(),
-      1,
-      2,
-      FrameSerializer::getCurrentProtocolVersion());
+  auto token = ResumeIdentificationToken::generateNew();
+  auto const protocol = FrameSerializer::getCurrentProtocolVersion();
+
+  ResumeParameters resumeParams(std::move(token), 1, 2, protocol);
   std::shared_ptr<FrameTransport> transport_;
   EXPECT_CALL(*handler_, resumeSocket(_, _))
       .WillOnce(Invoke(
@@ -248,7 +244,7 @@ TEST_F(ServerConnectionAcceptorTest, VerifyAsyncProcessorFrame) {
       resumeParams.token,
       resumeParams.serverPosition,
       resumeParams.clientPosition,
-      FrameSerializer::getCurrentProtocolVersion())));
+      protocol)));
 
   // The transport won't have a processor now, try sending a frame
   clientOutput_->onNext(frameSerializer->serializeOut(Frame_REQUEST_FNF(


### PR DESCRIPTION
Right now it's always tied to a specific worker thread.  The issue we hit is
that there is no synchronous way of closing all FrameTransports held by the
ServerConnectionAcceptor, and waiting for all their associated events to drain
from the worker thread's EventBase.

This diff adds ServerConnectionAcceptor::stop().  This method calls close() on
each FrameTransport, and then waits on a newly created folly::Baton until the
transport set is empty.  To make this truly safe, we need the callbacks from
the ConnectionHandler to finish executing before the transport is removed
from the set.

Using that, we can make ~RSocketServer thread-safe as well.  I've enabled
RSocketClientServer.SimpleConnect, and run it 50 times in parallel on my machine
successfully.