### PR TITLE
[yarpl] Add skip operator for Flowable/Observable

### DIFF
--- a/yarpl/include/yarpl/flowable/Flowable.h
+++ b/yarpl/include/yarpl/flowable/Flowable.h
@@ -95,6 +95,8 @@ class Flowable : public virtual Refcounted {
 
   auto take(int64_t);
 
+  auto skip(int64_t);
+
   auto subscribeOn(Scheduler&);
 
   /**
@@ -371,6 +373,12 @@ template <typename T>
 auto Flowable<T>::take(int64_t limit) {
   return Reference<Flowable<T>>(
       new TakeOperator<T>(Reference<Flowable<T>>(this), limit));
+}
+
+template <typename T>
+auto Flowable<T>::skip(int64_t offset) {
+  return Reference<Flowable<T>>(
+    new SkipOperator<T>(Reference<Flowable<T>>(this), offset));
 }
 
 template <typename T>

--- a/yarpl/include/yarpl/observable/Observable.h
+++ b/yarpl/include/yarpl/observable/Observable.h
@@ -98,6 +98,8 @@ class Observable : public virtual Refcounted {
 
   auto take(int64_t);
 
+  auto skip(int64_t);
+
   auto subscribeOn(Scheduler&);
 
   /**
@@ -156,6 +158,12 @@ template <typename T>
 auto Observable<T>::take(int64_t limit) {
   return Reference<Observable<T>>(
       new TakeOperator<T>(Reference<Observable<T>>(this), limit));
+}
+
+template <typename T>
+auto Observable<T>::skip(int64_t offset) {
+  return Reference<Observable<T>>(
+      new SkipOperator<T>(Reference<Observable<T>>(this), offset));
 }
 
 template <typename T>

--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -286,6 +286,47 @@ class TakeOperator : public ObservableOperator<T, T> {
 };
 
 template <typename T>
+class SkipOperator : public ObservableOperator<T, T> {
+ public:
+  SkipOperator(Reference<Observable<T>> upstream, int64_t offset)
+      : ObservableOperator<T, T>(std::move(upstream)), offset_(offset) {}
+
+  void subscribe(Reference<Observer<T>> observer) override {
+    ObservableOperator<T, T>::upstream_->subscribe(
+        Reference<Subscription>(new Subscription(
+            Reference<Observable<T>>(this), offset_, std::move(observer))));
+  }
+
+ private:
+  class Subscription : public ObservableOperator<T, T>::Subscription {
+    using Super = typename ObservableOperator<T,T>::Subscription;
+   public:
+    Subscription(
+       Reference<Observable<T>> observable,
+       int64_t offset,
+       Reference<Observer<T>> observer)
+       : ObservableOperator<T, T>::Subscription(
+             std::move(observable),
+             std::move(observer)),
+       offset_(offset) {}
+
+    void onNext(T value) override {
+      if (offset_ <= 0) {
+        Super::observerOnNext(
+            std::move(value));
+      } else {
+        --offset_;
+      }
+    }
+
+   private:
+    int64_t offset_;
+  };
+
+  const int64_t offset_;
+};
+
+template <typename T>
 class SubscribeOnOperator : public ObservableOperator<T, T> {
  public:
   SubscribeOnOperator(Reference<Observable<T>> upstream, Scheduler& scheduler)

--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -293,8 +293,8 @@ class SkipOperator : public ObservableOperator<T, T> {
 
   void subscribe(Reference<Observer<T>> observer) override {
     ObservableOperator<T, T>::upstream_->subscribe(
-        Reference<Subscription>(new Subscription(
-            Reference<Observable<T>>(this), offset_, std::move(observer))));
+      make_ref<Subscription>(
+          Reference<Observable<T>>(this), offset_, std::move(observer)));
   }
 
  private:
@@ -305,9 +305,7 @@ class SkipOperator : public ObservableOperator<T, T> {
        Reference<Observable<T>> observable,
        int64_t offset,
        Reference<Observer<T>> observer)
-       : ObservableOperator<T, T>::Subscription(
-             std::move(observable),
-             std::move(observer)),
+       : Super(std::move(observable), std::move(observer)),
        offset_(offset) {}
 
     void onNext(T value) override {

--- a/yarpl/test/FlowableTest.cpp
+++ b/yarpl/test/FlowableTest.cpp
@@ -286,6 +286,18 @@ TEST(FlowableTest, SimpleTake) {
   EXPECT_EQ(std::size_t{0}, Refcounted::objects());
 }
 
+TEST(FlowableTest, SimpleSkip) {
+  ASSERT_EQ(std::size_t{0}, Refcounted::objects());
+  EXPECT_EQ(run(Flowables::range(0, 10)->skip(8)), std::vector<int64_t>({8, 9}));
+  EXPECT_EQ(std::size_t{0}, Refcounted::objects());
+}
+
+TEST(FlowableTest, OverflowSkip) {
+  EXPECT_EQ(std::size_t{0}, Refcounted::objects());
+  EXPECT_EQ(run(Flowables::range(0, 10)->skip(12)), std::vector<int64_t>({}));
+  EXPECT_EQ(std::size_t{0}, Refcounted::objects());
+}
+
 TEST(FlowableTest, FlowableError) {
   auto flowable = Flowables::error<int>(std::runtime_error("something broke!"));
   auto collector = make_ref<CollectingSubscriber<int>>();

--- a/yarpl/test/FlowableTest.cpp
+++ b/yarpl/test/FlowableTest.cpp
@@ -298,6 +298,21 @@ TEST(FlowableTest, OverflowSkip) {
   EXPECT_EQ(std::size_t{0}, Refcounted::objects());
 }
 
+TEST(FlowableTest, SkipPartial) {
+  ASSERT_EQ(std::size_t{0}, Refcounted::objects());
+  auto collector = make_ref<CollectingSubscriber<int64_t>>(2);
+  auto flowable = Flowables::range(0, 10)->skip(5);
+  flowable->subscribe(collector);
+
+  EXPECT_EQ(collector->values(), std::vector<int64_t>({5, 6}));
+  collector->cancelSubscription();
+
+  flowable.reset();
+  collector.reset();
+
+  ASSERT_EQ(std::size_t{0}, Refcounted::objects());
+}
+
 TEST(FlowableTest, FlowableError) {
   auto flowable = Flowables::error<int>(std::runtime_error("something broke!"));
   auto collector = make_ref<CollectingSubscriber<int>>();

--- a/yarpl/test/Observable_test.cpp
+++ b/yarpl/test/Observable_test.cpp
@@ -454,6 +454,22 @@ TEST(Observable, DISABLED_SimpleTake) {
   EXPECT_EQ(0u, Refcounted::objects());
 }
 
+TEST(Observable, SimpleSkip) {
+  ASSERT_EQ(0u, Refcounted::objects());
+  EXPECT_EQ(
+      run(Observables::range(0, 10)->skip(8)),
+      std::vector<int64_t>({8, 9}));
+  ASSERT_EQ(0u, Refcounted::objects());
+}
+
+TEST(Observable, OverflowSkip) {
+  ASSERT_EQ(0u, Refcounted::objects());
+  EXPECT_EQ(
+      run(Observables::range(0, 10)->skip(12)),
+      std::vector<int64_t>({}));
+  ASSERT_EQ(0u, Refcounted::objects());
+}
+
 TEST(Observable, Error) {
   auto observable =
       Observables::error<int>(std::runtime_error("something broke!"));


### PR DESCRIPTION
* Implements [`skip`](http://reactivex.io/documentation/operators/skip.html) for both `Flowable` and `Observable`, which moves over arbitrary data in a stream

Usage example:
```
Flowables::range(0, 10)
    ->skip(8)
    ->map([] (int64_t n) { return n + 1; })
    ->subscribe(mySubscriber);
```
Returns `{9, 10}`