### PR TITLE
Simple refactoring on SetupResumeAcceptor

### DIFF
--- a/src/internal/SetupResumeAcceptor.cpp
+++ b/src/internal/SetupResumeAcceptor.cpp
@@ -1,7 +1,9 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "SetupResumeAcceptor.h"
+
 #include <folly/ExceptionWrapper.h>
+
 #include "src/DuplexConnection.h"
 #include "src/RSocketStats.h"
 #include "src/framing/Frame.h"
@@ -9,13 +11,9 @@
 #include "src/framing/FrameSerializer.h"
 #include "src/framing/FrameTransport.h"
 
-#include <iostream>
-
 namespace rsocket {
 
-class OneFrameProcessor
-    : public FrameProcessor,
-      public std::enable_shared_from_this<OneFrameProcessor> {
+class OneFrameProcessor : public FrameProcessor {
  public:
   OneFrameProcessor(
       SetupResumeAcceptor& acceptor,

--- a/src/internal/SetupResumeAcceptor.h
+++ b/src/internal/SetupResumeAcceptor.h
@@ -4,14 +4,15 @@
 
 #include <memory>
 #include <unordered_set>
+
 #include "src/RSocketParameters.h"
 #include "src/internal/Common.h"
 
 namespace folly {
 class EventBase;
 class Executor;
-class exception_wrapper;
 class IOBuf;
+class exception_wrapper;
 }
 
 namespace rsocket {
@@ -19,16 +20,15 @@ namespace rsocket {
 class DuplexConnection;
 class FrameSerializer;
 class FrameTransport;
-class OneFrameProcessor;
 
 // This class allows to store duplex connection and wait until the first frame
-// is received. Then either onNewSocket or onResumeSocket is invoked.
+// is received. Then either onSetup or onResume is invoked.
 class SetupResumeAcceptor final {
  public:
-  using OnSetup = std::function<void(
-      std::shared_ptr<FrameTransport> frameTransport, SetupParameters setupParams)>;
-  using OnResume = std::function<void(
-      std::shared_ptr<FrameTransport> frameTransport, ResumeParameters resumeParams)>;
+  using OnSetup =
+      std::function<void(std::shared_ptr<FrameTransport>, SetupParameters)>;
+  using OnResume =
+      std::function<void(std::shared_ptr<FrameTransport>, ResumeParameters)>;
 
   explicit SetupResumeAcceptor(ProtocolVersion defaultProtocolVersion);
   ~SetupResumeAcceptor();
@@ -38,8 +38,8 @@ class SetupResumeAcceptor final {
       OnSetup onSetup,
       OnResume onResume);
 
- protected:
-  friend OneFrameProcessor;
+private:
+  friend class OneFrameProcessor;
 
   void processFrame(
       std::shared_ptr<FrameTransport> transport,
@@ -52,7 +52,6 @@ class SetupResumeAcceptor final {
       folly::exception_wrapper ex);
   void removeConnection(const std::shared_ptr<FrameTransport>& transport);
 
- private:
   std::shared_ptr<FrameSerializer> getOrAutodetectFrameSerializer(
       const folly::IOBuf& firstFrame);
 


### PR DESCRIPTION
* OneFrameProcessor doesn't need to subclass enable_shared_from_this.

* SetupResumeAcceptor has a protected block but it's a final class.  Replace
  with private.

* Get rid of unnecessary <iostream> include.