### PR TITLE
Eliminate ReactiveSocket.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,8 +200,6 @@ add_library(
   src/temporary_home/ResumeCache.h
   src/temporary_home/ServerConnectionAcceptor.cpp
   src/temporary_home/ServerConnectionAcceptor.h
-  src/temporary_home/ReactiveSocket.cpp
-  src/temporary_home/ReactiveSocket.h
   src/temporary_home/Stats.cpp
   src/temporary_home/Stats.h
   src/temporary_home/StreamsFactory.cpp
@@ -273,7 +271,10 @@ add_executable(
   test/integration/ServerFixture.cpp
   test/integration/WarmResumptionTest.cpp
   test/streams/Mocks.h
-  test/framing/FrameTransportTest.cpp)
+  test/framing/FrameTransportTest.cpp
+  test/deprecated/ReactiveSocket.cpp
+  test/deprecated/ReactiveSocket.h
+)
 
 target_link_libraries(
   tests
@@ -304,7 +305,10 @@ add_executable(
   tck-test/TestSuite.h
   tck-test/TestInterpreter.cpp
   tck-test/TestInterpreter.h
-  tck-test/TypedCommands.h)
+  tck-test/TypedCommands.h
+  test/deprecated/ReactiveSocket.cpp
+  test/deprecated/ReactiveSocket.h
+)
 
 target_link_libraries(
   tckclient
@@ -321,7 +325,10 @@ add_executable(
   tck-test/MarbleProcessor.cpp
   tck-test/MarbleProcessor.h
   test/test_utils/StatsPrinter.cpp
-  test/test_utils/StatsPrinter.h)
+  test/test_utils/StatsPrinter.h
+  test/deprecated/ReactiveSocket.cpp
+  test/deprecated/ReactiveSocket.h
+)
 
 target_link_libraries(
   tckserver
@@ -339,10 +346,11 @@ add_executable(
   test/resumption/TcpResumeClient.cpp
   test/test_utils/PrintSubscriber.cpp
   test/test_utils/PrintSubscriber.h
-  src/temporary_home/ReactiveSocket.cpp
-  src/temporary_home/ReactiveSocket.h
   test/test_utils/StatsPrinter.cpp
-  test/test_utils/StatsPrinter.h)
+  test/test_utils/StatsPrinter.h
+  test/deprecated/ReactiveSocket.cpp
+  test/deprecated/ReactiveSocket.h
+)
 
 target_link_libraries(
   tcpresumeclient
@@ -362,7 +370,10 @@ add_executable(
   test/test_utils/PrintSubscriber.cpp
   test/test_utils/PrintSubscriber.h
   test/test_utils/StatsPrinter.cpp
-  test/test_utils/StatsPrinter.h)
+  test/test_utils/StatsPrinter.h
+  test/deprecated/ReactiveSocket.cpp
+  test/deprecated/ReactiveSocket.h
+)
 
 target_link_libraries(
   tcpresumeserver

--- a/src/ConnectionResumeRequest.cpp
+++ b/src/ConnectionResumeRequest.cpp
@@ -2,6 +2,4 @@
 
 #include "ConnectionResumeRequest.h"
 
-using namespace reactivesocket;
-
 namespace rsocket {}

--- a/src/ConnectionResumeRequest.h
+++ b/src/ConnectionResumeRequest.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include "src/temporary_home/ReactiveSocket.h"
-
 namespace rsocket {
 
 /**

--- a/src/ConnectionSetupRequest.h
+++ b/src/ConnectionSetupRequest.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "src/temporary_home/ReactiveSocket.h"
+#include "src/temporary_home/ConnectionSetupPayload.h"
 
 namespace rsocket {
 

--- a/src/RSocketClient.cpp
+++ b/src/RSocketClient.cpp
@@ -2,9 +2,9 @@
 
 #include "RSocketClient.h"
 #include "RSocketRequester.h"
-#include "src/temporary_home/NullRequestHandler.h"
-#include "src/temporary_home/ReactiveSocket.h"
+#include "src/temporary_home/Stats.h"
 #include "src/internal/FollyKeepaliveTimer.h"
+#include "src/temporary_home/NullRequestHandler.h"
 
 using namespace reactivesocket;
 using namespace folly;
@@ -26,21 +26,39 @@ Future<std::shared_ptr<RSocketRequester>> RSocketClient::connect() {
       EventBase& eventBase) {
     LOG(INFO) << "RSocketClient => onConnect received DuplexConnection";
 
-    auto r = ReactiveSocket::fromClientConnection(
+    auto rs = std::make_shared<RSocketStateMachine>(
         eventBase,
-        std::move(framedConnection),
-        // TODO need to optionally allow this being passed in for a duplex
-        // client
+        // need to allow Responder being passed in optionally
         std::make_unique<NullRequestHandler>(),
-        // TODO need to allow this being passed in
-        ConnectionSetupPayload(
-            "text/plain", "text/plain", Payload("meta", "data")),
+        // need to allow stats being passed in
         Stats::noop(),
         // TODO need to optionally allow defining the keepalive timer
         std::make_unique<FollyKeepaliveTimer>(
-            eventBase, std::chrono::milliseconds(5000)));
+            eventBase, std::chrono::milliseconds(5000)),
+    ReactiveSocketMode::CLIENT);
 
-    auto rsocket = RSocketRequester::create(std::move(r), eventBase);
+    // TODO need to allow this being passed in
+    auto setupPayload = ConnectionSetupPayload(
+        "text/plain", "text/plain", Payload("meta", "data"));
+
+    rs->setFrameSerializer(
+        setupPayload.protocolVersion == ProtocolVersion::Unknown
+            ? FrameSerializer::createCurrentVersion()
+            : FrameSerializer::createFrameSerializer(
+                  setupPayload.protocolVersion));
+
+    rs->setResumable(setupPayload.resumable);
+
+    if (setupPayload.protocolVersion != ProtocolVersion::Unknown) {
+      CHECK_EQ(
+          setupPayload.protocolVersion, rs->getSerializerProtocolVersion());
+    }
+
+    auto frameTransport =
+        std::make_shared<FrameTransport>(std::move(framedConnection));
+    rs->setUpFrame(std::move(frameTransport), std::move(setupPayload));
+
+    auto rsocket = RSocketRequester::create(std::move(rs), eventBase);
     // store it so it lives as long as the RSocketClient
     rsockets_.push_back(rsocket);
     promise->setValue(rsocket);

--- a/src/RSocketClient.cpp
+++ b/src/RSocketClient.cpp
@@ -2,9 +2,9 @@
 
 #include "RSocketClient.h"
 #include "RSocketRequester.h"
-#include "src/temporary_home/Stats.h"
 #include "src/internal/FollyKeepaliveTimer.h"
 #include "src/temporary_home/NullRequestHandler.h"
+#include "src/temporary_home/Stats.h"
 
 using namespace reactivesocket;
 using namespace folly;
@@ -35,11 +35,13 @@ Future<std::shared_ptr<RSocketRequester>> RSocketClient::connect() {
         // TODO need to optionally allow defining the keepalive timer
         std::make_unique<FollyKeepaliveTimer>(
             eventBase, std::chrono::milliseconds(5000)),
-    ReactiveSocketMode::CLIENT);
+        ReactiveSocketMode::CLIENT);
 
     // TODO need to allow this being passed in
     auto setupPayload = ConnectionSetupPayload(
         "text/plain", "text/plain", Payload("meta", "data"));
+
+    // TODO ---> this code needs to be moved inside RSocketStateMachine
 
     rs->setFrameSerializer(
         setupPayload.protocolVersion == ProtocolVersion::Unknown
@@ -57,6 +59,10 @@ Future<std::shared_ptr<RSocketRequester>> RSocketClient::connect() {
     auto frameTransport =
         std::make_shared<FrameTransport>(std::move(framedConnection));
     rs->setUpFrame(std::move(frameTransport), std::move(setupPayload));
+
+    // TODO <---- up to here
+    // TODO and then a simple API such as:
+    // TODO rs->connectAndSendSetup(frameTransport, params, setupPayload)
 
     auto rsocket = RSocketRequester::create(std::move(rs), eventBase);
     // store it so it lives as long as the RSocketClient

--- a/src/RSocketClient.h
+++ b/src/RSocketClient.h
@@ -5,7 +5,6 @@
 #include <folly/futures/Future.h>
 #include "src/ConnectionFactory.h"
 #include "RSocketRequester.h"
-#include "src/temporary_home/ReactiveSocket.h"
 
 namespace rsocket {
 

--- a/src/RSocketConnectionHandler.cpp
+++ b/src/RSocketConnectionHandler.cpp
@@ -6,9 +6,11 @@
 #include <folly/io/async/EventBase.h>
 #include <folly/io/async/EventBaseManager.h>
 
-#include "src/temporary_home/OldNewBridge.h"
 #include "RSocketErrors.h"
+#include "src/statemachine/RSocketStateMachine.h"
 #include "src/temporary_home/NullRequestHandler.h"
+#include "src/temporary_home/OldNewBridge.h"
+#include "src/temporary_home/Stats.h"
 
 namespace rsocket {
 
@@ -23,7 +25,8 @@ class RSocketHandlerBridge : public reactivesocket::DefaultRequestHandler {
   void handleRequestStream(
       Payload request,
       StreamId streamId,
-      const yarpl::Reference<yarpl::flowable::Subscriber<Payload>>& response) noexcept override {
+      const yarpl::Reference<yarpl::flowable::Subscriber<Payload>>&
+          response) noexcept override {
     auto flowable =
         handler_->handleRequestStream(std::move(request), std::move(streamId));
     // bridge from the existing eager RequestHandler and old Subscriber type
@@ -34,7 +37,8 @@ class RSocketHandlerBridge : public reactivesocket::DefaultRequestHandler {
   yarpl::Reference<yarpl::flowable::Subscriber<Payload>> handleRequestChannel(
       Payload request,
       StreamId streamId,
-      const yarpl::Reference<yarpl::flowable::Subscriber<Payload>>& response) noexcept override {
+      const yarpl::Reference<yarpl::flowable::Subscriber<Payload>>&
+          response) noexcept override {
     auto eagerSubscriber = make_ref<EagerSubscriberBridge>();
     auto flowable = handler_->handleRequestChannel(
         std::move(request),
@@ -63,7 +67,8 @@ class RSocketHandlerBridge : public reactivesocket::DefaultRequestHandler {
      public:
       BridgeSubscriptionToSingle(
           yarpl::Reference<yarpl::single::Single<Payload>> single,
-          yarpl::Reference<yarpl::flowable::Subscriber<Payload>> responseSubscriber)
+          yarpl::Reference<yarpl::flowable::Subscriber<Payload>>
+              responseSubscriber)
           : single_{std::move(single)},
             responseSubscriber_{std::move(responseSubscriber)} {}
 
@@ -89,13 +94,13 @@ class RSocketHandlerBridge : public reactivesocket::DefaultRequestHandler {
 
      private:
       yarpl::Reference<yarpl::single::Single<Payload>> single_;
-      yarpl::Reference<yarpl::flowable::Subscriber<Payload>> responseSubscriber_;
+      yarpl::Reference<yarpl::flowable::Subscriber<Payload>>
+          responseSubscriber_;
       std::atomic_bool subscribed_{false};
     };
 
-    responseSubscriber->onSubscribe(
-        make_ref<BridgeSubscriptionToSingle>(
-            std::move(single), responseSubscriber));
+    responseSubscriber->onSubscribe(make_ref<BridgeSubscriptionToSingle>(
+        std::move(single), responseSubscriber));
   }
 
   void handleFireAndForgetRequest(
@@ -133,18 +138,25 @@ void RSocketConnectionHandler::setupNewSocket(
 
   auto handlerBridge =
       std::make_shared<RSocketHandlerBridge>(std::move(requestHandler));
-  auto rs = ReactiveSocket::disconnectedServer(
-      // we know this callback is on a specific EventBase
+
+  auto rs = std::make_shared<RSocketStateMachine>(
       *executor,
       std::move(handlerBridge),
-      Stats::noop());
+      Stats::noop(),
+      nullptr,
+      ReactiveSocketMode::SERVER);
 
-  auto rawRs = rs.get();
-
-  manageSocket(setupRequest, std::move(rs));
+  manageSocket(setupRequest, rs);
 
   // Connect last, after all state has been set up.
-  rawRs->serverConnect(std::move(frameTransport), socketParams);
+  rs->setResumable(socketParams.resumable);
+
+  if (socketParams.protocolVersion != ProtocolVersion::Unknown) {
+    rs->setFrameSerializer(
+        FrameSerializer::createFrameSerializer(socketParams.protocolVersion));
+  }
+
+  rs->connect(std::move(frameTransport), true, socketParams.protocolVersion);
 }
 
 bool RSocketConnectionHandler::resumeSocket(

--- a/src/RSocketConnectionHandler.cpp
+++ b/src/RSocketConnectionHandler.cpp
@@ -148,6 +148,8 @@ void RSocketConnectionHandler::setupNewSocket(
 
   manageSocket(setupRequest, rs);
 
+  // TODO ---> this code needs to be moved inside RSocketStateMachine
+
   // Connect last, after all state has been set up.
   rs->setResumable(socketParams.resumable);
 
@@ -157,6 +159,10 @@ void RSocketConnectionHandler::setupNewSocket(
   }
 
   rs->connect(std::move(frameTransport), true, socketParams.protocolVersion);
+
+  // TODO <---- up to here
+  // TODO and then a simple API such as:
+  // TODO rs->connectServer(frameTransport, params)
 }
 
 bool RSocketConnectionHandler::resumeSocket(

--- a/src/RSocketConnectionHandler.h
+++ b/src/RSocketConnectionHandler.h
@@ -15,6 +15,14 @@ namespace rsocket {
  * class that is responsible for basic RSocket creation and setup; the virtual
  * functions will be implemented to customize the actual handling of the
  * RSocket.
+ * Handles the setup/creation/error steps for an RSocketServer accepting
+ * connections.
+ *
+ * This is an abstract class that is responsible for basic RSocket creation and
+ * setup.
+ *
+ * The virtual functions will be implemented to customize the actual handling of
+ * the RSocket.
  *
  * TODO: Resumability
  *
@@ -49,7 +57,7 @@ class RSocketConnectionHandler : public reactivesocket::ConnectionHandler {
    */
   virtual void manageSocket(
       std::shared_ptr<ConnectionSetupRequest> request,
-      std::unique_ptr<reactivesocket::ReactiveSocket> socket) = 0;
+      std::shared_ptr<reactivesocket::RSocketStateMachine> socket) = 0;
 };
 
 } // namespace rsocket

