### PR TITLE
[yarpl] Add ignoreElements operator for Flowable/Observable

### DIFF
--- a/yarpl/include/yarpl/flowable/Flowable.h
+++ b/yarpl/include/yarpl/flowable/Flowable.h
@@ -97,6 +97,8 @@ class Flowable : public virtual Refcounted {
 
   auto skip(int64_t);
 
+  auto ignoreElements();
+
   auto subscribeOn(Scheduler&);
 
   /**
@@ -379,6 +381,12 @@ template <typename T>
 auto Flowable<T>::skip(int64_t offset) {
   return Reference<Flowable<T>>(
     new SkipOperator<T>(Reference<Flowable<T>>(this), offset));
+}
+
+template <typename T>
+auto Flowable<T>::ignoreElements() {
+  return Reference<Flowable<T>>(
+      new IgnoreElementsOperator<T>(Reference<Flowable<T>>(this)));
 }
 
 template <typename T>

--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -360,6 +360,32 @@ class SkipOperator : public FlowableOperator<T, T> {
 };
 
 template <typename T>
+class IgnoreElementsOperator : public FlowableOperator<T, T> {
+ public:
+  explicit IgnoreElementsOperator(Reference<Flowable<T>> upstream)
+      : FlowableOperator<T, T>(std::move(upstream)) {}
+
+  void subscribe(Reference<Subscriber<T>> subscriber) override {
+    FlowableOperator<T, T>::upstream_->subscribe(
+        Reference<Subscription>(new Subscription(
+            Reference<Flowable<T>>(this), std::move(subscriber))));
+  }
+
+ private:
+  class Subscription : public FlowableOperator<T, T>::Subscription {
+   public:
+    Subscription(
+        Reference<Flowable<T>> flowable,
+        Reference<Subscriber<T>> subscriber)
+        : FlowableOperator<T, T>::Subscription(
+              std::move(flowable),
+              std::move(subscriber)) {}
+
+    void onNext(T value) override {}
+  };
+};
+
+template <typename T>
 class SubscribeOnOperator : public FlowableOperator<T, T> {
  public:
   SubscribeOnOperator(Reference<Flowable<T>> upstream, Scheduler& scheduler)

--- a/yarpl/include/yarpl/observable/Observable.h
+++ b/yarpl/include/yarpl/observable/Observable.h
@@ -100,6 +100,8 @@ class Observable : public virtual Refcounted {
 
   auto skip(int64_t);
 
+  auto ignoreElements();
+
   auto subscribeOn(Scheduler&);
 
   /**
@@ -164,6 +166,12 @@ template <typename T>
 auto Observable<T>::skip(int64_t offset) {
   return Reference<Observable<T>>(
       new SkipOperator<T>(Reference<Observable<T>>(this), offset));
+}
+
+template <typename T>
+auto Observable<T>::ignoreElements() {
+  return Reference<Observable<T>>(
+      new IgnoreElementsOperator<T>(Reference<Observable<T>>(this)));
 }
 
 template <typename T>

--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -325,6 +325,33 @@ class SkipOperator : public ObservableOperator<T, T> {
 };
 
 template <typename T>
+class IgnoreElementsOperator : public ObservableOperator<T, T> {
+ public:
+  explicit IgnoreElementsOperator(Reference<Observable<T>> upstream)
+      : ObservableOperator<T, T>(std::move(upstream)) {}
+
+  void subscribe(Reference<Observer<T>> observer) override {
+    ObservableOperator<T, T>::upstream_->subscribe(
+        Reference<Subscription>(new Subscription(
+            Reference<Observable<T>>(this), std::move(observer))));
+  }
+
+ private:
+  class Subscription : public ObservableOperator<T, T>::Subscription {
+    using Super = typename ObservableOperator<T,T>::Subscription;
+   public:
+    Subscription(
+        Reference<Observable<T>> observable,
+        Reference<Observer<T>> observer)
+        : ObservableOperator<T, T>::Subscription(
+              std::move(observable),
+              std::move(observer)) {}
+
+    void onNext(T value) override {}
+  };
+};
+
+template <typename T>
 class SubscribeOnOperator : public ObservableOperator<T, T> {
  public:
   SubscribeOnOperator(Reference<Observable<T>> upstream, Scheduler& scheduler)

--- a/yarpl/test/Observable_test.cpp
+++ b/yarpl/test/Observable_test.cpp
@@ -470,6 +470,22 @@ TEST(Observable, OverflowSkip) {
   ASSERT_EQ(0u, Refcounted::objects());
 }
 
+TEST(Observable, IgnoreElements) {
+  ASSERT_EQ(0u, Refcounted::objects());
+
+  auto collector = make_ref<CollectingObserver<int64_t>>();
+  auto observable = Observables::range(0, 105)
+      ->ignoreElements()
+      ->map([](int64_t v) { return v + 1; });
+  observable->subscribe(collector);
+
+  EXPECT_EQ(collector->values(), std::vector<int64_t>({}));
+  EXPECT_EQ(collector->complete(), true);
+  EXPECT_EQ(collector->error(), false);
+
+  EXPECT_EQ(4u, Refcounted::objects());
+}
+
 TEST(Observable, Error) {
   auto observable =
       Observables::error<int>(std::runtime_error("something broke!"));


### PR DESCRIPTION
* Calling ignoreElements on a Flowable or Observable results in no `onNext` calls for Flowables and Observables

* Still allows `onCompleted`, `onError`, and other events to pass through

* Example:
```
Flowables::range(0, 10)->ignoreElements()->subscribe(mySubscriber)
```
completes `mySubscriber`