### PR TITLE
Ability to pretty print in/out frames in rsocket-cpp

### DIFF
--- a/src/statemachine/RSocketStateMachine.cpp
+++ b/src/statemachine/RSocketStateMachine.cpp
@@ -272,7 +272,7 @@ void RSocketStateMachine::closeWithError(Frame_ERROR&& error) {
       error.payload_.data->cloneAsValue().moveToFbString().toStdString());
 
   if (frameSerializer_) {
-    outputFrameOrEnqueue(frameSerializer_->serializeOut(std::move(error)));
+    outputFrameOrEnqueue(std::move(error));
   }
   close(std::move(exception), signal);
 }
@@ -442,7 +442,7 @@ void RSocketStateMachine::handleConnectionFrame(
               remoteResumeable_, frame, std::move(payload))) {
         return;
       }
-
+      VLOG(3) << "In:" << frame;
       resumeCache_->resetUpToPosition(frame.position_);
       if (mode_ == ReactiveSocketMode::SERVER) {
         if (!!(frame.header_.flags_ & FrameFlags::KEEPALIVE_RESPOND)) {
@@ -464,6 +464,7 @@ void RSocketStateMachine::handleConnectionFrame(
     case FrameType::METADATA_PUSH: {
       Frame_METADATA_PUSH frame;
       if (deserializeFrameOrError(frame, std::move(payload))) {
+        VLOG(3) << "In:" << frame;
         requestResponder_->handleMetadataPush(std::move(frame.metadata_));
       }
       return;
@@ -473,6 +474,7 @@ void RSocketStateMachine::handleConnectionFrame(
       if (!deserializeFrameOrError(frame, std::move(payload))) {
         return;
       }
+      VLOG(3) << "In:" << frame;
       if (resumeCallback_) {
         if (resumeCache_->isPositionAvailable(frame.position_)) {
           resumeCallback_->onResumeOk();
@@ -494,6 +496,7 @@ void RSocketStateMachine::handleConnectionFrame(
       if (!deserializeFrameOrError(frame, std::move(payload))) {
         return;
       }
+      VLOG(3) << "In:" << frame;
 
       // TODO: handle INVALID_SETUP, UNSUPPORTED_SETUP, REJECTED_SETUP
 
@@ -548,10 +551,12 @@ void RSocketStateMachine::handleStreamFrame(
       if (!deserializeFrameOrError(frameRequestN, std::move(serializedFrame))) {
         return;
       }
+      VLOG(3) << "In:" << frameRequestN;
       stateMachine->handleRequestN(frameRequestN.requestN_);
       break;
     }
     case FrameType::CANCEL: {
+      VLOG(3) << "In:" << Frame_CANCEL();
       stateMachine->handleCancel();
       break;
     }
@@ -560,6 +565,7 @@ void RSocketStateMachine::handleStreamFrame(
       if (!deserializeFrameOrError(framePayload, std::move(serializedFrame))) {
         return;
       }
+      VLOG(3) << "In:" << framePayload;
       stateMachine->handlePayload(
           std::move(framePayload.payload_),
           framePayload.header_.flagsComplete(),
@@ -571,6 +577,7 @@ void RSocketStateMachine::handleStreamFrame(
       if (!deserializeFrameOrError(frameError, std::move(serializedFrame))) {
         return;
       }
+      VLOG(3) << "In:" << frameError;
       stateMachine->handleError(
           std::runtime_error(frameError.payload_.moveDataToString()));
       break;
@@ -615,6 +622,7 @@ void RSocketStateMachine::handleUnknownStream(
       if (!deserializeFrameOrError(frame, std::move(serializedFrame))) {
         return;
       }
+      VLOG(3) << "In:" << frame;
       auto stateMachine =
           streamsFactory_.createChannelResponder(frame.requestN_, streamId);
       auto requestSink = requestResponder_->handleRequestChannelCore(
@@ -627,6 +635,7 @@ void RSocketStateMachine::handleUnknownStream(
       if (!deserializeFrameOrError(frame, std::move(serializedFrame))) {
         return;
       }
+      VLOG(3) << "In:" << frame;
       auto stateMachine =
           streamsFactory_.createStreamResponder(frame.requestN_, streamId);
       requestResponder_->handleRequestStreamCore(
@@ -638,6 +647,7 @@ void RSocketStateMachine::handleUnknownStream(
       if (!deserializeFrameOrError(frame, std::move(serializedFrame))) {
         return;
       }
+      VLOG(3) << "In:" << frame;
       auto stateMachine =
           streamsFactory_.createRequestResponseResponder(streamId);
       requestResponder_->handleRequestResponseCore(
@@ -649,6 +659,7 @@ void RSocketStateMachine::handleUnknownStream(
       if (!deserializeFrameOrError(frame, std::move(serializedFrame))) {
         return;
       }
+      VLOG(3) << "In:" << frame;
       // no stream tracking is necessary
       requestResponder_->handleFireAndForget(
           std::move(frame.payload_), streamId);
@@ -685,6 +696,7 @@ void RSocketStateMachine::sendKeepalive(
   debugCheckCorrectExecutor();
   Frame_KEEPALIVE pingFrame(
       flags, resumeCache_->impliedPosition(), std::move(data));
+  VLOG(3) << "Out: " << pingFrame;
   outputFrameOrEnqueue(
       frameSerializer_->serializeOut(std::move(pingFrame), remoteResumeable_));
 }
@@ -693,12 +705,14 @@ void RSocketStateMachine::tryClientResume(
     const ResumeIdentificationToken& token,
     std::shared_ptr<FrameTransport> frameTransport,
     std::unique_ptr<ClientResumeStatusCallback> resumeCallback) {
+  Frame_RESUME resumeFrame(
+      token,
+      resumeCache_->impliedPosition(),
+      resumeCache_->lastResetPosition(),
+      frameSerializer_->protocolVersion());
+  VLOG(3) << "Out: " << resumeFrame;
   frameTransport->outputFrameOrEnqueue(
-      frameSerializer_->serializeOut(Frame_RESUME(
-          token,
-          resumeCache_->impliedPosition(),
-          resumeCache_->lastResetPosition(),
-          frameSerializer_->protocolVersion())));
+      frameSerializer_->serializeOut(std::move(resumeFrame)));
 
   // if the client was still connected we will disconnected the old connection
   // with a clear error message
@@ -725,8 +739,10 @@ bool RSocketStateMachine::resumeFromPositionOrClose(
 
   if (clientPositionExist &&
       resumeCache_->isPositionAvailable(serverPosition)) {
+    Frame_RESUME_OK resumeOkFrame(resumeCache_->impliedPosition());
+    VLOG(3) << "Out: " << resumeOkFrame;
     frameTransport_->outputFrameOrEnqueue(frameSerializer_->serializeOut(
-        Frame_RESUME_OK(resumeCache_->impliedPosition())));
+        std::move(resumeOkFrame)));
     resumeFromPosition(serverPosition);
     return true;
   } else {
@@ -774,12 +790,15 @@ void RSocketStateMachine::requestFireAndForget(Payload request) {
       streamsFactory().getNextStreamId(),
       FrameFlags::EMPTY,
       std::move(std::move(request)));
+  VLOG(3) << "Out: " << frame;
   outputFrameOrEnqueue(frameSerializer_->serializeOut(std::move(frame)));
 }
 
 void RSocketStateMachine::metadataPush(std::unique_ptr<folly::IOBuf> metadata) {
+  Frame_METADATA_PUSH metadataPushFrame(std::move(metadata));
+  VLOG(3) << "Out: " << metadataPushFrame;
   outputFrameOrEnqueue(
-      frameSerializer_->serializeOut(Frame_METADATA_PUSH(std::move(metadata))));
+      frameSerializer_->serializeOut(std::move(metadataPushFrame)));
 }
 
 void RSocketStateMachine::outputFrame(std::unique_ptr<folly::IOBuf> frame) {
@@ -874,6 +893,7 @@ void RSocketStateMachine::connectClientSendSetup(
   // TODO: when the server returns back that it doesn't support resumability, we
   // should retry without resumability
 
+  VLOG(3) << "Out: " << frame;
   // making sure we send setup frame first
   frameTransport->outputFrameOrEnqueue(
       frameSerializer_->serializeOut(std::move(frame)));
@@ -889,27 +909,26 @@ void RSocketStateMachine::writeNewStream(
     bool completed) {
   switch (streamType) {
     case StreamType::CHANNEL:
-      outputFrameOrEnqueue(frameSerializer_->serializeOut(Frame_REQUEST_CHANNEL(
+      outputFrameOrEnqueue(Frame_REQUEST_CHANNEL(
           streamId,
           completed ? FrameFlags::COMPLETE : FrameFlags::EMPTY,
           initialRequestN,
-          std::move(payload))));
+          std::move(payload)));
       break;
 
     case StreamType::STREAM:
-      outputFrameOrEnqueue(frameSerializer_->serializeOut(Frame_REQUEST_STREAM(
-          streamId, FrameFlags::EMPTY, initialRequestN, std::move(payload))));
+      outputFrameOrEnqueue(Frame_REQUEST_STREAM(
+          streamId, FrameFlags::EMPTY, initialRequestN, std::move(payload)));
       break;
 
     case StreamType::REQUEST_RESPONSE:
       outputFrameOrEnqueue(
-          frameSerializer_->serializeOut(Frame_REQUEST_RESPONSE(
-              streamId, FrameFlags::EMPTY, std::move(payload))));
+          Frame_REQUEST_RESPONSE(streamId, FrameFlags::EMPTY, std::move(payload)));
       break;
 
     case StreamType::FNF:
-      outputFrameOrEnqueue(frameSerializer_->serializeOut(
-          Frame_REQUEST_FNF(streamId, FrameFlags::EMPTY, std::move(payload))));
+      outputFrameOrEnqueue(
+          Frame_REQUEST_FNF(streamId, FrameFlags::EMPTY, std::move(payload)));
       break;
 
     default:
@@ -918,8 +937,7 @@ void RSocketStateMachine::writeNewStream(
 }
 
 void RSocketStateMachine::writeRequestN(StreamId streamId, uint32_t n) {
-  outputFrameOrEnqueue(
-      frameSerializer_->serializeOut(Frame_REQUEST_N(streamId, n)));
+  outputFrameOrEnqueue(Frame_REQUEST_N(streamId, n));
 }
 
 void RSocketStateMachine::writePayload(
@@ -930,7 +948,7 @@ void RSocketStateMachine::writePayload(
       streamId,
       FrameFlags::NEXT | (complete ? FrameFlags::COMPLETE : FrameFlags::EMPTY),
       std::move(payload));
-  outputFrameOrEnqueue(frameSerializer_->serializeOut(std::move(frame)));
+  outputFrameOrEnqueue(std::move(frame));
 }
 
 void RSocketStateMachine::writeCloseStream(
@@ -939,23 +957,21 @@ void RSocketStateMachine::writeCloseStream(
     Payload payload) {
   switch (signal) {
     case StreamCompletionSignal::COMPLETE:
-      outputFrameOrEnqueue(
-          frameSerializer_->serializeOut(Frame_PAYLOAD::complete(streamId)));
+      outputFrameOrEnqueue(Frame_PAYLOAD::complete(streamId));
       break;
 
     case StreamCompletionSignal::CANCEL:
-      outputFrameOrEnqueue(
-          frameSerializer_->serializeOut(Frame_CANCEL(streamId)));
+      outputFrameOrEnqueue(Frame_CANCEL(streamId));
       break;
 
     case StreamCompletionSignal::ERROR:
-      outputFrameOrEnqueue(frameSerializer_->serializeOut(
-          Frame_ERROR::error(streamId, std::move(payload))));
+      outputFrameOrEnqueue(
+          Frame_ERROR::error(streamId, std::move(payload)));
       break;
 
     case StreamCompletionSignal::APPLICATION_ERROR:
-      outputFrameOrEnqueue(frameSerializer_->serializeOut(
-          Frame_ERROR::applicationError(streamId, std::move(payload))));
+      outputFrameOrEnqueue(
+          Frame_ERROR::applicationError(streamId, std::move(payload)));
       break;
 
     case StreamCompletionSignal::INVALID_SETUP:

--- a/src/statemachine/RSocketStateMachine.h
+++ b/src/statemachine/RSocketStateMachine.h
@@ -139,6 +139,12 @@ class RSocketStateMachine final
 
   void outputFrameOrEnqueue(std::unique_ptr<folly::IOBuf> frame);
 
+  template<typename T>
+  void outputFrameOrEnqueue(T&& frame) {
+    VLOG(3) << "Out: " << frame;
+    outputFrameOrEnqueue(frameSerializer_->serializeOut(std::forward<T>(frame)));
+  }
+
   void requestFireAndForget(Payload request);
 
   template <typename TFrame>


### PR DESCRIPTION
When we are debugging the program, we would want to see increasing levels of details with the --verbosity (-v) flag.

Say for --verbosity=3, a simple request-response should look like something like this.

Out: SETUP FrameLen=45 DataLen=245 Encoding=abc 
Out: REQUEST_RESPONSE FrameLen=240 DataLen=156 Data=hello Metadata=World
In: PAYLOAD FrameLen=230 Flags=NEXT|COMPLETE DataLen=23 Data=hello Metadata=Buddy

Then for --verbosity=3, we could print the hexDump.