### PR TITLE
Remove isInfinite Behavior

### DIFF
--- a/src/internal/AllowanceSemaphore.h
+++ b/src/internal/AllowanceSemaphore.h
@@ -17,9 +17,6 @@ class AllowanceSemaphore {
   explicit AllowanceSemaphore(ValueType initialValue) : value_(initialValue) {}
 
   bool tryAcquire(ValueType n = 1) {
-    if (isInfinite()) {
-      return true;
-    }
     if (!canAcquire(n)) {
       return false;
     }
@@ -40,18 +37,11 @@ class AllowanceSemaphore {
     return value_ >= n;
   }
 
-  bool isInfinite() const {
-    return value_ == max();
-  }
-
   ValueType drain() {
     return drainWithLimit(max());
   }
 
   ValueType drainWithLimit(ValueType limit) {
-    if (isInfinite()) {
-      return value_;
-    }
     if (limit > value_) {
       limit = value_;
     }

--- a/test/internal/AllowanceSemaphoreTest.cpp
+++ b/test/internal/AllowanceSemaphoreTest.cpp
@@ -10,12 +10,10 @@ using namespace ::rsocket;
 TEST(AllowanceSemaphoreTest, Finite) {
   AllowanceSemaphore sem;
 
-  ASSERT_FALSE(sem.isInfinite());
   ASSERT_FALSE(sem.canAcquire());
   ASSERT_FALSE(sem.tryAcquire());
 
   ASSERT_EQ(0U, sem.release(1));
-  ASSERT_FALSE(sem.isInfinite());
   ASSERT_FALSE(sem.canAcquire(2));
   ASSERT_TRUE(sem.canAcquire());
   ASSERT_TRUE(sem.tryAcquire());
@@ -26,31 +24,11 @@ TEST(AllowanceSemaphoreTest, Finite) {
   ASSERT_EQ(0U, sem.drain());
 
   ASSERT_EQ(0U, sem.release(2));
-  ASSERT_FALSE(sem.isInfinite());
   ASSERT_FALSE(sem.canAcquire(3));
   ASSERT_FALSE(sem.tryAcquire(3));
   ASSERT_TRUE(sem.canAcquire(2));
   ASSERT_TRUE(sem.tryAcquire(2));
   ASSERT_FALSE(sem.canAcquire());
-}
-
-TEST(AllowanceSemaphoreTest, Infinite) {
-  AllowanceSemaphore sem;
-
-  auto infty = decltype(sem)::max();
-  auto overHalfOfInfty = infty / 2 + 1;
-  ASSERT_EQ(0U, sem.release(overHalfOfInfty));
-  ASSERT_FALSE(sem.isInfinite());
-  ASSERT_EQ(overHalfOfInfty, sem.release(overHalfOfInfty));
-  ASSERT_TRUE(sem.isInfinite());
-  ASSERT_TRUE(sem.tryAcquire());
-  ASSERT_TRUE(sem.isInfinite());
-  ASSERT_TRUE(sem.tryAcquire(overHalfOfInfty));
-  ASSERT_TRUE(sem.tryAcquire(overHalfOfInfty));
-  ASSERT_TRUE(sem.tryAcquire(overHalfOfInfty));
-  ASSERT_TRUE(sem.isInfinite());
-  ASSERT_EQ(infty, sem.drain());
-  ASSERT_TRUE(sem.isInfinite());
 }
 
 TEST(AllowanceSemaphoreTest, DrainWithLimit) {


### PR DESCRIPTION
The spec does not support the concept of "infinite" credits.

Proposed fix for https://github.com/rsocket/rsocket-cpp/issues/286

I can't see any behavior that breaks with this simple removal, and unit tests all pass - but we don't have good coverage of this functionality yet. The only two methods that used `isInfinite` are in this class so this seems to have been an optimization only. 

Is there anything that this would cause issues with?