### PR TITLE
Simplify ResumeCache

### DIFF
--- a/src/statemachine/RSocketStateMachine.cpp
+++ b/src/statemachine/RSocketStateMachine.cpp
@@ -378,10 +378,6 @@ void RSocketStateMachine::processFrameImpl(
 
   auto streamIdPtr = frameSerializer_->peekStreamId(*frame);
 
-  // TODO(tmont): If a frame is invalid, it will still be tracked. However, we
-  // actually want that. We want to keep
-  // each side in sync, even if a frame is invalid.
-  resumeCache_->trackReceivedFrame(*frame, frameType, streamIdPtr);
 
   if (!streamIdPtr) {
     // Failed to deserialize the frame.
@@ -389,6 +385,7 @@ void RSocketStateMachine::processFrameImpl(
     return;
   }
   auto streamId = *streamIdPtr;
+  resumeCache_->trackReceivedFrame(*frame, frameType, streamId);
   if (streamId == 0) {
     handleConnectionFrame(frameType, std::move(frame));
     return;

--- a/src/statemachine/RSocketStateMachine.cpp
+++ b/src/statemachine/RSocketStateMachine.cpp
@@ -313,6 +313,7 @@ bool RSocketStateMachine::endStreamInternal(
     StreamId streamId,
     StreamCompletionSignal signal) {
   VLOG(6) << "endStreamInternal";
+  resumeCache_->rmFromActiveStreams(streamId);
   auto it = streamState_->streams_.find(streamId);
   if (it == streamState_->streams_.end()) {
     // Unsubscribe handshake initiated by the connection, we're done.

--- a/src/statemachine/RSocketStateMachine.cpp
+++ b/src/statemachine/RSocketStateMachine.cpp
@@ -377,8 +377,6 @@ void RSocketStateMachine::processFrameImpl(
   stats_->frameRead(frameType);
 
   auto streamIdPtr = frameSerializer_->peekStreamId(*frame);
-
-
   if (!streamIdPtr) {
     // Failed to deserialize the frame.
     closeWithError(Frame_ERROR::invalidFrame());

--- a/src/temporary_home/ResumeCache.cpp
+++ b/src/temporary_home/ResumeCache.cpp
@@ -47,10 +47,14 @@ ResumeCache::~ResumeCache() {
 void ResumeCache::trackReceivedFrame(
     const folly::IOBuf& serializedFrame,
     const FrameType frameType,
-    const folly::Optional<StreamId> streamIdPtr) {
-  if (frameType == FrameType::REQUEST_STREAM && streamIdPtr) {
-    const StreamId streamId = *streamIdPtr;
-    activeStreams_.insert(streamId);
+    const StreamId streamId) {
+
+  if (frameType == FrameType::REQUEST_STREAM) {
+    activeRequestStreams_.insert(streamId);
+  } else if (frameType == FrameType::REQUEST_CHANNEL) {
+    activeRequestChannels_.insert(streamId);
+  } else if (frameType == FrameType::REQUEST_RESPONSE) {
+    activeRequestResponses_.insert(streamId);
   }
 
   if (shouldTrackFrame(frameType)) {
@@ -64,9 +68,15 @@ void ResumeCache::trackSentFrame(
     const folly::IOBuf& serializedFrame,
     const FrameType frameType,
     const folly::Optional<StreamId> streamIdPtr) {
-  if (frameType == FrameType::REQUEST_STREAM && streamIdPtr) {
+  if (streamIdPtr) {
     const StreamId streamId = *streamIdPtr;
-    activeStreams_.insert(streamId);
+    if (frameType == FrameType::REQUEST_STREAM) {
+      activeRequestStreams_.insert(streamId);
+    } else if (frameType == FrameType::REQUEST_CHANNEL) {
+      activeRequestChannels_.insert(streamId);
+    } else if (frameType == FrameType::REQUEST_RESPONSE) {
+      activeRequestResponses_.insert(streamId);
+    }
   }
 
   if (shouldTrackFrame(frameType)) {

--- a/src/temporary_home/ResumeCache.h
+++ b/src/temporary_home/ResumeCache.h
@@ -77,13 +77,9 @@ class ResumeCache {
     return size_;
   }
 
-  void onStreamClosed(StreamId streamId) {
-    // This is crude. We could try to preserve the stream type in
-    // RSocketStateMachine and pass it down explicitly here.
-    activeRequestStreams_.erase(streamId);
-    activeRequestChannels_.erase(streamId);
-    activeRequestResponses_.erase(streamId);
-  }
+  void onStreamOpen(StreamId streamId, FrameType frameType);
+
+  void onStreamClosed(StreamId streamId);
 
  private:
   void addFrame(const folly::IOBuf&, size_t);

--- a/src/temporary_home/ResumeCache.h
+++ b/src/temporary_home/ResumeCache.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <deque>
+#include <set>
 #include <unordered_map>
 
 #include <folly/Optional.h>
@@ -51,8 +52,6 @@ class ResumeCache {
 
   bool isPositionAvailable(ResumePosition position) const;
 
-  bool isPositionAvailable(ResumePosition position, StreamId streamId) const;
-
   void sendFramesFromPosition(
       ResumePosition position,
       FrameTransport& transport) const;
@@ -77,6 +76,10 @@ class ResumeCache {
     return size_;
   }
 
+  void rmFromActiveStreams(StreamId streamId) {
+    activeStreams_.erase(streamId);
+  }
+
  private:
   void addFrame(const folly::IOBuf&, size_t);
   void evictFrame();
@@ -93,7 +96,8 @@ class ResumeCache {
   // Inferred position of the rcvd frames
   ResumePosition impliedPosition_{0};
 
-  std::unordered_map<StreamId, ResumePosition> streamMap_;
+  // Only active REQUEST_STREAMs are preserved here
+  std::set<StreamId> activeStreams_;
 
   std::deque<std::pair<ResumePosition, std::unique_ptr<folly::IOBuf>>> frames_;
 

--- a/src/temporary_home/ResumeCache.h
+++ b/src/temporary_home/ResumeCache.h
@@ -39,7 +39,7 @@ class ResumeCache {
   void trackReceivedFrame(
       const folly::IOBuf& serializedFrame,
       const FrameType frameType,
-      const folly::Optional<StreamId> streamIdPtr);
+      const StreamId streamId);
 
   // Tracks a sent frame.
   void trackSentFrame(
@@ -78,7 +78,11 @@ class ResumeCache {
   }
 
   void onStreamClosed(StreamId streamId) {
-    activeStreams_.erase(streamId);
+    // This is crude. We could try to preserve the stream type in
+    // RSocketStateMachine and pass it down explicitly here.
+    activeRequestStreams_.erase(streamId);
+    activeRequestChannels_.erase(streamId);
+    activeRequestResponses_.erase(streamId);
   }
 
  private:
@@ -97,8 +101,14 @@ class ResumeCache {
   // Inferred position of the rcvd frames
   ResumePosition impliedPosition_{0};
 
-  // Only active REQUEST_STREAMs are preserved here
-  std::set<StreamId> activeStreams_;
+  // Active REQUEST_STREAMs are preserved here
+  std::set<StreamId> activeRequestStreams_;
+
+  // Active REQUEST_CHANNELs are preserved here
+  std::set<StreamId> activeRequestChannels_;
+
+  // Active REQUEST_RESPONSEs are preserved here
+  std::set<StreamId> activeRequestResponses_;
 
   std::deque<std::pair<ResumePosition, std::unique_ptr<folly::IOBuf>>> frames_;
 

--- a/src/temporary_home/ResumeCache.h
+++ b/src/temporary_home/ResumeCache.h
@@ -38,7 +38,8 @@ class ResumeCache {
   // Tracks a received frame.
   void trackReceivedFrame(
       const folly::IOBuf& serializedFrame,
-      const FrameType frameType);
+      const FrameType frameType,
+      const folly::Optional<StreamId> streamIdPtr);
 
   // Tracks a sent frame.
   void trackSentFrame(
@@ -76,7 +77,7 @@ class ResumeCache {
     return size_;
   }
 
-  void rmFromActiveStreams(StreamId streamId) {
+  void onStreamClosed(StreamId streamId) {
     activeStreams_.erase(streamId);
   }
 


### PR DESCRIPTION
This PR has two changes
- Remove the `map<StreamId, ResumePosition> streamMap_` from `ResumeCache`.
This map was never used.
- Add a set of `activeStreams_` in `ResumeCache`.

The main reason for doing this is driven by cold-resumption.  In cold-resumption,
we need to know all the streams which are active when the application restarts.

`streamMap_` contained an entry only if there are some frames buffered for a
stream.  If all the frames of a stream have been delivered to the other side,
the stream entry was removed.   And since `streamMap_` was not being used
anywhere else in RSocket, I have removed all the associated code.  This also
simplifies code.

On the other hand, `activeStreams_` stores StreamIds of all the streams which
are currently active.  The entries get removed only when the streams are
closed.  This can directly be used in cold resumption.  This is currently done 
only for REQUEST_STREAM

