### PR TITLE
Systematic usage of log levels in rsocket-cpp

### DIFF
--- a/src/Payload.cpp
+++ b/src/Payload.cpp
@@ -10,13 +10,16 @@ namespace rsocket {
 Payload::Payload(
     std::unique_ptr<folly::IOBuf> _data,
     std::unique_ptr<folly::IOBuf> _metadata)
-    : data(std::move(_data)), metadata(std::move(_metadata)) {}
+    : data(std::move(_data)), metadata(std::move(_metadata)) {
+  VLOG(5) << "Created Payload.";
+}
 
 Payload::Payload(const std::string& _data, const std::string& _metadata)
     : data(folly::IOBuf::copyBuffer(_data)) {
   if (!_metadata.empty()) {
     metadata = folly::IOBuf::copyBuffer(_metadata);
   }
+  VLOG(5) << "Created PayLoad.";
 }
 
 void Payload::checkFlags(FrameFlags flags) const {

--- a/src/RSocketClient.cpp
+++ b/src/RSocketClient.cpp
@@ -14,11 +14,11 @@ namespace rsocket {
 RSocketClient::RSocketClient(
     std::unique_ptr<ConnectionFactory> connectionFactory)
     : connectionFactory_(std::move(connectionFactory)) {
-  VLOG(1) << "Constructing RSocketClient";
+  VLOG(5) << "RSocketClient()";
 }
 
 folly::Future<std::shared_ptr<RSocketRequester>> RSocketClient::connect() {
-  VLOG(2) << "Starting connection";
+  VLOG(1) << "Starting connection";
 
   auto promise =
       std::make_shared<folly::Promise<std::shared_ptr<RSocketRequester>>>();
@@ -27,7 +27,7 @@ folly::Future<std::shared_ptr<RSocketRequester>> RSocketClient::connect() {
   connectionFactory_->connect([this, promise = std::move(promise)](
       std::unique_ptr<DuplexConnection> connection,
       folly::EventBase& eventBase) mutable {
-    VLOG(3) << "onConnect received DuplexConnection";
+    VLOG(1) << "onConnect received DuplexConnection";
 
     auto rs = std::make_shared<RSocketStateMachine>(
         eventBase,

--- a/src/RSocketResponder.cpp
+++ b/src/RSocketResponder.cpp
@@ -7,12 +7,14 @@ namespace rsocket {
 
 yarpl::Reference<yarpl::single::Single<rsocket::Payload>>
 RSocketResponder::handleRequestResponse(rsocket::Payload request, rsocket::StreamId streamId) {
+  VLOG(4) << "handleRequestResponse not implemented.";
   return yarpl::single::Singles::error<rsocket::Payload>(
       std::logic_error("handleRequestResponse not implemented"));
 }
 
 yarpl::Reference<yarpl::flowable::Flowable<rsocket::Payload>>
 RSocketResponder::handleRequestStream(rsocket::Payload request, rsocket::StreamId streamId) {
+  VLOG(4) << "handleRequestStream not implemented.";
   return yarpl::flowable::Flowables::error<rsocket::Payload>(
       std::logic_error("handleRequestStream not implemented"));
 }
@@ -23,6 +25,7 @@ RSocketResponder::handleRequestChannel(
     yarpl::Reference<yarpl::flowable::Flowable<rsocket::Payload>>
         requestStream,
     rsocket::StreamId streamId) {
+  VLOG(4) << "handleRequestChannel not implemented.";
   return yarpl::flowable::Flowables::error<rsocket::Payload>(
       std::logic_error("handleRequestChannel not implemented"));
 }

--- a/src/RSocketServer.cpp
+++ b/src/RSocketServer.cpp
@@ -65,6 +65,7 @@ RSocketServer::~RSocketServer() {
 
 void RSocketServer::start(OnSetupConnection onSetupConnection) {
   if (started) {
+    LOG(ERROR) << "RSocketServer::start() already called.";
     throw std::runtime_error("RSocketServer::start() already called.");
   }
   started = true;
@@ -174,6 +175,8 @@ void RSocketServer::unpark() {
 void RSocketServer::addConnection(
     std::shared_ptr<RSocketStateMachine> socket,
     folly::Executor& executor) {
+  VLOG(2) << "Added ReactiveSocket";
+
   sockets_.lock()->insert({std::move(socket), executor});
 }
 

--- a/src/framing/FrameSerializer_v0.cpp
+++ b/src/framing/FrameSerializer_v0.cpp
@@ -207,10 +207,12 @@ std::unique_ptr<folly::IOBuf> FrameSerializerV0::deserializeMetadataFrom(
   const auto length = cur.readBE<uint32_t>();
 
   if (length >= kMaxMetadataLength) {
+    LOG(ERROR) << "Metadata is too big to deserialize";
     throw std::runtime_error("Metadata is too big to deserialize");
   }
 
   if (length <= sizeof(uint32_t)) {
+    LOG(ERROR) << "Metadata is too small to encode its size";
     throw std::runtime_error("Metadata is too small to encode its size");
   }
 

--- a/src/framing/FrameSerializer_v1_0.cpp
+++ b/src/framing/FrameSerializer_v1_0.cpp
@@ -47,6 +47,7 @@ static void serializeHeaderInto(
 static void deserializeHeaderFrom(folly::io::Cursor& cur, FrameHeader& header) {
   auto streamId = cur.readBE<int32_t>();
   if (streamId < 0) {
+    LOG(ERROR) << "Invalid stream id.";
     throw std::runtime_error("invalid stream id");
   }
   header.streamId_ = static_cast<StreamId>(streamId);
@@ -65,6 +66,7 @@ static void serializeMetadataInto(
 
   // Use signed int because the first bit in metadata length is reserved.
   if (metadata->length() > kMaxMetadataLength) {
+    LOG(ERROR) << "Metadata is too big to serialize.";
     CHECK(false) << "Metadata is too big to serialize";
   }
 
@@ -91,6 +93,7 @@ std::unique_ptr<folly::IOBuf> FrameSerializerV1_0::deserializeMetadataFrom(
   metadataLength |= cur.read<uint8_t>();
 
   if (metadataLength > kMaxMetadataLength) {
+    LOG(ERROR) << "Metadata is too big to deserialize.";
     throw std::runtime_error("Metadata is too big to deserialize");
   }
 
@@ -155,6 +158,7 @@ static bool deserializeFromInternal(
     auto requestN = cur.readBE<int32_t>();
     // TODO(lehecka): requestN <= 0
     if (requestN < 0) {
+      LOG(ERROR) << "Invalid request N";
       throw std::runtime_error("invalid request N");
     }
     frame.requestN_ = static_cast<uint32_t>(requestN);
@@ -424,6 +428,7 @@ bool FrameSerializerV1_0::deserializeFrom(
     deserializeHeaderFrom(cur, frame.header_);
     auto requestN = cur.readBE<int32_t>();
     if (requestN <= 0) {
+      LOG(ERROR) << "Invalid request n.";
       throw std::runtime_error("invalid request n");
     }
     frame.requestN_ = static_cast<uint32_t>(requestN);
@@ -496,6 +501,7 @@ bool FrameSerializerV1_0::deserializeFrom(
     deserializeHeaderFrom(cur, frame.header_);
     auto position = cur.readBE<int64_t>();
     if (position < 0) {
+      LOG(ERROR) << "Invalid value for position.";
       throw std::runtime_error("invalid value for position");
     }
     frame.position_ = static_cast<ResumePosition>(position);
@@ -518,12 +524,14 @@ bool FrameSerializerV1_0::deserializeFrom(
 
     auto keepaliveTime = cur.readBE<int32_t>();
     if (keepaliveTime <= 0) {
+      LOG(ERROR) << "Invalid keepalive time.";
       throw std::runtime_error("invalid keepalive time");
     }
     frame.keepaliveTime_ = static_cast<uint32_t>(keepaliveTime);
 
     auto maxLifetime = cur.readBE<int32_t>();
     if (maxLifetime <= 0) {
+      LOG(ERROR) << "Invalid maxLife time.";
       throw std::runtime_error("invalid maxLife time");
     }
     frame.maxLifetime_ = static_cast<uint32_t>(maxLifetime);
@@ -558,12 +566,14 @@ bool FrameSerializerV1_0::deserializeFrom(
 
     auto ttl = cur.readBE<int32_t>();
     if (ttl <= 0) {
+      LOG(ERROR) << "invalid ttl value.";
       throw std::runtime_error("invalid ttl value");
     }
     frame.ttl_ = static_cast<uint32_t>(ttl);
 
     auto numberOfRequests = cur.readBE<int32_t>();
     if (numberOfRequests <= 0) {
+      LOG(ERROR) << "invalid numberOfRequests value";
       throw std::runtime_error("invalid numberOfRequests value");
     }
     frame.numberOfRequests_ = static_cast<uint32_t>(numberOfRequests);
@@ -590,6 +600,7 @@ bool FrameSerializerV1_0::deserializeFrom(
 
     auto lastReceivedServerPosition = cur.readBE<int64_t>();
     if (lastReceivedServerPosition < 0) {
+      LOG(ERROR) << "Invalid value for lastReceivedServerPosition.";
       throw std::runtime_error("invalid value for lastReceivedServerPosition");
     }
     frame.lastReceivedServerPosition_ =
@@ -597,6 +608,7 @@ bool FrameSerializerV1_0::deserializeFrom(
 
     auto clientPosition = cur.readBE<int64_t>();
     if (clientPosition < 0) {
+      LOG(ERROR) << "Invalid value for clientPosition";
       throw std::runtime_error("invalid value for clientPosition");
     }
     frame.clientPosition_ = static_cast<ResumePosition>(clientPosition);
@@ -615,6 +627,7 @@ bool FrameSerializerV1_0::deserializeFrom(
 
     auto position = cur.readBE<int64_t>();
     if (position < 0) {
+      LOG(ERROR) << "Invalid value for position";
       throw std::runtime_error("invalid value for position");
     }
     frame.position_ = static_cast<ResumePosition>(position);

--- a/src/framing/FramedDuplexConnection.cpp
+++ b/src/framing/FramedDuplexConnection.cpp
@@ -13,7 +13,9 @@ FramedDuplexConnection::FramedDuplexConnection(
     : FramedDuplexConnection(
           std::move(connection),
           FrameSerializer::getCurrentProtocolVersion(),
-          executor) {}
+          executor) {
+  VLOG(5) << "FrameDuplexConnection()";
+}
 
 FramedDuplexConnection::FramedDuplexConnection(
     std::unique_ptr<DuplexConnection> connection,
@@ -21,7 +23,9 @@ FramedDuplexConnection::FramedDuplexConnection(
     folly::Executor& executor)
     : connection_(std::move(connection)),
       protocolVersion_(std::make_shared<ProtocolVersion>(protocolVersion)),
-      executor_(executor) {}
+      executor_(executor) {
+  VLOG(5) << "~FrameDuplexConnection()";
+}
 
 FramedDuplexConnection::~FramedDuplexConnection() {
   // to make sure we close the parties when the connection dies

--- a/src/framing/FramedReader.h
+++ b/src/framing/FramedReader.h
@@ -25,7 +25,9 @@ class FramedReader : public SubscriberBaseT<std::unique_ptr<folly::IOBuf>>,
       : ExecutorBase(executor),
         frames_(std::move(frames)),
         payloadQueue_(folly::IOBufQueue::cacheChainLength()),
-        protocolVersion_(std::move(protocolVersion)) {}
+        protocolVersion_(std::move(protocolVersion)) {
+    VLOG(5) << "FramedReader()";
+  }
 
  private:
   // Subscriber methods

--- a/src/framing/FramedWriter.h
+++ b/src/framing/FramedWriter.h
@@ -27,7 +27,9 @@ class FramedWriter : public SubscriberBaseT<std::unique_ptr<folly::IOBuf>>,
       std::shared_ptr<ProtocolVersion> protocolVersion)
       : ExecutorBase(executor),
         stream_(std::move(stream)),
-        protocolVersion_(std::move(protocolVersion)) {}
+        protocolVersion_(std::move(protocolVersion)) {
+    VLOG(5) << "FramedWriter()";
+  }
 
   void onNextMultiple(std::vector<std::unique_ptr<folly::IOBuf>> element);
 

--- a/src/statemachine/RequestResponseResponder.cpp
+++ b/src/statemachine/RequestResponseResponder.cpp
@@ -61,6 +61,10 @@ void RequestResponseResponder::endStream(StreamCompletionSignal signal) {
   switch (state_) {
     case State::RESPONDING:
       // Spontaneous ::endStream signal means an error.
+      LOG_IF(ERROR,
+             StreamCompletionSignal::COMPLETE == signal ||
+                 StreamCompletionSignal::CANCEL == signal)
+             << "Spontaneous ::endStream signal means an error.";
       DCHECK(StreamCompletionSignal::COMPLETE != signal);
       DCHECK(StreamCompletionSignal::CANCEL != signal);
       state_ = State::CLOSED;

--- a/src/transports/tcp/TcpConnectionAcceptor.cpp
+++ b/src/transports/tcp/TcpConnectionAcceptor.cpp
@@ -33,7 +33,7 @@ class TcpConnectionAcceptor::SocketCallback
   }
 
   void acceptError(const std::exception& ex) noexcept override {
-    VLOG(1) << "TCP error: " << ex.what();
+    LOG(ERROR) << "TCP error: " << ex.what();
   }
 
   folly::EventBase* eventBase() const {
@@ -64,6 +64,7 @@ TcpConnectionAcceptor::~TcpConnectionAcceptor() {
 folly::Future<folly::Unit> TcpConnectionAcceptor::start(
     OnDuplexConnectionAccept onAccept) {
   if (onAccept_ != nullptr) {
+    LOG(ERROR) << "TcpConnectionAcceptor::start() already called.";
     return folly::makeFuture<folly::Unit>(
         std::runtime_error("TcpConnectionAcceptor::start() already called"));
   }


### PR DESCRIPTION
Sending an early PR to get feedback.
Internal: T18976114

LOG(ERROR) 
- A error from which the process can recover itself, but affects connections or data frames.
- Examples:  Unparseable Frames; Unsupported versions; Handler not provided by application; SETUP asks for resumption, but server does not provide support.

LOG(INFO)
- Data which might interest the user of rsocket.
- Examples: Server/Client startup/shutdown.  OnError events.  Maybe Resumption events?

VLOG(N)
- These log levels should be for the assistance of the developer.

Example:
VLOG(1) - Details at connection/stream level - connection setup/teardown events; stream begin/onComplete events.
VLOG(2) - Details at Frame level - in/out frames - t18912650
VLOG(3) - Details at byte level - in/out hexDump
VLOG(4) - State machines changes ?
VLOG(5) - Important object construction/destruction.
and so on ...

We could rate limit with LOG_FIRST_N or LOG_EVERY_N for repetitive events. 