### PR TITLE
RSocketClient from TCP socket

### DIFF
--- a/src/RSocketClient.h
+++ b/src/RSocketClient.h
@@ -52,6 +52,15 @@ class RSocketClient {
   // without waiting for transport to connect and ack)
   //  std::shared_ptr<RSocketRequester> fastConnect();
 
+  std::unique_ptr<RSocketRequester> fromConnection(
+      std::unique_ptr<DuplexConnection> connection,
+      folly::EventBase& eventBase,
+      SetupParameters setupParameters = SetupParameters(),
+      std::shared_ptr<RSocketResponder> responder = std::shared_ptr<RSocketResponder>(),
+      std::unique_ptr<KeepaliveTimer> keepaliveTimer = std::unique_ptr<KeepaliveTimer>(),
+      std::shared_ptr<RSocketStats> stats = std::shared_ptr<RSocketStats>(),
+      std::shared_ptr<RSocketNetworkStats> networkStats = std::shared_ptr<RSocketNetworkStats>());
+
  private:
   std::unique_ptr<ConnectionFactory> connectionFactory_;
   std::unique_ptr<RSocketConnectionManager> connectionManager_;

--- a/src/transports/tcp/TcpConnectionFactory.h
+++ b/src/transports/tcp/TcpConnectionFactory.h
@@ -3,13 +3,14 @@
 #pragma once
 
 #include <folly/SocketAddress.h>
+#include <folly/io/async/AsyncSocket.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
-
 #include "src/ConnectionFactory.h"
-
 #include "src/DuplexConnection.h"
 
 namespace rsocket {
+
+class RSocketStats;
 
 /**
  * TCP implementation of ConnectionFactory for use with RSocket::createClient().
@@ -27,6 +28,11 @@ class TcpConnectionFactory : public ConnectionFactory {
    * Each call to connect() creates a new AsyncSocket.
    */
   void connect(OnConnect) override;
+
+  static std::unique_ptr<DuplexConnection> createDuplexConnectionFromSocket(
+      folly::AsyncSocket::UniquePtr socket,
+      folly::EventBase& eventBase,
+      std::shared_ptr<RSocketStats> stats = std::shared_ptr<RSocketStats>());
 
  private:
   folly::SocketAddress address_;


### PR DESCRIPTION
This allows creating RSocketClient directly from the opened TCP socket (folly::AsyncSocket) via 2 synchronous calls.