### PR TITLE
Fix integer overflow in flowable::SkipOperator

### DIFF
--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -346,7 +346,13 @@ class SkipOperator : public FlowableOperator<T, T> {
      void request(int64_t delta) override {
        if (firstRequest_) {
          firstRequest_ = false;
-         delta = delta + offset_;
+
+         // TODO: This should be helper like `clampAdd` or something.
+         if (delta <= std::numeric_limits<int64_t>::max() - offset_) {
+           delta = delta + offset_;
+         } else {
+           delta = std::numeric_limits<int64_t>::max();
+         }
        }
        Super::request(delta);
      }

--- a/yarpl/test/FlowableTest.cpp
+++ b/yarpl/test/FlowableTest.cpp
@@ -16,7 +16,8 @@ void unreachable() {
 template <typename T>
 class CollectingSubscriber : public Subscriber<T> {
  public:
-  explicit CollectingSubscriber(int64_t requestCount = 100)
+  explicit CollectingSubscriber(
+      int64_t requestCount = Flowable<T>::NO_FLOW_CONTROL)
       : requestCount_(requestCount) {}
 
   void onSubscribe(Reference<Subscription> subscription) override {
@@ -78,7 +79,7 @@ class CollectingSubscriber : public Subscriber<T> {
 template <typename T>
 std::vector<T> run(
     Reference<Flowable<T>> flowable,
-    uint64_t requestCount = 100) {
+    int64_t requestCount = Flowable<T>::NO_FLOW_CONTROL) {
   auto collector = make_ref<CollectingSubscriber<T>>(requestCount);
   flowable->subscribe(collector);
   return collector->values();


### PR DESCRIPTION
Changes CollectingSubscriber to default to requesting INT_MAX.  This exposes the
overflow on master, and is a more intuitive default than 100.