### PR TITLE
fireAndForget using Single<void>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,6 +495,40 @@ target_link_libraries(
         ${GLOG_LIBRARY}
         ${CMAKE_THREAD_LIBS_INIT})
 
+# fire-and-forget-hello-world
+
+add_executable(
+        example_fire-and-forget-hello-world-server
+        examples/fire-and-forget-hello-world/FireAndForgetHelloWorld_Server.cpp
+)
+
+target_link_libraries(
+        example_fire-and-forget-hello-world-server
+        ReactiveSocket
+        rsocket_experimental
+        reactivesocket_examples_util
+        yarpl
+        ${FOLLY_LIBRARIES}
+        ${GFLAGS_LIBRARY}
+        ${GLOG_LIBRARY}
+        ${CMAKE_THREAD_LIBS_INIT})
+
+add_executable(
+        example_fire-and-forget-hello-world-client
+        examples/fire-and-forget-hello-world/FireAndForgetHelloWorld_Client.cpp
+)
+
+target_link_libraries(
+        example_fire-and-forget-hello-world-client
+        ReactiveSocket
+        rsocket_experimental
+        reactivesocket_examples_util
+        yarpl
+        ${FOLLY_LIBRARIES}
+        ${GFLAGS_LIBRARY}
+        ${GLOG_LIBRARY}
+        ${CMAKE_THREAD_LIBS_INIT})
+
 
 # stream-hello-world
 

--- a/examples/fire-and-forget-hello-world/FireAndForgetHelloWorld_Client.cpp
+++ b/examples/fire-and-forget-hello-world/FireAndForgetHelloWorld_Client.cpp
@@ -1,0 +1,48 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <iostream>
+
+#include <folly/init/Init.h>
+#include <folly/io/async/ScopedEventBaseThread.h>
+#include <folly/portability/GFlags.h>
+
+#include "examples/util/ExampleSubscriber.h"
+#include "rsocket/RSocket.h"
+#include "rsocket/transports/TcpConnectionFactory.h"
+
+#include "yarpl/Single.h"
+
+using namespace reactivesocket;
+using namespace rsocket_example;
+using namespace rsocket;
+using namespace yarpl;
+using namespace yarpl::single;
+
+DEFINE_string(host, "localhost", "host to connect to");
+DEFINE_int32(port, 9898, "host:port to connect to");
+
+int main(int argc, char* argv[]) {
+  FLAGS_logtostderr = true;
+  FLAGS_minloglevel = 0;
+  folly::init(&argc, &argv);
+
+  folly::SocketAddress address;
+  address.setFromHostPort(FLAGS_host, FLAGS_port);
+
+  // create a client which can then make connections below
+  auto rsf = RSocket::createClient(
+      std::make_unique<TcpConnectionFactory>(std::move(address)));
+
+  // connect and wait for connection
+  auto rs = rsf->connect().get();
+
+  // perform request on connected RSocket
+  rs->fireAndForget(Payload("Hello World!"))->subscribe([] {
+    std::cout << "wrote to network" << std::endl;
+  });
+
+  // Wait for a newline on the console to terminate the client.
+  std::getchar();
+
+  return 0;
+}

--- a/examples/fire-and-forget-hello-world/FireAndForgetHelloWorld_Server.cpp
+++ b/examples/fire-and-forget-hello-world/FireAndForgetHelloWorld_Server.cpp
@@ -1,0 +1,56 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <iostream>
+#include <thread>
+
+#include <folly/init/Init.h>
+#include <folly/portability/GFlags.h>
+
+#include "rsocket/RSocket.h"
+#include "rsocket/transports/TcpConnectionAcceptor.h"
+#include "yarpl/Single.h"
+
+using namespace reactivesocket;
+using namespace rsocket;
+using namespace yarpl;
+using namespace yarpl::single;
+
+DEFINE_int32(port, 9898, "port to connect to");
+
+class HelloFireAndForgetRequestHandler : public rsocket::RSocketResponder {
+ public:
+  void handleFireAndForget(Payload request, StreamId streamId) override {
+    LOG(INFO) << "Received fireAndForget: " << request.moveDataToString();
+  }
+};
+
+int main(int argc, char* argv[]) {
+  FLAGS_logtostderr = true;
+  FLAGS_minloglevel = 0;
+  folly::init(&argc, &argv);
+
+  TcpConnectionAcceptor::Options opts;
+  opts.port = FLAGS_port;
+  opts.threads = 2;
+
+  // RSocket server accepting on TCP
+  auto rs = RSocket::createServer(
+      std::make_unique<TcpConnectionAcceptor>(std::move(opts)));
+
+  // global request handler
+  auto handler = std::make_shared<HelloFireAndForgetRequestHandler>();
+
+  auto rawRs = rs.get();
+  auto serverThread = std::thread([=] {
+    // start accepting connections
+    rawRs->startAndPark([handler](auto r) { return handler; });
+  });
+
+  // Wait for a newline on the console to terminate the server.
+  std::getchar();
+
+  rs->unpark();
+  serverThread.join();
+
+  return 0;
+}

