### PR TITLE
fixing thread safety in RSocketServer and clean shut down

### DIFF
--- a/src/internal/SetupResumeAcceptor.cpp
+++ b/src/internal/SetupResumeAcceptor.cpp
@@ -53,14 +53,14 @@ class OneFrameProcessor : public FrameProcessor {
 };
 
 SetupResumeAcceptor::SetupResumeAcceptor(
-    ProtocolVersion protocolVersion) {
+    ProtocolVersion protocolVersion, folly::EventBase* eventBase)
+    : eventBase_(eventBase) {
   // if protocolVersion is unknown we will try to autodetect the version
   // with the first frame
   if (protocolVersion != ProtocolVersion::Unknown) {
     defaultFrameSerializer_ =
         FrameSerializer::createFrameSerializer(protocolVersion);
   }
-  eventBase_ = folly::EventBaseManager::get()->getExistingEventBase();
   CHECK(eventBase_);
 }
 
@@ -73,9 +73,9 @@ void SetupResumeAcceptor::processFrame(
     std::unique_ptr<folly::IOBuf> frame,
     SetupResumeAcceptor::OnSetup onSetup,
     SetupResumeAcceptor::OnResume onResume) {
-  DCHECK(eventBase_ == folly::EventBaseManager::get()->getExistingEventBase());
+  DCHECK(eventBase_->isInEventBaseThread());
 
-  if(!connections_) {
+  if (closed_) {
     transport->close(std::runtime_error("shut down"));
     return;
   }
@@ -180,7 +180,7 @@ void SetupResumeAcceptor::accept(
   auto transport = std::make_shared<FrameTransport>(std::move(connection));
   auto processor = std::make_shared<OneFrameProcessor>(
       *this, transport, std::move(onSetup), std::move(onResume));
-  connections_->insert(transport);
+  connections_.insert(transport);
   // transport can receive frames right away
   transport->setFrameProcessor(std::move(processor));
 }
@@ -206,42 +206,32 @@ void SetupResumeAcceptor::closeAndRemoveConnection(
     const std::shared_ptr<FrameTransport>& transport,
     folly::exception_wrapper ex) {
   transport->close(ex);
-  connections_->erase(transport);
+  connections_.erase(transport);
 }
 
 void SetupResumeAcceptor::removeConnection(
     const std::shared_ptr<FrameTransport>& transport) {
   transport->setFrameProcessor(nullptr);
-  connections_->erase(transport);
+  connections_.erase(transport);
 }
 
 folly::Future<folly::Unit> SetupResumeAcceptor::close() {
-  folly::Promise<folly::Unit> closingPromise;
-  auto closingFuture = closingPromise.getFuture();
-
   if(eventBase_->isInEventBaseThread()) {
     closeAllConnections();
-    closingPromise.setValue();
+    return folly::makeFuture();
   } else {
-    auto queued = eventBase_->runInEventBaseThread([this, closingPromise = std::move(closingPromise)]() mutable {
-      closeAllConnections();
-      closingPromise.setValue();
-    });
-    CHECK(queued);
+    return folly::via(eventBase_).then(
+        [this]() mutable {
+          closeAllConnections();
+        });
   }
-  return closingFuture;
 }
 
 void SetupResumeAcceptor::closeAllConnections() {
-  if(!connections_) {
-    return;
+  closed_ = true;
+  for(auto& connection : connections_) {
+    connection->close(std::runtime_error("shutting down"));
   }
-
-  folly::exception_wrapper closingEx = std::runtime_error("shutting down");
-  for(auto& connection : *connections_) {
-    connection->close(closingEx);
-  }
-  connections_ = nullptr;
 }
 
 } // reactivesocket

--- a/src/internal/SetupResumeAcceptor.h
+++ b/src/internal/SetupResumeAcceptor.h
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <unordered_set>
+#include <folly/futures/Future.h>
 #include "src/RSocketParameters.h"
 #include "src/internal/Common.h"
 
@@ -38,6 +39,8 @@ class SetupResumeAcceptor final {
       OnSetup onSetup,
       OnResume onResume);
 
+  folly::Future<folly::Unit> close();
+
  protected:
   friend OneFrameProcessor;
 
@@ -53,11 +56,16 @@ class SetupResumeAcceptor final {
   void removeConnection(const std::shared_ptr<FrameTransport>& transport);
 
  private:
+  void closeAllConnections();
+
   std::shared_ptr<FrameSerializer> getOrAutodetectFrameSerializer(
       const folly::IOBuf& firstFrame);
 
-  std::unordered_set<std::shared_ptr<FrameTransport>> connections_;
+  std::shared_ptr<std::unordered_set<std::shared_ptr<FrameTransport>>> connections_{
+      std::make_shared<std::unordered_set<std::shared_ptr<FrameTransport>>>()};
+
   std::shared_ptr<FrameSerializer> defaultFrameSerializer_;
+  folly::EventBase* eventBase_;
 };
 
 } // reactivesocket

--- a/src/internal/SetupResumeAcceptor.h
+++ b/src/internal/SetupResumeAcceptor.h
@@ -31,7 +31,10 @@ class SetupResumeAcceptor final {
   using OnResume =
       std::function<void(std::shared_ptr<FrameTransport>, ResumeParameters)>;
 
-  explicit SetupResumeAcceptor(ProtocolVersion defaultProtocolVersion);
+  explicit SetupResumeAcceptor(
+      ProtocolVersion defaultProtocolVersion,
+      folly::EventBase* eventBase);
+
   ~SetupResumeAcceptor();
 
   void accept(
@@ -60,8 +63,8 @@ private:
   std::shared_ptr<FrameSerializer> getOrAutodetectFrameSerializer(
       const folly::IOBuf& firstFrame);
 
-  std::shared_ptr<std::unordered_set<std::shared_ptr<FrameTransport>>> connections_{
-      std::make_shared<std::unordered_set<std::shared_ptr<FrameTransport>>>()};
+  std::unordered_set<std::shared_ptr<FrameTransport>> connections_;
+  bool closed_{false};
 
   std::shared_ptr<FrameSerializer> defaultFrameSerializer_;
   folly::EventBase* eventBase_;

--- a/src/transports/tcp/TcpConnectionAcceptor.h
+++ b/src/transports/tcp/TcpConnectionAcceptor.h
@@ -19,7 +19,7 @@ namespace rsocket {
 class TcpConnectionAcceptor : public ConnectionAcceptor {
  public:
   struct Options {
-    explicit Options(uint16_t port_ = 8080, size_t threads_ = 1,
+    explicit Options(uint16_t port_ = 8080, size_t threads_ = 2,
                      int backlog_ = 10) : port(port_), threads(threads_),
                                           backlog(backlog_) {}
 


### PR DESCRIPTION
Tested this by setting number of tcp server worker threads to 8 and modified one of the client examples to create thousands of connection in a infinite loop. Then I terminated the server and verified that the cleanup happened cleanly and all connections got closed.