### PR TITLE
RequestStream Tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,7 @@ add_executable(
   test/internal/AllowanceSemaphoreTest.cpp
   test/RSocketTests.h
   test/RequestResponseTest.cpp
+  test/RequestStreamTest.cpp
 )
 
 target_link_libraries(

--- a/test/RequestStreamTest.cpp
+++ b/test/RequestStreamTest.cpp
@@ -1,0 +1,93 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <thread>
+
+#include "RSocketTests.h"
+#include "yarpl/Flowable.h"
+#include "yarpl/flowable/TestSubscriber.h"
+
+using namespace yarpl;
+using namespace yarpl::flowable;
+using namespace rsocket;
+using namespace rsocket::tests;
+using namespace rsocket::tests::client_server;
+
+namespace {
+class TestHandlerSync : public rsocket::RSocketResponder {
+ public:
+  Reference<Flowable<Payload>> handleRequestStream(
+      Payload request,
+      StreamId streamId) override {
+    // string from payload data
+    auto requestString = request.moveDataToString();
+
+    return Flowables::range(1, 10)->map([name = std::move(requestString)](
+        int64_t v) {
+      std::stringstream ss;
+      ss << "Hello " << name << " " << v << "!";
+      std::string s = ss.str();
+      return Payload(s, "metadata");
+    });
+  }
+};
+
+TEST(RequestStreamTest, HelloSync) {
+  auto port = randPort();
+  auto server = makeServer(port, std::make_shared<TestHandlerSync>());
+  auto client = makeClient(port);
+  auto requester = client->connect().get();
+  auto ts = TestSubscriber<std::string>::create();
+  requester->requestStream(Payload("Bob"))
+      ->map([](auto p) { return p.moveDataToString(); })
+      ->subscribe(ts);
+  ts->awaitTerminalEvent();
+  ts->assertSuccess();
+  ts->assertValueCount(10);
+  ts->assertValueAt(0, "Hello Bob 1!");
+  ts->assertValueAt(9, "Hello Bob 10!");
+}
+
+class TestHandlerAsync : public rsocket::RSocketResponder {
+ public:
+  Reference<Flowable<Payload>> handleRequestStream(
+      Payload request,
+      StreamId streamId) override {
+    // string from payload data
+    auto requestString = request.moveDataToString();
+
+    return Flowables::fromPublisher<
+        Payload>([requestString = std::move(requestString)](
+        Reference<flowable::Subscriber<Payload>> subscriber) {
+      std::thread([
+        requestString = std::move(requestString),
+        subscriber = std::move(subscriber)
+      ]() {
+        Flowables::range(1, 40)
+            ->map([name = std::move(requestString)](int64_t v) {
+              std::stringstream ss;
+              ss << "Hello " << name << " " << v << "!";
+              std::string s = ss.str();
+              return Payload(s, "metadata");
+            })
+            ->subscribe(subscriber);
+      }).detach();
+    });
+  }
+};
+}
+
+TEST(RequestStreamTest, HelloAsync) {
+  auto port = randPort();
+  auto server = makeServer(port, std::make_shared<TestHandlerAsync>());
+  auto client = makeClient(port);
+  auto requester = client->connect().get();
+  auto ts = TestSubscriber<std::string>::create();
+  requester->requestStream(Payload("Bob"))
+      ->map([](auto p) { return p.moveDataToString(); })
+      ->subscribe(ts);
+  ts->awaitTerminalEvent();
+  ts->assertSuccess();
+  ts->assertValueCount(40);
+  ts->assertValueAt(0, "Hello Bob 1!");
+  ts->assertValueAt(39, "Hello Bob 40!");
+}

--- a/yarpl/CMakeLists.txt
+++ b/yarpl/CMakeLists.txt
@@ -80,7 +80,7 @@ add_library(
         # Scheduler
         include/yarpl/schedulers/ThreadScheduler.h
         src/yarpl/schedulers/ThreadScheduler.cpp
-)
+        include/yarpl/flowable/TestSubscriber.h)
 
 target_include_directories(
         yarpl

--- a/yarpl/include/yarpl/flowable/Flowables.h
+++ b/yarpl/include/yarpl/flowable/Flowables.h
@@ -11,11 +11,19 @@ namespace flowable {
 
 class Flowables {
  public:
-  static Reference<Flowable<int64_t>> range(int64_t start, int64_t end) {
-    auto lambda = [ start, end, i = start ](
+  /**
+   * Emit a sequence of numbers.
+   *
+   * @param start starting value
+   * @param count how many to emit
+   * @return
+   */
+  static Reference<Flowable<int64_t>> range(int64_t start, int64_t count) {
+    auto lambda = [ start, count, i = start ](
         Subscriber<int64_t> & subscriber, int64_t requested) mutable {
       int64_t emitted = 0;
       bool done = false;
+      int64_t end = start + count;
 
       while (i < end && emitted < requested) {
         subscriber.onNext(i++);

--- a/yarpl/include/yarpl/flowable/TestSubscriber.h
+++ b/yarpl/include/yarpl/flowable/TestSubscriber.h
@@ -1,0 +1,188 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+#include <sstream>
+#include <vector>
+#include "Flowable.h"
+#include "Subscriber.h"
+
+namespace yarpl {
+namespace flowable {
+
+/**
+ * A utility class for unit testing or experimenting with Flowable.
+ *
+ * Example usage:
+ *
+ * auto flowable = ...
+ * auto ts = TestSubscriber<int>::create();
+ * flowable->subscribe(to);
+ * ts->awaitTerminalEvent();
+ * ts->assert...
+ *
+ * @tparam T
+ */
+template <typename T>
+class TestSubscriber : public Subscriber<T> {
+ public:
+  /**
+   * Create a TestSubscriber that will subscribe and store the value it
+   * receives.
+   *
+   * @return
+   */
+  static Reference<TestSubscriber<T>> create() {
+    return make_ref<TestSubscriber<T>>();
+  }
+
+  /**
+   * Create a TestSubscriber that will delegate all on* method calls
+   * to the provided Subscriber.
+   *
+   * This will store the value it receives to allow assertions.
+   * @return
+   */
+  static Reference<TestSubscriber<T>> create(
+      Reference<Subscriber<T>> delegate) {
+    return make_ref<TestSubscriber<T>>(std::move(delegate));
+  }
+
+  TestSubscriber() : delegate_(nullptr) {}
+
+  explicit TestSubscriber(Reference<Subscriber<T>> delegate)
+      : delegate_(std::move(delegate)) {}
+
+  void onSubscribe(Reference<Subscription> subscription) override {
+    if (delegate_) {
+      subscription_ = subscription; // copy
+      delegate_->onSubscribe(std::move(subscription));
+    } else {
+      subscription_ = std::move(subscription);
+    }
+    subscription_->request(Flowable<T>::NO_FLOW_CONTROL);
+  }
+
+  void onNext(T t) override {
+    if (delegate_) {
+      values_.push_back(t);
+      delegate_->onNext(std::move(t));
+    } else {
+      values_.push_back(std::move(t));
+    }
+  }
+
+  void onComplete() override {
+    if (delegate_) {
+      delegate_->onComplete();
+    }
+    terminated_ = true;
+    terminalEventCV_.notify_all();
+  }
+
+  void onError(const std::exception_ptr ex) override {
+    if (delegate_) {
+      delegate_->onError(ex);
+    }
+    e_ = ex;
+    terminated_ = true;
+    terminalEventCV_.notify_all();
+  }
+
+  /**
+   * Block the current thread until either onSuccess or onError is called.
+   */
+  void awaitTerminalEvent() {
+    // now block this thread
+    std::unique_lock<std::mutex> lk(m_);
+    // if shutdown gets implemented this would then be released by it
+    terminalEventCV_.wait(lk, [this] { return terminated_; });
+  }
+
+  void assertValueCount(size_t count) {
+    if (values_.size() != count) {
+      std::stringstream ss;
+      ss << "Value count " << values_.size() << " does not match " << count;
+      throw std::runtime_error(ss.str());
+    }
+  }
+
+  int64_t getValueCount() {
+    return values_.size();
+  }
+
+  T& getValueAt(size_t index) {
+    return values_[index];
+  }
+
+  void assertValueAt(int64_t index, T expected) {
+    if (index < getValueCount()) {
+      T& v = getValueAt(index);
+      if (expected != v) {
+        std::stringstream ss;
+        ss << "Expected: " << expected << " Actual: " << v;
+        throw std::runtime_error(ss.str());
+      }
+    } else {
+      std::stringstream ss;
+      ss << "Index " << index << " is larger than received values "
+         << values_.size();
+      throw std::runtime_error(ss.str());
+    }
+  }
+
+  /**
+   * If an onComplete call was not received throw a runtime_error
+   */
+  void assertSuccess() {
+    if (!terminated_) {
+      throw std::runtime_error("Did not receive terminal event.");
+    }
+    if (e_) {
+      throw std::runtime_error("Received onError instead of onSuccess");
+    }
+  }
+
+  /**
+   * If the onError exception_ptr points to an error containing
+   * the given msg, complete successfully, otherwise throw a runtime_error
+   */
+  void assertOnErrorMessage(std::string msg) {
+    if (e_ == nullptr) {
+      std::stringstream ss;
+      ss << "exception_ptr == nullptr, but expected " << msg;
+      throw std::runtime_error(ss.str());
+    }
+    try {
+      std::rethrow_exception(e_);
+    } catch (std::runtime_error& re) {
+      if (re.what() != msg) {
+        std::stringstream ss;
+        ss << "Error message is: " << re.what() << " but expected: " << msg;
+        throw std::runtime_error(ss.str());
+      }
+    } catch (...) {
+      throw std::runtime_error("Expects an std::runtime_error");
+    }
+  }
+
+  /**
+   * Submit Subscription->cancel();
+   */
+  void cancel() {
+    subscription_->cancel();
+  }
+
+ private:
+  Reference<Subscriber<T>> delegate_;
+  std::vector<T> values_;
+  std::exception_ptr e_;
+  bool terminated_{false};
+  std::mutex m_;
+  std::condition_variable terminalEventCV_;
+  Reference<Subscription> subscription_;
+};
+}
+}

--- a/yarpl/test/FlowableTest.cpp
+++ b/yarpl/test/FlowableTest.cpp
@@ -139,14 +139,14 @@ TEST(FlowableTest, JustIncomplete) {
 TEST(FlowableTest, Range) {
   ASSERT_EQ(std::size_t{0}, Refcounted::objects());
   EXPECT_EQ(
-      run(Flowables::range(10, 15)),
+      run(Flowables::range(10, 5)),
       std::vector<int64_t>({10, 11, 12, 13, 14}));
   EXPECT_EQ(std::size_t{0}, Refcounted::objects());
 }
 
 TEST(FlowableTest, RangeWithMap) {
   ASSERT_EQ(std::size_t{0}, Refcounted::objects());
-  auto flowable = Flowables::range(1, 4)
+  auto flowable = Flowables::range(1, 3)
                       ->map([](int64_t v) { return v * v; })
                       ->map([](int64_t v) { return v * v; })
                       ->map([](int64_t v) { return std::to_string(v); });


### PR DESCRIPTION
Based aynchronous and asynchronous requestStream tests.

- and fixed Flowables::range to match other ReactiveX implementations. it is {start, count} not {start, end}