--- a/src/RSocketConnectionHandler.h
+++ b/src/RSocketConnectionHandler.h
@@ -25,8 +25,6 @@ namespace rsocket {
  * the RSocket.
  *
  * TODO: Resumability
- *
- * TODO: Concurrency (number of threads)
  */
 class RSocketConnectionHandler : public reactivesocket::ConnectionHandler {
  public:

--- a/src/RSocketRequester.cpp
+++ b/src/RSocketRequester.cpp
@@ -55,6 +55,8 @@ RSocketRequester::requestChannel(
     ]() mutable {
       auto responseSink = srs->streamsFactory().createChannelRequester(
           std::move(std::move(subscriber)));
+        // TODO the responseSink needs to be wrapped with thread scheduling
+        // so all emissions happen on the right thread
       requestStream->subscribe(std::move(responseSink));
     });
   });

--- a/src/RSocketRequester.h
+++ b/src/RSocketRequester.h
@@ -7,8 +7,9 @@
 #include "yarpl/Flowable.h"
 #include "yarpl/Single.h"
 
-#include "src/temporary_home/ReactiveSocket.h"
+#include "Payload.h"
 #include "src/internal/ReactiveStreamsCompat.h"
+#include "src/statemachine/RSocketStateMachine.h"
 
 namespace rsocket {
 
@@ -34,7 +35,7 @@ namespace rsocket {
 class RSocketRequester {
  public:
   static std::shared_ptr<RSocketRequester> create(
-      std::unique_ptr<reactivesocket::ReactiveSocket> srs,
+      std::shared_ptr<reactivesocket::RSocketStateMachine> srs,
       folly::EventBase& executor);
   // TODO figure out how to use folly::Executor instead of EventBase
 
@@ -105,9 +106,9 @@ class RSocketRequester {
 
  private:
   RSocketRequester(
-      std::unique_ptr<reactivesocket::ReactiveSocket> srs,
+      std::shared_ptr<reactivesocket::RSocketStateMachine> srs,
       folly::EventBase& eventBase);
-  std::shared_ptr<reactivesocket::ReactiveSocket> reactiveSocket_;
+  std::shared_ptr<reactivesocket::RSocketStateMachine> reactiveSocket_;
   folly::EventBase& eventBase_;
 };
 }

--- a/src/RSocketRequester.h
+++ b/src/RSocketRequester.h
@@ -108,7 +108,7 @@ class RSocketRequester {
   RSocketRequester(
       std::shared_ptr<reactivesocket::RSocketStateMachine> srs,
       folly::EventBase& eventBase);
-  std::shared_ptr<reactivesocket::RSocketStateMachine> reactiveSocket_;
+  std::shared_ptr<reactivesocket::RSocketStateMachine> stateMachine_;
   folly::EventBase& eventBase_;
 };
 }

--- a/src/RSocketServer.cpp
+++ b/src/RSocketServer.cpp
@@ -5,6 +5,7 @@
 #include <folly/ExceptionWrapper.h>
 
 #include "RSocketConnectionHandler.h"
+#include "src/statemachine/RSocketStateMachine.h"
 
 using namespace reactivesocket;
 
@@ -12,10 +13,11 @@ namespace rsocket {
 
 class RSocketServerConnectionHandler : public virtual RSocketConnectionHandler {
  public:
-  RSocketServerConnectionHandler(RSocketServer* server, OnAccept onAccept) {
-    server_ = server;
-    onAccept_ = onAccept;
-  }
+  RSocketServerConnectionHandler(
+      RSocketServer* server,
+      OnAccept onAccept,
+      folly::Executor& executor)
+      : server_{server}, onAccept_{std::move(onAccept)}, executor_{executor} {}
 
   std::shared_ptr<RSocketResponder> getHandler(
       std::shared_ptr<ConnectionSetupRequest> request) override {
@@ -24,23 +26,25 @@ class RSocketServerConnectionHandler : public virtual RSocketConnectionHandler {
 
   void manageSocket(
       std::shared_ptr<ConnectionSetupRequest> request,
-      std::shared_ptr<reactivesocket::RSocketStateMachine> socket) override {
-    // TODO restore this behavior
-    //    socket->onClosed([ this, socket = socket.get() ](
-    //        const folly::exception_wrapper&) {
-    //      // Enqueue another event to remove and delete it.  We cannot delete
-    //      // the ReactiveSocket now as it still needs to finish processing the
-    //      // onClosed handlers in the stack frame above us.
-    //      socket->executor().add([this, socket] {
-    //      server_->removeSocket(socket); });
-    //    });
+      std::shared_ptr<reactivesocket::RSocketStateMachine> stateMachine)
+      override {
+    stateMachine->addClosedListener(
+        [this, stateMachine](const folly::exception_wrapper&) {
+          // Enqueue another event to remove and delete it.  We cannot delete
+          // the RSocketStateMachine now as it still needs to finish processing
+          // the onClosed handlers in the stack frame above us.
+          executor_.add([this, stateMachine] {
+            server_->removeConnection(stateMachine);
+          });
+        });
 
-    server_->addSocket(std::move(socket));
+    server_->addConnection(std::move(stateMachine), executor_);
   }
 
  private:
   RSocketServer* server_;
   OnAccept onAccept_;
+  folly::Executor& executor_;
 };
 
 RSocketServer::RSocketServer(
@@ -65,11 +69,14 @@ RSocketServer::~RSocketServer() {
 
     shutdown_.emplace();
 
-    // TODO restore this behavior
-    //    for (auto& socket : *locked) {
-    //       close() has to be called on the same executor as the socket.
-    //      socket->executor().add([s = socket.get()] { s->close(); });
-    //    }
+    for (auto& connectionPair : *locked) {
+      // close() has to be called on the same executor as the socket
+      auto& executor_ = connectionPair.second;
+      executor_.add([s = connectionPair.first] {
+        s->close(
+            folly::exception_wrapper(), StreamCompletionSignal::SOCKET_CLOSED);
+      });
+    }
   }
 
   // Wait for all ReactiveSockets to close.
@@ -80,26 +87,26 @@ RSocketServer::~RSocketServer() {
 }
 
 void RSocketServer::start(OnAccept onAccept) {
-  if (connectionHandler_) {
+  if (started) {
     throw std::runtime_error("RSocketServer::start() already called.");
   }
+  started = true;
 
   LOG(INFO) << "Initializing connection acceptor on start";
 
-  connectionHandler_ =
-      std::make_unique<RSocketServerConnectionHandler>(this, onAccept);
-
   lazyAcceptor_
-      ->start([this](
-          std::unique_ptr<DuplexConnection> conn, folly::Executor& executor) {
+      ->start([ this, onAccept = std::move(onAccept) ](
+          std::unique_ptr<DuplexConnection> conn, folly::Executor & executor) {
         LOG(INFO) << "Going to accept duplex connection";
 
+        auto connectionHandler_ =
+            std::make_shared<RSocketServerConnectionHandler>(
+                this, onAccept, executor);
+
         // FIXME(alexanderm): This isn't thread safe
-        acceptor_.accept(std::move(conn), connectionHandler_);
+        acceptor_.accept(std::move(conn), std::move(connectionHandler_));
       })
-      .onError([](const folly::exception_wrapper& ex) {
-        LOG(FATAL) << "Failed to start ConnectionAcceptor: " << ex.what();
-      });
+      .get(); // block until finished and return or throw
 }
 
 void RSocketServer::startAndPark(OnAccept onAccept) {
@@ -111,12 +118,13 @@ void RSocketServer::unpark() {
   waiting_.post();
 }
 
-void RSocketServer::addSocket(
-    std::shared_ptr<reactivesocket::RSocketStateMachine> socket) {
-  sockets_.lock()->insert(std::move(socket));
+void RSocketServer::addConnection(
+    std::shared_ptr<reactivesocket::RSocketStateMachine> socket,
+    folly::Executor& executor) {
+  sockets_.lock()->insert({std::move(socket), executor});
 }
 
-void RSocketServer::removeSocket(
+void RSocketServer::removeConnection(
     std::shared_ptr<reactivesocket::RSocketStateMachine> socket) {
   auto locked = sockets_.lock();
   locked->erase(socket);

--- a/src/RSocketServer.h
+++ b/src/RSocketServer.h
@@ -40,14 +40,20 @@ class RSocketServer {
   /**
    * Start the ConnectionAcceptor and begin handling connections.
    *
-   * This method is asynchronous.
+   * This method blocks until the server has started. It returns if successful
+   * or throws an exception if failure occurs.
+   *
+   * This method assumes it will be called only once.
    */
   void start(OnAccept);
 
   /**
    * Start the ConnectionAcceptor and begin handling connections.
    *
-   * This method will block the calling thread.
+   * This method will block the calling thread as long as the server is running.
+   * It will throw an exception if a failure occurs on startup.
+   *
+   * This method assumes it will be called only once.
    */
   void startAndPark(OnAccept);
 
@@ -71,18 +77,18 @@ class RSocketServer {
   friend class RSocketServerConnectionHandler;
 
  private:
-  void addSocket(std::shared_ptr<reactivesocket::RSocketStateMachine>);
-  void removeSocket(std::shared_ptr<reactivesocket::RSocketStateMachine>);
+  void addConnection(std::shared_ptr<reactivesocket::RSocketStateMachine>, folly::Executor&);
+  void removeConnection(std::shared_ptr<reactivesocket::RSocketStateMachine>);
 
   //////////////////////////////////////////////////////////////////////////////
 
   std::unique_ptr<ConnectionAcceptor> lazyAcceptor_;
   reactivesocket::ServerConnectionAcceptor acceptor_;
-  std::shared_ptr<reactivesocket::ConnectionHandler> connectionHandler_;
+  bool started{false};
 
   /// Set of currently open ReactiveSockets.
   folly::Synchronized<
-      std::unordered_set<std::shared_ptr<reactivesocket::RSocketStateMachine>>,
+      std::unordered_map<std::shared_ptr<reactivesocket::RSocketStateMachine>, folly::Executor&>,
       std::mutex>
       sockets_;
 

--- a/src/RSocketServer.h
+++ b/src/RSocketServer.h
@@ -10,7 +10,6 @@
 #include "src/ConnectionAcceptor.h"
 #include "src/ConnectionSetupRequest.h"
 #include "src/RSocketResponder.h"
-#include "src/temporary_home/ReactiveSocket.h"
 #include "src/temporary_home/ServerConnectionAcceptor.h"
 
 namespace rsocket {
@@ -72,8 +71,8 @@ class RSocketServer {
   friend class RSocketServerConnectionHandler;
 
  private:
-  void addSocket(std::unique_ptr<reactivesocket::ReactiveSocket>);
-  void removeSocket(reactivesocket::ReactiveSocket*);
+  void addSocket(std::shared_ptr<reactivesocket::RSocketStateMachine>);
+  void removeSocket(std::shared_ptr<reactivesocket::RSocketStateMachine>);
 
   //////////////////////////////////////////////////////////////////////////////
 
@@ -83,7 +82,7 @@ class RSocketServer {
 
   /// Set of currently open ReactiveSockets.
   folly::Synchronized<
-      std::unordered_set<std::unique_ptr<reactivesocket::ReactiveSocket>>,
+      std::unordered_set<std::shared_ptr<reactivesocket::RSocketStateMachine>>,
       std::mutex>
       sockets_;
 

--- a/src/internal/FollyKeepaliveTimer.h
+++ b/src/internal/FollyKeepaliveTimer.h
@@ -4,7 +4,6 @@
 
 #include <folly/io/async/EventBase.h>
 #include <src/statemachine/RSocketStateMachine.h>
-#include <src/temporary_home/ReactiveSocket.h>
 
 namespace reactivesocket {
 class FollyKeepaliveTimer : public KeepaliveTimer {

--- a/src/statemachine/RSocketStateMachine.h
+++ b/src/statemachine/RSocketStateMachine.h
@@ -9,6 +9,7 @@
 #include "src/DuplexConnection.h"
 #include "src/temporary_home/Executor.h"
 #include "src/framing/Frame.h"
+#include "src/framing/FrameTransport.h"
 #include "src/framing/FrameProcessor.h"
 #include "src/framing/FrameSerializer.h"
 #include "src/Payload.h"
@@ -22,7 +23,6 @@ class ClientResumeStatusCallback;
 class RSocketStateMachine;
 class DuplexConnection;
 class Frame_ERROR;
-class FrameTransport;
 class KeepaliveTimer;
 class RequestHandler;
 class ResumeCache;
@@ -55,13 +55,12 @@ class FrameSink {
 class RSocketStateMachine final
     : public FrameSink,
       public FrameProcessor,
-      public ExecutorBase,
+      ExecutorBase,
       public StreamsWriter,
       public std::enable_shared_from_this<RSocketStateMachine> {
  public:
   RSocketStateMachine(
       folly::Executor& executor,
-      ReactiveSocket* reactiveSocket,
       std::shared_ptr<RequestHandler> requestHandler,
       std::shared_ptr<Stats> stats,
       std::unique_ptr<KeepaliveTimer> keepaliveTimer_,
@@ -266,8 +265,6 @@ class RSocketStateMachine final
       override;
 
   bool ensureOrAutodetectFrameSerializer(const folly::IOBuf& firstFrame);
-
-  ReactiveSocket* reactiveSocket_;
 
   const std::shared_ptr<Stats> stats_;
   ReactiveSocketMode mode_;

--- a/src/temporary_home/NullRequestHandler.cpp
+++ b/src/temporary_home/NullRequestHandler.cpp
@@ -48,13 +48,11 @@ void NullRequestHandler::handleMetadataPush(
     std::unique_ptr<folly::IOBuf> /*request*/) noexcept {}
 
 std::shared_ptr<StreamState> NullRequestHandler::handleSetupPayload(
-    ReactiveSocket& socket,
     ConnectionSetupPayload /*request*/) noexcept {
   return nullptr;
 }
 
 bool NullRequestHandler::handleResume(
-    ReactiveSocket& socket,
     ResumeParameters) noexcept {
   return false;
 }

--- a/src/temporary_home/NullRequestHandler.h
+++ b/src/temporary_home/NullRequestHandler.h
@@ -58,10 +58,9 @@ class NullRequestHandler : public RequestHandler {
       std::unique_ptr<folly::IOBuf> request) noexcept override;
 
   std::shared_ptr<StreamState> handleSetupPayload(
-      ReactiveSocket& socket,
       ConnectionSetupPayload request) noexcept override;
 
-  bool handleResume(ReactiveSocket& socket, ResumeParameters) noexcept override;
+  bool handleResume(ResumeParameters) noexcept override;
 
   void handleCleanResume(
       yarpl::Reference<yarpl::flowable::Subscription> response) noexcept override;

--- a/src/temporary_home/RequestHandler.h
+++ b/src/temporary_home/RequestHandler.h
@@ -46,14 +46,11 @@ class RequestHandler {
 
   /// Temporary home - this should eventually be an input to asking for a
   /// RequestHandler so negotiation is possible
-  virtual std::shared_ptr<StreamState> handleSetupPayload(
-      ReactiveSocket& socket,
-      ConnectionSetupPayload request) noexcept = 0;
+  virtual std::shared_ptr<StreamState> handleSetupPayload(ConnectionSetupPayload request) noexcept = 0;
 
   /// Temporary home - this should accompany handleSetupPayload
   /// Return stream state for the given token. Return nullptr to disable resume
   virtual bool handleResume(
-      ReactiveSocket& socket,
       ResumeParameters resumeParams) noexcept = 0;
 
   // Handle a stream that can resume in a "clean" state. Client and Server are

--- a/tck-test/TestInterpreter.h
+++ b/tck-test/TestInterpreter.h
@@ -5,7 +5,7 @@
 #include <map>
 #include "src/Payload.h"
 #include "src/internal/ReactiveStreamsCompat.h"
-#include "src/temporary_home/ReactiveSocket.h"
+#include "test/deprecated/ReactiveSocket.h"
 
 #include "tck-test/TestSubscriber.h"
 #include "tck-test/TestSuite.h"

--- a/tck-test/client.cpp
+++ b/tck-test/client.cpp
@@ -5,9 +5,9 @@
 #include <folly/io/async/AsyncSocket.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <folly/portability/GFlags.h>
+#include "test/deprecated/ReactiveSocket.h"
 
 #include "src/temporary_home/NullRequestHandler.h"
-#include "src/temporary_home/ReactiveSocket.h"
 #include "src/framing/FramedDuplexConnection.h"
 #include "src/transports/tcp/TcpDuplexConnection.h"
 

--- a/tck-test/server.cpp
+++ b/tck-test/server.cpp
@@ -7,9 +7,9 @@
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <folly/portability/GFlags.h>
 #include <gmock/gmock.h>
+#include "test/deprecated/ReactiveSocket.h"
 
 #include "src/temporary_home/NullRequestHandler.h"
-#include "src/temporary_home/ReactiveSocket.h"
 #include "src/temporary_home/SubscriptionBase.h"
 #include "src/framing/FramedDuplexConnection.h"
 #include "src/transports/tcp/TcpDuplexConnection.h"
@@ -220,7 +220,6 @@ class Callback : public AsyncServerSocket::AcceptCallback {
     }
 
     std::shared_ptr<StreamState> handleSetupPayload(
-        ReactiveSocket&,
         ConnectionSetupPayload request) noexcept override {
       LOG(INFO) << "handleSetupPayload " << request;
       return nullptr;

--- a/test/deprecated/ReactiveSocket.cpp
+++ b/test/deprecated/ReactiveSocket.cpp
@@ -11,7 +11,7 @@
 #include "src/internal/ClientResumeStatusCallback.h"
 #include "src/statemachine/RSocketStateMachine.h"
 #include "src/framing/FrameTransport.h"
-#include "RequestHandler.h"
+#include "src/temporary_home/RequestHandler.h"
 
 namespace reactivesocket {
 
@@ -31,7 +31,6 @@ ReactiveSocket::ReactiveSocket(
     folly::Executor& executor)
     : connection_(std::make_shared<RSocketStateMachine>(
           executor,
-          this,
           std::move(handler),
           std::move(stats),
           std::move(keepaliveTimer),

--- a/test/deprecated/ReactiveSocket.h
+++ b/test/deprecated/ReactiveSocket.h
@@ -6,7 +6,7 @@
 #include "src/internal/Common.h"
 #include "src/temporary_home/ConnectionSetupPayload.h"
 #include "src/Payload.h"
-#include "Stats.h"
+#include "src/temporary_home/Stats.h"
 #include "yarpl/flowable/Subscriber.h"
 #include "yarpl/flowable/Subscription.h"
 
@@ -24,15 +24,7 @@ class RequestHandler;
 
 folly::Executor& defaultExecutor();
 
-// TODO(stupaq): Here is some heavy problem with the recursion on shutdown.
-// Giving someone ownership over this object would probably lead to a deadlock
-// (or a crash) if one calls ::~ReactiveSocket from a terminal signal handler
-// of any of the connections. It seems natural to follow ReactiveStreams
-// specification and make this object "self owned", so that we don't need to
-// perform all of the cleanup from a d'tor. We could give out a "proxy" object
-// that (internally) holds a weak reference (conceptually, not std::weak_ptr)
-// and forbids any interactions with the socket after the shutdown procedure has
-// been initiated.
+    // TODO eliminate this class and use RSocketStateMachine directly
 class ReactiveSocket {
  public:
   ReactiveSocket(ReactiveSocket&&) = delete;

--- a/test/deprecated/ReactiveSocketConcurrencyTest.cpp
+++ b/test/deprecated/ReactiveSocketConcurrencyTest.cpp
@@ -12,7 +12,7 @@
 #include <gmock/gmock.h>
 
 #include "test/test_utils/MockStats.h"
-#include "src/temporary_home/ReactiveSocket.h"
+#include "test/deprecated/ReactiveSocket.h"
 #include "src/framing/FramedDuplexConnection.h"
 #include "src/framing/FrameSerializer_v0_1.h"
 #include "test/test_utils/InlineConnection.h"
@@ -51,7 +51,7 @@ class ClientSideConcurrencyTest : public testing::Test {
     EXPECT_CALL(*serverHandler, socketOnClosed(_)).Times(1);
     auto& serverHandlerRef = *serverHandler;
 
-    EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+    EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
         .WillRepeatedly(Return(nullptr));
 
     serverSock = ReactiveSocket::fromServerConnection(
@@ -257,7 +257,7 @@ class ServerSideConcurrencyTest : public testing::Test {
     auto serverHandler = std::make_unique<StrictMock<MockRequestHandler>>();
     auto& serverHandlerRef = *serverHandler;
 
-    EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+    EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
         .WillRepeatedly(Return(nullptr));
 
     thread2.getEventBase()->runImmediatelyOrRunInEventBaseThreadAndWait([&] {
@@ -491,7 +491,7 @@ class InitialRequestNDeliveredTest : public testing::Test {
     EXPECT_CALL(*serverHandler, socketOnClosed(_)).Times(1);
     auto& serverHandlerRef = *serverHandler;
 
-    EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+    EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
         .WillRepeatedly(Return(nullptr));
 
     EXPECT_CALL(serverHandlerRef, handleRequestStream_(_, _, _))

--- a/test/deprecated/ReactiveSocketTest.cpp
+++ b/test/deprecated/ReactiveSocketTest.cpp
@@ -1123,7 +1123,14 @@ TEST(ReactiveSocketTest, CloseWithError) {
 
   EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
       .WillRepeatedly(Invoke([&](auto&) {
-        return nullptr;
+          // TODO this has become somewhat odd ...
+          // it used to receive ReactiveSocket in the callback
+          // but no longer does as part of the refactor away from
+          // using ReactiveSocket.h
+          // so to make this test pass for now it uses the clientSock
+          // reference it creates outside of this callback
+          clientSock->closeConnectionError(errString.str());
+          return nullptr;
       }));
 
   auto serverSock = ReactiveSocket::disconnectedServer(

--- a/test/deprecated/ReactiveSocketTest.cpp
+++ b/test/deprecated/ReactiveSocketTest.cpp
@@ -12,7 +12,7 @@
 #include <thread>
 #include "src/framing/FrameTransport.h"
 #include "src/temporary_home/NullRequestHandler.h"
-#include "src/temporary_home/ReactiveSocket.h"
+#include "test/deprecated/ReactiveSocket.h"
 #include "src/internal/FollyKeepaliveTimer.h"
 #include "test/test_utils/InlineConnection.h"
 #include "test/test_utils/MockKeepaliveTimer.h"
@@ -73,7 +73,7 @@ TEST(ReactiveSocketTest, RequestChannel) {
   EXPECT_CALL(*serverHandler, socketOnClosed(_)).Times(1);
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
       .InSequence(s)
       .WillRepeatedly(Return(nullptr));
 
@@ -198,7 +198,7 @@ TEST(ReactiveSocketTest, RequestStreamComplete) {
   EXPECT_CALL(*serverHandler, socketOnClosed(_)).Times(1);
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
       .InSequence(s)
       .WillRepeatedly(Return(nullptr));
 
@@ -293,7 +293,7 @@ TEST(ReactiveSocketTest, RequestStreamCancel) {
   EXPECT_CALL(*serverHandler, socketOnClosed(_)).Times(1);
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
       .InSequence(s)
       .WillRepeatedly(Return(nullptr));
 
@@ -385,7 +385,7 @@ auto clientSock = ReactiveSocket::fromClientConnection(
   EXPECT_CALL(*serverHandler, socketOnClosed(_)).Times(1);
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
       .InSequence(s)
       .WillRepeatedly(Return(nullptr));
 
@@ -541,7 +541,7 @@ TEST(ReactiveSocketTest, RequestStreamSurplusResponse) {
   EXPECT_CALL(*serverHandler, socketOnClosed(_)).Times(1);
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
       .InSequence(s)
       .WillRepeatedly(Return(nullptr));
 
@@ -620,7 +620,7 @@ TEST(ReactiveSocketTest, RequestResponse) {
   EXPECT_CALL(*serverHandler, socketOnClosed(_)).Times(1);
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
       .InSequence(s)
       .WillRepeatedly(Return(nullptr));
 
@@ -764,7 +764,7 @@ TEST(ReactiveSocketTest, RequestFireAndForget) {
   EXPECT_CALL(*serverHandler, socketOnClosed(_)).Times(1);
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
       .InSequence(s)
       .WillRepeatedly(Return(nullptr));
 
@@ -809,7 +809,7 @@ TEST(ReactiveSocketTest, RequestMetadataPush) {
   EXPECT_CALL(*serverHandler, socketOnClosed(_)).Times(1);
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
       .InSequence(s)
       .WillRepeatedly(Return(nullptr));
 
@@ -853,7 +853,7 @@ TEST(ReactiveSocketTest, SetupData) {
   EXPECT_CALL(*serverHandler, socketOnClosed(_)).Times(1);
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
       .InSequence(s)
       .WillRepeatedly(Return(nullptr));
 
@@ -885,7 +885,7 @@ TEST(ReactiveSocketTest, SetupWithKeepaliveAndStats) {
   EXPECT_CALL(*serverHandler, socketOnClosed(_)).Times(1);
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
       .InSequence(s)
       .WillRepeatedly(Return(nullptr));
 
@@ -1002,7 +1002,7 @@ TEST(ReactiveSocketTest, DISABLED_Destructor) {
   EXPECT_CALL(*serverHandler, socketOnClosed(_)).Times(1);
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
       .InSequence(s)
       .WillRepeatedly(Return(nullptr));
 
@@ -1090,7 +1090,7 @@ TEST(ReactiveSocketTest, ReactiveSocketOverInlineConnection) {
   EXPECT_CALL(*serverHandler, socketOnClosed(_)).Times(1);
   auto& serverHandlerRef = *serverHandler;
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
       .WillRepeatedly(Return(nullptr));
 
   auto serverSock = ReactiveSocket::fromServerConnection(
@@ -1121,9 +1121,8 @@ TEST(ReactiveSocketTest, CloseWithError) {
 
   const folly::StringPiece errString{"Hahaha"};
 
-  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
-      .WillRepeatedly(Invoke([&](auto& socket, auto&) {
-        socket.closeConnectionError(errString.str());
+  EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
+      .WillRepeatedly(Invoke([&](auto&) {
         return nullptr;
       }));
 
@@ -1244,7 +1243,7 @@ class ReactiveSocketOnErrorOnShutdownTest : public testing::Test {
     EXPECT_CALL(*serverHandler, socketOnClosed(_)).Times(1);
     auto& serverHandlerRef = *serverHandler;
 
-    EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+    EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
         .WillRepeatedly(Return(nullptr));
 
     serverSock = ReactiveSocket::fromServerConnection(
@@ -1380,7 +1379,7 @@ class ReactiveSocketRegressionTest : public Test {
     EXPECT_CALL(connection, getOutput())
         .WillOnce(Return(std::make_shared<MockSubscriber<IOBufPtr>>()));
 
-    EXPECT_CALL(requestHandler_, handleSetupPayload_(_, _))
+    EXPECT_CALL(requestHandler_, handleSetupPayload_(_))
         .WillRepeatedly(Return(nullptr));
 
     EXPECT_CALL(requestHandler_, socketOnConnected()).Times(1);
@@ -1439,7 +1438,7 @@ class ReactiveSocketEmptyPayloadTest : public testing::Test {
     EXPECT_CALL(*serverHandler, socketOnClosed(_)).Times(1);
     auto& serverHandlerRef = *serverHandler;
 
-    EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_, _))
+    EXPECT_CALL(serverHandlerRef, handleSetupPayload_(_))
         .WillRepeatedly(Return(nullptr));
 
     serverSock = ReactiveSocket::fromServerConnection(

--- a/test/framing/FramedReaderTest.cpp
+++ b/test/framing/FramedReaderTest.cpp
@@ -7,7 +7,7 @@
 #include <folly/io/Cursor.h>
 #include <gmock/gmock.h>
 #include "src/framing/FrameSerializer.h"
-#include "src/temporary_home/ReactiveSocket.h"
+#include "test/deprecated/ReactiveSocket.h"
 #include "src/framing/FramedDuplexConnection.h"
 #include "src/framing/FramedReader.h"
 #include "test/test_utils/InlineConnection.h"

--- a/test/integration/ClientUtils.h
+++ b/test/integration/ClientUtils.h
@@ -7,7 +7,7 @@
 #include "src/internal/ClientResumeStatusCallback.h"
 #include "src/framing/FrameTransport.h"
 #include "src/temporary_home/NullRequestHandler.h"
-#include "src/temporary_home/ReactiveSocket.h"
+#include "test/deprecated/ReactiveSocket.h"
 #include "src/internal/FollyKeepaliveTimer.h"
 #include "src/framing/FramedDuplexConnection.h"
 #include "src/transports/tcp/TcpDuplexConnection.h"

--- a/test/integration/ServerFixture.cpp
+++ b/test/integration/ServerFixture.cpp
@@ -67,14 +67,12 @@ class ServerRequestHandler : public DefaultRequestHandler {
   }
 
   std::shared_ptr<StreamState> handleSetupPayload(
-      ReactiveSocket& socket,
       ConnectionSetupPayload request) noexcept override {
     LOG(INFO) << "Received SetupPayload. NOT IMPLEMENTED";
     return nullptr;
   }
 
   bool handleResume(
-      ReactiveSocket& socket,
       ResumeParameters) noexcept override {
     LOG(INFO) << "Received Resume. NOT IMPLEMENTED";
     return false;

--- a/test/integration/ServerFixture.h
+++ b/test/integration/ServerFixture.h
@@ -5,7 +5,7 @@
 #include <folly/io/async/AsyncServerSocket.h>
 
 #include "src/temporary_home/NullRequestHandler.h"
-#include "src/temporary_home/ReactiveSocket.h"
+#include "test/deprecated/ReactiveSocket.h"
 #include "src/temporary_home/ServerConnectionAcceptor.h"
 #include "src/temporary_home/SubscriptionBase.h"
 #include "src/framing/FramedDuplexConnection.h"

--- a/test/resumption/ReactiveSocketResumabilityTest.cpp
+++ b/test/resumption/ReactiveSocketResumabilityTest.cpp
@@ -5,7 +5,7 @@
 
 #include "src/temporary_home/NullRequestHandler.h"
 #include "test/test_utils/MockRequestHandler.h"
-#include "src/temporary_home/ReactiveSocket.h"
+#include "test/deprecated/ReactiveSocket.h"
 #include "test/test_utils/InlineConnection.h"
 #include "test/test_utils/MockStats.h"
 #include "test/streams/Mocks.h"

--- a/test/resumption/TcpResumeClient.cpp
+++ b/test/resumption/TcpResumeClient.cpp
@@ -9,7 +9,7 @@
 #include "src/internal/ClientResumeStatusCallback.h"
 #include "src/framing/FrameTransport.h"
 #include "src/temporary_home/NullRequestHandler.h"
-#include "src/temporary_home/ReactiveSocket.h"
+#include "test/deprecated/ReactiveSocket.h"
 #include "src/internal/FollyKeepaliveTimer.h"
 #include "src/framing/FramedDuplexConnection.h"
 #include "src/transports/tcp/TcpDuplexConnection.h"

--- a/test/resumption/TcpResumeServer.cpp
+++ b/test/resumption/TcpResumeServer.cpp
@@ -8,7 +8,7 @@
 #include "src/framing/FrameTransport.h"
 #include "src/temporary_home/NullRequestHandler.h"
 #include "src/temporary_home/ServerConnectionAcceptor.h"
-#include "src/temporary_home/ReactiveSocket.h"
+#include "test/deprecated/ReactiveSocket.h"
 #include "src/temporary_home/SubscriptionBase.h"
 #include "src/framing/FramedDuplexConnection.h"
 #include "src/transports/tcp/TcpDuplexConnection.h"
@@ -86,14 +86,12 @@ class ServerRequestHandler : public DefaultRequestHandler {
   }
 
   std::shared_ptr<StreamState> handleSetupPayload(
-      ReactiveSocket& socket,
       ConnectionSetupPayload request) noexcept override {
     CHECK(false) << "unexpected call";
     return nullptr;
   }
 
   bool handleResume(
-      ReactiveSocket& socket,
       ResumeParameters) noexcept override {
     CHECK(false) << "unexpected call";
     return false;

--- a/test/statemachine/PublisherBaseTest.cpp
+++ b/test/statemachine/PublisherBaseTest.cpp
@@ -1,6 +1,6 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-#include "src/temporary_home/ReactiveSocket.h"
+#include "test/deprecated/ReactiveSocket.h"
 #include "src/temporary_home/SubscriberBase.h"
 #include "src/statemachine/PublisherBase.h"
 #include "test/test_utils/MockRequestHandler.h"

--- a/test/statemachine/RSocketStateMachineTest.cpp
+++ b/test/statemachine/RSocketStateMachineTest.cpp
@@ -73,7 +73,6 @@ TEST(ConnectionAutomatonTest, InvalidFrameHeader) {
   std::shared_ptr<RSocketStateMachine> connectionAutomaton;
   connectionAutomaton = std::make_shared<RSocketStateMachine>(
       defaultExecutor(),
-      nullptr,
       std::make_shared<NullRequestHandler>(),
       Stats::noop(),
       nullptr,
@@ -149,7 +148,6 @@ static void terminateTest(
   std::shared_ptr<RSocketStateMachine> connectionAutomaton;
   connectionAutomaton = std::make_shared<RSocketStateMachine>(
       defaultExecutor(),
-      nullptr,
       std::make_shared<NullRequestHandler>(),
       Stats::noop(),
       nullptr,
@@ -249,7 +247,6 @@ TEST(ConnectionAutomatonTest, RefuseFrame) {
   std::shared_ptr<RSocketStateMachine> connectionAutomaton;
   connectionAutomaton = std::make_shared<RSocketStateMachine>(
       defaultExecutor(),
-      nullptr,
       std::make_shared<NullRequestHandler>(),
       Stats::noop(),
       nullptr,

--- a/test/test_utils/MockKeepaliveTimer.h
+++ b/test/test_utils/MockKeepaliveTimer.h
@@ -8,7 +8,7 @@
 #include <gmock/gmock.h>
 
 #include "src/statemachine/RSocketStateMachine.h"
-#include "src/temporary_home/ReactiveSocket.h"
+#include "test/deprecated/ReactiveSocket.h"
 
 namespace reactivesocket {
 class MockKeepaliveTimer : public KeepaliveTimer {

--- a/test/test_utils/MockRequestHandler.h
+++ b/test/test_utils/MockRequestHandler.h
@@ -37,14 +37,13 @@ class MockRequestHandler : public RequestHandler {
   MOCK_METHOD1(
       handleMetadataPush_,
       void(std::unique_ptr<folly::IOBuf>& request));
-  MOCK_METHOD2(
+  MOCK_METHOD1(
       handleSetupPayload_,
       std::shared_ptr<StreamState>(
-          ReactiveSocket& socket,
           ConnectionSetupPayload& request));
-  MOCK_METHOD2(
+  MOCK_METHOD1(
       handleResume_,
-      bool(ReactiveSocket& socket, ResumeParameters& resumeParams));
+      bool(ResumeParameters& resumeParams));
 
   yarpl::Reference<yarpl::flowable::Subscriber<Payload>> handleRequestChannel(
       Payload request,
@@ -79,15 +78,13 @@ class MockRequestHandler : public RequestHandler {
   }
 
   std::shared_ptr<StreamState> handleSetupPayload(
-      ReactiveSocket& socket,
       ConnectionSetupPayload request) noexcept override {
-    return handleSetupPayload_(socket, request);
+    return handleSetupPayload_(request);
   }
 
   bool handleResume(
-      ReactiveSocket& socket,
       ResumeParameters resumeParams) noexcept override {
-    return handleResume_(socket, resumeParams);
+    return handleResume_(resumeParams);
   }
 
   void handleCleanResume(


### PR DESCRIPTION
This pull request eliminates ReactiveSocket.h from the /src/ folder. It is still used by unit and tck tests for now (by moving into /tests/) as I wanted to decouple those changes from this one.

RSocketServer and RSocketClient now interact directly with the RSocketStateMachine.