### PR TITLE
Passing setup parameters to RSocketClient

### DIFF
--- a/examples/conditional-request-handling/ConditionalRequestHandling_Client.cpp
+++ b/examples/conditional-request-handling/ConditionalRequestHandling_Client.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) {
 
   auto rsf = RSocket::createClient(
       std::make_unique<TcpConnectionFactory>(std::move(address)));
-  auto rs = rsf->connect().get();
+  auto rs = rsf->connect(SetupParameters("application/json", "application/json")).get();
 
   rs->requestStream(Payload("Bob"))->take(5)->subscribe([](Payload p) {
     std::cout << "Received: " << p.moveDataToString() << std::endl;

--- a/src/ConnectionFactory.h
+++ b/src/ConnectionFactory.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <folly/Function.h>
 #include "src/DuplexConnection.h"
 
 namespace folly {
@@ -10,7 +11,7 @@ class EventBase;
 
 namespace rsocket {
 
-using OnConnect = std::function<
+using OnConnect = folly::Function<
     void(std::unique_ptr<rsocket::DuplexConnection>, folly::EventBase&)>;
 
 /**

--- a/src/RSocketClient.h
+++ b/src/RSocketClient.h
@@ -5,6 +5,8 @@
 #include <folly/futures/Future.h>
 #include "RSocketRequester.h"
 #include "src/ConnectionFactory.h"
+#include "src/RSocketParameters.h"
+#include "src/RSocketStats.h"
 
 namespace rsocket {
 
@@ -23,10 +25,6 @@ class RSocketClient {
   RSocketClient& operator=(const RSocketClient&) = delete; // copy
   RSocketClient& operator=(RSocketClient&&) = delete; // move
 
-  // TODO ConnectionSetupPayload
-  // TODO keepalive timer
-  // TODO duplex with RequestHandler
-
   /*
    * Connect asynchronously and return a Future which will deliver the RSocket
    *
@@ -40,7 +38,11 @@ class RSocketClient {
    * To destruct a single RSocketRequester sooner than the RSocketClient
    * call RSocketRequester.close().
    */
-  folly::Future<std::shared_ptr<RSocketRequester>> connect();
+  folly::Future<std::shared_ptr<RSocketRequester>> connect(
+      SetupParameters setupParameters = SetupParameters(),
+      std::shared_ptr<RSocketResponder> responder = std::shared_ptr<RSocketResponder>(),
+      std::shared_ptr<RSocketStats> stats = RSocketStats::noop(),
+      std::unique_ptr<KeepaliveTimer> keepaliveTimer = std::unique_ptr<KeepaliveTimer>());
 
   // TODO implement version supporting fast start (send SETUP and requests
   // without waiting for transport to connect and ack)

--- a/src/RSocketParameters.h
+++ b/src/RSocketParameters.h
@@ -22,8 +22,8 @@ class RSocketParameters {
 class SetupParameters : public RSocketParameters {
  public:
   explicit SetupParameters(
-      std::string _metadataMimeType = "",
-      std::string _dataMimeType = "",
+      std::string _metadataMimeType = "text/plain",
+      std::string _dataMimeType = "text/plain",
       Payload _payload = Payload(),
       bool _resumable = false,
       const ResumeIdentificationToken& _token =


### PR DESCRIPTION
this allows client application code to pass setup parameters to the RSocketClient as well as other parameters. All of them have a default value so the client doesn't have to specify them.