### PR TITLE
Make yarpl depend on pthreads

### DIFF
--- a/yarpl/CMakeLists.txt
+++ b/yarpl/CMakeLists.txt
@@ -86,7 +86,13 @@ target_include_directories(
         yarpl
         PUBLIC "${PROJECT_SOURCE_DIR}/include" # allow include paths such as "yarpl/observable.h"
         PUBLIC "${PROJECT_SOURCE_DIR}/src" # allow include paths such as "yarpl/flowable/FlowableRange.h"
+        )
+
+target_link_libraries(
+        yarpl
+        ${CMAKE_THREAD_LIBS_INIT}
 )
+
 
 # Executable for Experimenting
 add_executable(


### PR DESCRIPTION
Needed this change to build yarpl on Arch Linux, otherwise the thread scheduler
code fails to link.