### PR TITLE
[rsocket-cpp] Enable tck tests in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,11 +81,10 @@ script:
   - ./yarpl/yarpl-tests
   - cd ..
   - ./scripts/prepare_tck_drivers.sh
-# Commenting out TCK until it is upgraded to new APIs
-#  - ./scripts/tck_test.sh -c cpp -s cpp
-#  - ./scripts/tck_test.sh -c java -s java
-#  - ./scripts/tck_test.sh -c java -s cpp
-#  - ./scripts/tck_test.sh -c cpp -s java
+  - ./scripts/tck_test.sh -c cpp -s cpp
+  - ./scripts/tck_test.sh -c java -s java
+  - ./scripts/tck_test.sh -c java -s cpp
+  - ./scripts/tck_test.sh -c cpp -s java
 
 after_success:
   - if [ -n "$GCC_VERSION" ]; then lcov --directory . --capture --output-file coverage.info; fi # capture coverage info

--- a/scripts/tck_test.sh
+++ b/scripts/tck_test.sh
@@ -61,7 +61,7 @@ timeout 60 ${!client}
 ret=$?
 
 # terminate server
-kill -9 $!
+kill $!
 
 # wait for server to relinquish its socket resources
 sleep 2

--- a/scripts/tck_test.sh
+++ b/scripts/tck_test.sh
@@ -61,7 +61,7 @@ timeout 60 ${!client}
 ret=$?
 
 # terminate server
-kill $!
+kill -9 $!
 
 # wait for server to relinquish its socket resources
 sleep 2

--- a/scripts/tck_test.sh
+++ b/scripts/tck_test.sh
@@ -61,7 +61,7 @@ timeout 60 ${!client}
 ret=$?
 
 # terminate server
-kill $!
+kill -9  $!
 
 # wait for server to relinquish its socket resources
 sleep 2

--- a/scripts/tck_test.sh
+++ b/scripts/tck_test.sh
@@ -61,7 +61,7 @@ timeout 60 ${!client}
 ret=$?
 
 # terminate server
-kill -9  $!
+kill $!
 
 # wait for server to relinquish its socket resources
 sleep 2

