### PR TITLE
Hopefully fix RSocketStateMachine leak

### DIFF
--- a/src/RSocketRequester.cpp
+++ b/src/RSocketRequester.cpp
@@ -35,6 +35,7 @@ RSocketRequester::RSocketRequester(
 
 RSocketRequester::~RSocketRequester() {
   LOG(INFO) << "RSocketRequester => destroy";
+  stateMachine_->close(folly::exception_wrapper(), StreamCompletionSignal::CONNECTION_END);
 }
 
 yarpl::Reference<yarpl::flowable::Flowable<rsocket::Payload>>


### PR DESCRIPTION
Seems like we need to close it in ~RSocketRequester.  LSAN warnings stop for me
locally, but I'm not 100% sure of the logic here.