### PR TITLE
Fix TakeOperator::onNext() deleting itself too early

### DIFF
--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -219,8 +219,8 @@ class TakeOperator : public FlowableOperator<T, T> {
         FlowableOperator<T, T>::Subscription::subscriber_->onNext(
             std::move(value));
         if (limit_ == 0) {
+          FlowableOperator<T, T>::Subscription::subscriber_->onComplete();
           FlowableOperator<T, T>::Subscription::cancel();
-          FlowableOperator<T, T>::Subscription::onComplete();
         }
       }
     }


### PR DESCRIPTION
It would call FlowableOperator::Subscription::onComplete() and then
FlowableOperator::Subscription::cancel().  This doesn't work as ::onComplete()
will call release(), and we are no longer safe running any more methods on the
object.

Instead run onComplete() manually on the subscriber, and then cancel the
subscription.