--- a/src/statemachine/StreamResponder.cpp
+++ b/src/statemachine/StreamResponder.cpp
@@ -39,8 +39,8 @@ void StreamResponder::onError(const std::exception_ptr ex) noexcept {
 //}
 
 void StreamResponder::endStream(StreamCompletionSignal signal) {
-  terminatePublisher();
   StreamStateMachineBase::endStream(signal);
+  terminatePublisher();
 }
 
 void StreamResponder::handleCancel() {

--- a/src/statemachine/StreamResponder.cpp
+++ b/src/statemachine/StreamResponder.cpp
@@ -39,13 +39,13 @@ void StreamResponder::onError(const std::exception_ptr ex) noexcept {
 //}
 
 void StreamResponder::endStream(StreamCompletionSignal signal) {
-  StreamStateMachineBase::endStream(signal);
   terminatePublisher();
+  StreamStateMachineBase::endStream(signal);
 }
 
 void StreamResponder::handleCancel() {
-  publisherComplete();
   closeStream(StreamCompletionSignal::CANCEL);
+  publisherComplete();
 }
 
 void StreamResponder::handleRequestN(uint32_t n) {

--- a/tck-test/BaseSubscriber.h
+++ b/tck-test/BaseSubscriber.h
@@ -14,18 +14,18 @@ class BaseSubscriber : public virtual yarpl::Refcounted {
  public:
   virtual void request(int n) = 0;
   virtual void cancel() = 0;
-  virtual void awaitTerminalEvent();
-  virtual void awaitAtLeast(int numItems);
-  virtual void awaitNoEvents(int waitTime);
-  virtual void assertNoErrors();
-  virtual void assertError();
-  virtual void assertValues(
+  void awaitTerminalEvent();
+  void awaitAtLeast(int numItems);
+  void awaitNoEvents(int waitTime);
+  void assertNoErrors();
+  void assertError();
+  void assertValues(
       const std::vector<std::pair<std::string, std::string>>& values);
-  virtual void assertValueCount(size_t valueCount);
-  virtual void assertReceivedAtLeast(size_t valueCount);
-  virtual void assertCompleted();
-  virtual void assertNotCompleted();
-  virtual void assertCanceled();
+  void assertValueCount(size_t valueCount);
+  void assertReceivedAtLeast(size_t valueCount);
+  void assertCompleted();
+  void assertNotCompleted();
+  void assertCanceled();
 
  protected:
   std::atomic<bool> canceled_{false};

--- a/tck-test/TestInterpreter.cpp
+++ b/tck-test/TestInterpreter.cpp
@@ -18,8 +18,8 @@ namespace tck {
 
 TestInterpreter::TestInterpreter(
     const Test& test,
-    std::unique_ptr<RSocketRequester> requester)
-    : requester_(std::move(requester)), test_(test) {
+    RSocketRequester* requester)
+    : requester_(requester), test_(test) {
   DCHECK(!test.empty());
 }
 

--- a/tck-test/TestInterpreter.h
+++ b/tck-test/TestInterpreter.h
@@ -31,7 +31,7 @@ class TestInterpreter {
  public:
   TestInterpreter(
       const Test& test,
-      std::unique_ptr<RSocketRequester> requester);
+      RSocketRequester* requester);
 
   bool run();
 
@@ -44,7 +44,7 @@ class TestInterpreter {
 
   yarpl::Reference<BaseSubscriber> getSubscriber(const std::string& id);
 
-  std::unique_ptr<RSocketRequester> requester_;
+  RSocketRequester* requester_;
   const Test& test_;
   std::map<std::string, std::string> interactionIdToType_;
   std::map<std::string, yarpl::Reference<BaseSubscriber>> testSubscribers_;

--- a/tck-test/client.cpp
+++ b/tck-test/client.cpp
@@ -37,6 +37,8 @@ int main(int argc, char* argv[]) {
   folly::SocketAddress address;
   address.setFromHostPort(FLAGS_ip, FLAGS_port);
 
+  LOG(INFO) << "Creating client to connect to " << address.describe();
+
   // create a client which can then make connections below
   auto rsf = RSocket::createClient(
       std::make_unique<TcpConnectionFactory>(std::move(address)));
@@ -57,7 +59,7 @@ int main(int argc, char* argv[]) {
         std::find(testsToRun.begin(), testsToRun.end(), test.name()) !=
             testsToRun.end()) {
       ++ran;
-      TestInterpreter interpreter(test, std::move(rs));
+      TestInterpreter interpreter(test, rs.get());
       bool passing = interpreter.run();
       if (passing) {
         ++passed;

--- a/tck-test/clienttest.txt
+++ b/tck-test/clienttest.txt
@@ -3,7 +3,7 @@ name%%streamTest3
 subscribe%%rs%%cf114994-3782-4cb6-943f-78e4a45e9359%%c%%d
 request%%5%%cf114994-3782-4cb6-943f-78e4a45e9359
 await%%atLeast%%cf114994-3782-4cb6-943f-78e4a45e9359%%5%%100
-await%%no_events%%cf114994-3782-4cb6-943f-78e4a45e9359%%5000
+await%%no_events%%cf114994-3782-4cb6-943f-78e4a45e9359%%3000
 cancel%%cf114994-3782-4cb6-943f-78e4a45e9359
 assert%%canceled%%cf114994-3782-4cb6-943f-78e4a45e9359
 assert%%no_error%%cf114994-3782-4cb6-943f-78e4a45e9359

--- a/tck-test/server.cpp
+++ b/tck-test/server.cpp
@@ -2,12 +2,11 @@
 
 #include <fstream>
 #include <future>
+#include <signal.h>
 
 #include <folly/Memory.h>
 #include <folly/String.h>
 #include <folly/init/Init.h>
-
-#include <gmock/gmock.h>
 
 #include "src/RSocket.h"
 
@@ -15,7 +14,6 @@
 
 #include "tck-test/MarbleProcessor.h"
 
-using namespace ::testing;
 using namespace folly;
 using namespace rsocket;
 using namespace yarpl;

--- a/tck-test/server.cpp
+++ b/tck-test/server.cpp
@@ -148,10 +148,6 @@ int main(int argc, char* argv[]) {
     rawRs->startAndPark([responder](auto& setup) { setup.createRSocket(responder); });
   });
 
-  // Wait for a newline on the console to terminate the server.
-  std::getchar();
-
-  rs->unpark();
   serverThread.join();
 
   return 0;


### PR DESCRIPTION
- Enable tck tests to run in travis builds
- Make the server terminate with signal (instead of stdin - which doesnt work well with background jobs)
- Reuse the same requester for all requests
