### PR TITLE
Fix reading an undefined boolean member

### DIFF
--- a/yarpl/include/yarpl/single/SingleSubscriptions.h
+++ b/yarpl/include/yarpl/single/SingleSubscriptions.h
@@ -87,7 +87,7 @@ class DelegateSingleSubscription : public SingleSubscription {
  private:
   // all must be protected by a mutex
   mutable std::mutex m_;
-  bool cancelled_;
+  bool cancelled_{false};
   Reference<SingleSubscription> delegate_;
 };
 


### PR DESCRIPTION
SingleSubscription::cancelled_ could be read before ever being set.  UBSAN
catches this.