### PR TITLE
fixing memory leaking tests

### DIFF
--- a/benchmarks/RequestResponseLatency.cpp
+++ b/benchmarks/RequestResponseLatency.cpp
@@ -1,5 +1,6 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
+#include <condition_variable>
 #include <benchmark/benchmark.h>
 #include <thread>
 #include <folly/io/async/ScopedEventBaseThread.h>

--- a/benchmarks/RequestResponseThroughput.cpp
+++ b/benchmarks/RequestResponseThroughput.cpp
@@ -2,7 +2,7 @@
 
 #include <benchmark/benchmark.h>
 #include <thread>
-
+#include <condition_variable>
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <folly/ExceptionString.h>
 #include <iostream>

--- a/benchmarks/StreamThroughput.cpp
+++ b/benchmarks/StreamThroughput.cpp
@@ -2,7 +2,7 @@
 
 #include <benchmark/benchmark.h>
 #include <thread>
-
+#include <condition_variable>
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <folly/ExceptionString.h>
 #include <iostream>

--- a/src/statemachine/ConsumerBase.cpp
+++ b/src/statemachine/ConsumerBase.cpp
@@ -38,7 +38,6 @@ void ConsumerBase::endStream(StreamCompletionSignal signal) {
       subscriber->onError(std::make_exception_ptr(StreamInterruptedException(static_cast<int>(signal))));
     }
   }
-  Subscription::release();
   Base::endStream(signal);
 }
 

--- a/src/statemachine/RequestResponseRequester.cpp
+++ b/src/statemachine/RequestResponseRequester.cpp
@@ -72,7 +72,6 @@ void RequestResponseRequester::endStream(StreamCompletionSignal signal) {
       subscriber->onError(std::make_exception_ptr(StreamInterruptedException(static_cast<int>(signal))));
     }
   }
-  Subscription::release();
 }
 
 void RequestResponseRequester::handleError(

--- a/src/temporary_home/OldNewBridge.h
+++ b/src/temporary_home/OldNewBridge.h
@@ -31,9 +31,7 @@ class NewToOldSubscription : public yarpl::flowable::Subscription {
 
   void cancel() override {
     inner_->cancel();
-
     inner_.reset();
-    release();
   }
 
  private:

--- a/yarpl/include/yarpl/Refcounted.h
+++ b/yarpl/include/yarpl/Refcounted.h
@@ -29,10 +29,19 @@ class Refcounted {
   virtual ~Refcounted() = default;
 #endif /* NDEBUG */
 
- private:
-  template <typename T>
-  friend class Reference;
+  // not intended to be broadly used by the application code
+  // mostly for library code (static to purposely make it more awkward)
+  static void incRef(Refcounted& obj) {
+    obj.incRef();
+  }
 
+  // not intended to be broadly used by the application code
+  // mostly for library code (static to purposely make it more awkward)
+  static void decRef(Refcounted& obj) {
+    obj.decRef();
+  }
+
+ private:
   void incRef() {
     refcount_.fetch_add(1, std::memory_order_relaxed);
   }
@@ -145,13 +154,13 @@ class Reference {
  private:
   void inc() {
     if (pointer_) {
-      pointer_->incRef();
+      Refcounted::incRef(*pointer_);
     }
   }
 
   void dec() {
     if (pointer_) {
-      pointer_->decRef();
+      Refcounted::decRef(*pointer_);
     }
   }
 

--- a/yarpl/include/yarpl/flowable/Subscription.h
+++ b/yarpl/include/yarpl/flowable/Subscription.h
@@ -8,25 +8,9 @@ namespace flowable {
 class Subscription : public virtual Refcounted {
  public:
   virtual ~Subscription() = default;
+
   virtual void request(int64_t n) = 0;
   virtual void cancel() = 0;
-
- protected:
-  Subscription() : reference_(this) {}
-
-  // Drop the reference we're holding on the subscription (handle).
-  void release() {
-    reference_.reset();
-  }
-
- private:
-  // TODO(lehecka): we can save some bytes by removing reference_ and replace
-  // it with addRef/release calls
-  //
-  // We expect to be heap-allocated; until this subscription finishes
-  // (is canceled; completes; error's out), hold a reference so we are
-  // not deallocated (by the subscriber).
-  Reference<Refcounted> reference_;
 };
 
 } // flowable

--- a/yarpl/test/Observable_test.cpp
+++ b/yarpl/test/Observable_test.cpp
@@ -462,3 +462,21 @@ TEST(Observable, ObserversError) {
 
   EXPECT_TRUE(errored);
 }
+
+TEST(Observable, CancelReleasesObjects) {
+  EXPECT_EQ(0u, Refcounted::objects());
+
+  auto lambda = [](Reference<Observer<int>> observer) {
+      // we will send nothing
+  };
+  auto observable = Observable<int>::create(std::move(lambda));
+
+  EXPECT_EQ(1u, Refcounted::objects());
+
+  auto collector = make_ref<CollectingObserver<int>>();
+  observable->subscribe(collector);
+
+  observable.reset();
+  collector.reset();
+  EXPECT_EQ(0u, Refcounted::objects());
+}


### PR DESCRIPTION
The Subscription interface is now used in ReactiveSocket library and the special behavior around lifetime is unnecessary and awkward to use leading to memory leaks.
The fix also focuses on breaking the reference cycles between subscribers and subscriptions