### PR TITLE
Disable ASAN for yarpl-tests on macOS

### DIFF
--- a/yarpl/CMakeLists.txt
+++ b/yarpl/CMakeLists.txt
@@ -19,6 +19,12 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-weak-vtables -Wno-padded")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -momit-leaf-frame-pointer")
 
+# The yarpl-tests binary constantly fails with an ASAN error in gtest internal
+# code on macOS.
+if(APPLE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-sanitize=address")
+endif()
+
 # Configuration for Debug build mode.
 #set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")


### PR DESCRIPTION
It has never worked for the yarpl tests, so I'm confused as to why it was
enabled.  Here's what I get 100% of the time when running yarpl/yarpl-tests:

=================================================================
==69355==ERROR: AddressSanitizer: SEGV on unknown address 0x61100007f740 (pc 0x000100b2c207 bp 0x7fff5f4fe260 sp 0x7fff5f4fe230 T0)
    #0 0x100b2c206 in testing::TestCase::GetMutableTestInfo(int) (yarpl-tests:x86_64+0x10042b206)
    #1 0x100b2c57e in testing::TestCase::Run() (yarpl-tests:x86_64+0x10042b57e)
    #2 0x100b3ab5b in testing::internal::UnitTestImpl::RunAllTests() (yarpl-tests:x86_64+0x100439b5b)
    #3 0x100b6a5f9 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (yarpl-tests:x86_64+0x1004695f9)
    #4 0x100b3a566 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (yarpl-tests:x86_64+0x100439566)
    #5 0x100b3a417 in testing::UnitTest::Run() (yarpl-tests:x86_64+0x100439417)
    #6 0x10070344e in RUN_ALL_TESTS() (yarpl-tests:x86_64+0x10000244e)
    #7 0x10070321f in main (yarpl-tests:x86_64+0x10000221f)
    #8 0x7fffc67b8234 in start (libdyld.dylib:x86_64+0x5234)

==69355==Register values:
rax = 0x00006110000098c0  rbx = 0x00007fff5f4fe840  rcx = 0x000000000000ebd0  rdx = 0x000000000000ebd0
rdi = 0x000061200000b000  rsi = 0x0000000000000012  rbp = 0x00007fff5f4fe260  rsp = 0x00007fff5f4fe230
 r8 = 0x0000000000000000   r9 = 0x000000010298b760  r10 = 0x0000000000000000  r11 = 0x0000000000012068
r12 = 0x0000000000000000  r13 = 0x0000000000000000  r14 = 0x0000000000000000  r15 = 0x0000000000000000
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV (yarpl-tests:x86_64+0x10042b206) in testing::TestCase::GetMutableTestInfo(int)
==69355==ABORTING
[1]    69355 abort      ./yarpl/yarpl-tests`