### PR TITLE
requestResponse using Single<Payload>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,6 +461,41 @@ target_link_libraries(
         ${CMAKE_THREAD_LIBS_INIT}
 )
 
+# request-response-hello-world
+
+add_executable(
+        example_request-response-hello-world-server
+        examples/request-response-hello-world/RequestResponseHelloWorld_Server.cpp
+)
+
+target_link_libraries(
+        example_request-response-hello-world-server
+        ReactiveSocket
+        rsocket_experimental
+        reactivesocket_examples_util
+        yarpl
+        ${FOLLY_LIBRARIES}
+        ${GFLAGS_LIBRARY}
+        ${GLOG_LIBRARY}
+        ${CMAKE_THREAD_LIBS_INIT})
+
+add_executable(
+        example_request-response-hello-world-client
+        examples/request-response-hello-world/RequestResponseHelloWorld_Client.cpp
+)
+
+target_link_libraries(
+        example_request-response-hello-world-client
+        ReactiveSocket
+        rsocket_experimental
+        reactivesocket_examples_util
+        yarpl
+        ${FOLLY_LIBRARIES}
+        ${GFLAGS_LIBRARY}
+        ${GLOG_LIBRARY}
+        ${CMAKE_THREAD_LIBS_INIT})
+
+
 # stream-hello-world
 
 add_executable(

--- a/examples/request-response-hello-world/README.md
+++ b/examples/request-response-hello-world/README.md
@@ -1,0 +1,8 @@
+# Example: request-response-hello-world
+
+A basic TCP client/server relationship that requests a single string using ReactiveSocket `requestResponse`.
+
+CMake targets:
+
+- Server: example_request-response-hello-world-server
+- Client: example_request-response-hello-world-client

--- a/examples/request-response-hello-world/RequestResponseHelloWorld_Server.cpp
+++ b/examples/request-response-hello-world/RequestResponseHelloWorld_Server.cpp
@@ -1,0 +1,72 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <iostream>
+#include <thread>
+
+#include <folly/init/Init.h>
+#include <folly/portability/GFlags.h>
+
+#include "rsocket/RSocket.h"
+#include "rsocket/transports/TcpConnectionAcceptor.h"
+#include "yarpl/Single.h"
+
+using namespace reactivesocket;
+using namespace rsocket;
+using namespace yarpl;
+using namespace yarpl::single;
+
+DEFINE_int32(port, 9898, "port to connect to");
+
+class HelloRequestResponseRequestHandler
+    : public rsocket::RSocketRequestHandler {
+ public:
+  Reference<Single<Payload>> handleRequestResponse(
+      Payload request,
+      StreamId streamId) override {
+    LOG(INFO) << "HelloRequestResponseRequestHandler.handleRequestResponse "
+              << request;
+
+    // string from payload data
+    auto requestString = request.moveDataToString();
+
+    return Single<Payload>::create([name = std::move(requestString)](
+        auto subscriber) {
+
+      std::stringstream ss;
+      ss << "Hello " << name << "!";
+      std::string s = ss.str();
+      subscriber->onSuccess(Payload(s, "metadata"));
+    });
+  }
+};
+
+int main(int argc, char* argv[]) {
+  FLAGS_logtostderr = true;
+  FLAGS_minloglevel = 0;
+  folly::init(&argc, &argv);
+
+  TcpConnectionAcceptor::Options opts;
+  opts.port = FLAGS_port;
+  opts.threads = 2;
+
+  // RSocket server accepting on TCP
+  auto rs = RSocket::createServer(
+      std::make_unique<TcpConnectionAcceptor>(std::move(opts)));
+
+  // global request handler
+  auto handler = std::make_shared<HelloRequestResponseRequestHandler>();
+
+  auto rawRs = rs.get();
+  auto serverThread = std::thread([=] {
+    // start accepting connections
+    rawRs->startAndPark([handler](auto r) { return handler; });
+  });
+
+  // Wait for a newline on the console to terminate the server.
+  std::getchar();
+
+  rs->unpark();
+  serverThread.join();
+
+  return 0;
+}

--- a/experimental/rsocket/RSocketRequestHandler.h
+++ b/experimental/rsocket/RSocketRequestHandler.h
@@ -5,6 +5,7 @@
 #include <folly/io/async/EventBase.h>
 
 #include "yarpl/Flowable.h"
+#include "yarpl/Single.h"
 
 #include "src/Payload.h"
 #include "src/StreamState.h"
@@ -20,6 +21,23 @@ namespace rsocket {
 class RSocketRequestHandler {
  public:
   virtual ~RSocketRequestHandler() {}
+
+  /**
+   * Called when a new `requestResponse` occurs from an RSocketRequester.
+   *
+   * Return a Single with the response.
+   *
+   * @param request
+   * @param streamId
+   * @return
+   */
+  virtual yarpl::Reference<yarpl::single::Single<reactivesocket::Payload>>
+  handleRequestResponse(
+      reactivesocket::Payload request,
+      reactivesocket::StreamId streamId) {
+    return yarpl::single::Singles::error<reactivesocket::Payload>(
+        std::logic_error("handleRequestResponse not implemented"));
+  }
 
   /**
    * Called when a new `requestStream` occurs from an RSocketRequester.

--- a/experimental/rsocket/RSocketRequester.h
+++ b/experimental/rsocket/RSocketRequester.h
@@ -5,6 +5,7 @@
 #include <folly/io/async/EventBase.h>
 
 #include "yarpl/Flowable.h"
+#include "yarpl/Single.h"
 
 #include "src/ReactiveSocket.h"
 #include "src/ReactiveStreamsCompat.h"
@@ -29,8 +30,6 @@ class RSocketRequester {
   RSocketRequester(RSocketRequester&&) = delete; // move
   RSocketRequester& operator=(const RSocketRequester&) = delete; // copy
   RSocketRequester& operator=(RSocketRequester&&) = delete; // move
-
-  // TODO why is everything in here a shared_ptr and not just unique_ptr?
 
   /**
    * Send a single request and get a response stream.
@@ -63,12 +62,9 @@ class RSocketRequester {
    * https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md#stream-sequences-request-response
    *
    * @param payload
-   * @param responseSink
    */
-  void requestResponse(
-      reactivesocket::Payload payload,
-      std::shared_ptr<reactivesocket::Subscriber<reactivesocket::Payload>>
-          responseSink);
+  yarpl::Reference<yarpl::single::Single<reactivesocket::Payload>>
+  requestResponse(reactivesocket::Payload payload);
 
   /**
    * Send a single Payload with no response.


### PR DESCRIPTION
Adding requestResponse to RSocketRequester and RSocketRequestHandler with Single<Payload> type.

Note that a few corners are cut here when bridging old and new types. We are within 12ish hours of getting rid of the bridges so not bothering with those "corners" for now as they will shortly be removed.