### PR TITLE
Replace lots of LOG(INFO)s with VLOGs

### DIFF
--- a/src/RSocketClient.cpp
+++ b/src/RSocketClient.cpp
@@ -7,26 +7,27 @@
 #include "src/internal/FollyKeepaliveTimer.h"
 #include "src/framing/FrameTransport.h"
 
-using namespace rsocket;
 using namespace folly;
 
 namespace rsocket {
 
-RSocketClient::RSocketClient(std::unique_ptr<ConnectionFactory> connectionFactory)
+RSocketClient::RSocketClient(
+    std::unique_ptr<ConnectionFactory> connectionFactory)
     : connectionFactory_(std::move(connectionFactory)) {
-  LOG(INFO) << "RSocketClient => created";
+  VLOG(1) << "Constructing RSocketClient";
 }
 
-Future<std::shared_ptr<RSocketRequester>> RSocketClient::connect() {
-  LOG(INFO) << "RSocketClient => start connection with Future";
+folly::Future<std::shared_ptr<RSocketRequester>> RSocketClient::connect() {
+  VLOG(2) << "Starting connection";
 
-  auto promise = std::make_shared<Promise<std::shared_ptr<RSocketRequester>>>();
+  auto promise =
+      std::make_shared<folly::Promise<std::shared_ptr<RSocketRequester>>>();
   auto future = promise->getFuture();
 
   connectionFactory_->connect([this, promise = std::move(promise)](
       std::unique_ptr<DuplexConnection> framedConnection,
-      EventBase& eventBase) {
-    LOG(INFO) << "RSocketClient => onConnect received DuplexConnection";
+      folly::EventBase& eventBase) mutable {
+    VLOG(3) << "onConnect received DuplexConnection";
 
     auto rs = std::make_shared<RSocketStateMachine>(
         eventBase,
@@ -76,6 +77,6 @@ Future<std::shared_ptr<RSocketRequester>> RSocketClient::connect() {
 }
 
 RSocketClient::~RSocketClient() {
-  LOG(INFO) << "RSocketClient => destroy";
+  VLOG(1) << "Destroying RSocketClient";
 }
 }

--- a/src/RSocketRequester.cpp
+++ b/src/RSocketRequester.cpp
@@ -6,7 +6,6 @@
 #include "internal/ScheduledSubscriber.h"
 #include "internal/ScheduledSingleObserver.h"
 
-using namespace rsocket;
 using namespace folly;
 using namespace yarpl;
 
@@ -17,7 +16,7 @@ std::shared_ptr<RSocketRequester> RSocketRequester::create(
     EventBase& eventBase) {
   auto customDeleter = [&eventBase](RSocketRequester* pRequester) {
     eventBase.runImmediatelyOrRunInEventBaseThreadAndWait([&pRequester] {
-      LOG(INFO) << "RSocketRequester => destroy on EventBase";
+      VLOG(2) << "Destroying RSocketRequester on EventBase";
       delete pRequester;
     });
   };
@@ -33,8 +32,9 @@ RSocketRequester::RSocketRequester(
     : stateMachine_(std::move(srs)), eventBase_(eventBase) {}
 
 RSocketRequester::~RSocketRequester() {
-  LOG(INFO) << "RSocketRequester => destroy";
-  stateMachine_->close(folly::exception_wrapper(), StreamCompletionSignal::CONNECTION_END);
+  VLOG(1) << "Destroying RSocketRequester";
+  stateMachine_->close(
+      folly::exception_wrapper(), StreamCompletionSignal::CONNECTION_END);
 }
 
 yarpl::Reference<yarpl::flowable::Flowable<rsocket::Payload>>

--- a/src/RSocketServer.cpp
+++ b/src/RSocketServer.cpp
@@ -9,8 +9,6 @@
 #include "framing/FrameTransport.h"
 #include "RSocketStats.h"
 
-using namespace rsocket;
-
 namespace rsocket {
 
 RSocketServer::RSocketServer(
@@ -60,31 +58,38 @@ void RSocketServer::start(OnSetupConnection onSetupConnection) {
   }
   started = true;
 
-  LOG(INFO) << "Initializing connection acceptor on start";
+  LOG(INFO) << "Starting RSocketServer";
 
   duplexConnectionAcceptor_
       ->start([ this, onSetupConnection = std::move(onSetupConnection) ](
-          std::unique_ptr<DuplexConnection> connection, folly::EventBase& eventBase) {
+          std::unique_ptr<DuplexConnection> connection,
+          folly::EventBase & eventBase) {
         VLOG(2) << "Going to accept duplex connection";
 
         // FIXME(alexanderm): This isn't thread safe
         setupResumeAcceptor_.accept(
             std::move(connection),
-            std::bind(&RSocketServer::onSetupConnection, this,
-                      std::move(onSetupConnection), std::placeholders::_1,
-                      std::placeholders::_2),
-            std::bind(&RSocketServer::onResumeConnection, this,
-                      OnResumeConnection(), std::placeholders::_1,
-                      std::placeholders::_2));
+            std::bind(
+                &RSocketServer::onSetupConnection,
+                this,
+                std::move(onSetupConnection),
+                std::placeholders::_1,
+                std::placeholders::_2),
+            std::bind(
+                &RSocketServer::onResumeConnection,
+                this,
+                OnResumeConnection(),
+                std::placeholders::_1,
+                std::placeholders::_2));
       })
       .get(); // block until finished and return or throw
 }
 
 void RSocketServer::onSetupConnection(
     OnSetupConnection onSetupConnection,
-    std::shared_ptr<rsocket::FrameTransport> frameTransport,
-    rsocket::SetupParameters setupParams) {
-  LOG(INFO) << "RSocketServer => received new setup payload";
+    std::shared_ptr<FrameTransport> frameTransport,
+    SetupParameters setupParams) {
+  VLOG(1) << "Received new setup payload";
 
   // FIXME(alexanderm): Handler should be tied to specific executor
   auto* eventBase = folly::EventBaseManager::get()->getExistingEventBase();
@@ -148,8 +153,8 @@ void RSocketServer::onSetupConnection(
 
 void RSocketServer::onResumeConnection(
     OnResumeConnection onResumeConnection,
-    std::shared_ptr<rsocket::FrameTransport> frameTransport,
-    rsocket::ResumeParameters setupPayload) {
+    std::shared_ptr<FrameTransport> frameTransport,
+    ResumeParameters setupPayload) {
   CHECK(false) << "not implemented";
 }
 
@@ -163,17 +168,17 @@ void RSocketServer::unpark() {
 }
 
 void RSocketServer::addConnection(
-    std::shared_ptr<rsocket::RSocketStateMachine> socket,
+    std::shared_ptr<RSocketStateMachine> socket,
     folly::Executor& executor) {
   sockets_.lock()->insert({std::move(socket), executor});
 }
 
 void RSocketServer::removeConnection(
-    std::shared_ptr<rsocket::RSocketStateMachine> socket) {
+    std::shared_ptr<RSocketStateMachine> socket) {
   auto locked = sockets_.lock();
   locked->erase(socket);
 
-  LOG(INFO) << "Removed ReactiveSocket";
+  VLOG(2) << "Removed ReactiveSocket";
 
   if (shutdown_ && locked->empty()) {
     shutdown_->post();

--- a/src/transports/tcp/TcpConnectionAcceptor.h
+++ b/src/transports/tcp/TcpConnectionAcceptor.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <folly/io/async/AsyncServerSocket.h>
+
 #include "src/ConnectionAcceptor.h"
 
 namespace folly {
@@ -45,10 +46,7 @@ class TcpConnectionAcceptor : public ConnectionAcceptor {
   /**
    * Bind an AsyncServerSocket and start accepting TCP connections.
    */
-  folly::Future<folly::Unit> start(
-      std::function<
-          void(std::unique_ptr<rsocket::DuplexConnection>, folly::EventBase&)>)
-      override;
+  folly::Future<folly::Unit> start(OnDuplexConnectionAccept) override;
 
   /**
    * Shutdown the AsyncServerSocket and associated listener thread.
@@ -65,9 +63,7 @@ class TcpConnectionAcceptor : public ConnectionAcceptor {
   /// thread.
   std::vector<std::unique_ptr<SocketCallback>> callbacks_;
 
-  std::function<
-      void(std::unique_ptr<rsocket::DuplexConnection>, folly::EventBase&)>
-      onAccept_;
+  OnDuplexConnectionAccept onAccept_;
 
   /// The socket listening for new connections.
   folly::AsyncServerSocket::UniquePtr serverSocket_;


### PR DESCRIPTION
They get pretty spammy when running local tests/examples, as a lot of them are
run per connection.  Switch most of them to VLOGs, but leave some of the
arguably more important ones (like start/shutdown for server) alone.

* Delete some unnecessary `using namespace rsocket;` lines.

* Use `OnDuplexConnectionAccept` in `TcpConnectionAcceptor`.

* M-x clang-format-region where appropriate.