--- a/examples/fire-and-forget-hello-world/README.md
+++ b/examples/fire-and-forget-hello-world/README.md
@@ -1,0 +1,8 @@
+# Example: fire-and-forget-hello-world
+
+A basic TCP client/server relationship that submits a string using RSocket `fireAndForget`.
+
+CMake targets:
+
+- Server: example_fire-and-forget-hello-world-server
+- Client: example_fire-and-forget-hello-world-client

--- a/experimental/rsocket-src/RSocketConnectionHandler.cpp
+++ b/experimental/rsocket-src/RSocketConnectionHandler.cpp
@@ -106,6 +106,12 @@ class RSocketHandlerBridge : public reactivesocket::DefaultRequestHandler {
             std::move(single), responseSubscriber));
   }
 
+  void handleFireAndForgetRequest(
+      Payload request,
+      StreamId streamId) noexcept override {
+    handler_->handleFireAndForget(std::move(request), std::move(streamId));
+  }
+
  private:
   std::shared_ptr<RSocketResponder> handler_;
 };

--- a/experimental/rsocket/RSocketRequester.h
+++ b/experimental/rsocket/RSocketRequester.h
@@ -53,7 +53,7 @@ class RSocketRequester {
    * @param payload
    */
   yarpl::Reference<yarpl::flowable::Flowable<reactivesocket::Payload>>
-  requestStream(reactivesocket::Payload payload);
+  requestStream(reactivesocket::Payload request);
 
   /**
     * Start a channel (streams in both directions).
@@ -66,7 +66,7 @@ class RSocketRequester {
   yarpl::Reference<yarpl::flowable::Flowable<reactivesocket::Payload>>
   requestChannel(
       yarpl::Reference<yarpl::flowable::Flowable<reactivesocket::Payload>>
-          payloads);
+          requests);
 
   /**
    * Send a single request and get a single response.
@@ -77,17 +77,24 @@ class RSocketRequester {
    * @param payload
    */
   yarpl::Reference<yarpl::single::Single<reactivesocket::Payload>>
-  requestResponse(reactivesocket::Payload payload);
+  requestResponse(reactivesocket::Payload request);
 
   /**
    * Send a single Payload with no response.
+   *
+   * The returned Single<void> invokes onSuccess or onError
+   * based on client-side success or failure. Once the payload is
+   * sent to the network it is "forgotten" and the Single<void> will
+   * be finished with no further response indicating success
+   * or failure on the server.
    *
    * Interaction model details can be found at
    * https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md#request-fire-n-forget
    *
    * @param payload
    */
-  void requestFireAndForget(reactivesocket::Payload payload);
+  yarpl::Reference<yarpl::single::Single<void>> fireAndForget(
+      reactivesocket::Payload request);
 
   /**
    * Send metadata without response.

--- a/experimental/rsocket/RSocketResponder.h
+++ b/experimental/rsocket/RSocketResponder.h
@@ -87,5 +87,20 @@ class RSocketResponder {
     return yarpl::flowable::Flowables::error<reactivesocket::Payload>(
         std::logic_error("handleRequestChannel not implemented"));
   }
+
+  /**
+   * Called when a new `fireAndForget` occurs from an RSocketRequester.
+   *
+   * No response.
+   *
+   * @param request
+   * @param streamId
+   * @return
+   */
+  virtual void handleFireAndForget(
+      reactivesocket::Payload request,
+      reactivesocket::StreamId streamId) {
+    // no default implementation, no error response to provide
+  }
 };
 }

--- a/experimental/yarpl/include/yarpl/single/SingleObserver.h
+++ b/experimental/yarpl/include/yarpl/single/SingleObserver.h
@@ -37,5 +37,36 @@ class SingleObserver : public virtual Refcounted {
   Reference<SingleSubscription> subscription_{nullptr};
 };
 
+// specialization of SingleObserver<void>
+template <>
+class SingleObserver<void> : public virtual Refcounted {
+ public:
+  // Note: if any of the following methods is overridden in a subclass,
+  // the new methods SHOULD ensure that these are invoked as well.
+  virtual void onSubscribe(Reference<SingleSubscription> subscription) {
+    subscription_ = subscription;
+  }
+
+  // No further calls to the subscription after this method is invoked.
+  virtual void onSuccess() {
+    subscription_.reset();
+  }
+
+  // No further calls to the subscription after this method is invoked.
+  virtual void onError(const std::exception_ptr) {
+    subscription_.reset();
+  }
+
+ protected:
+  SingleSubscription* subscription() {
+    return subscription_.operator->();
+  }
+
+ private:
+  // "Our" reference to the subscription, to ensure that it is retained
+  // while calls to its methods are in-flight.
+  Reference<SingleSubscription> subscription_{nullptr};
+};
+
 } // single
 } // yarpl


### PR DESCRIPTION
This includes a specialization of Single<void> so that SingleSubscriber::onSuccess() can be called.