### PR TITLE
Internally create FramedConnection

### DIFF
--- a/src/ConnectionAcceptor.h
+++ b/src/ConnectionAcceptor.h
@@ -10,8 +10,10 @@
 
 namespace rsocket {
 
-using OnDuplexConnectionAccept = std::function<
-    void(std::unique_ptr<rsocket::DuplexConnection>, folly::EventBase&)>;
+using OnDuplexConnectionAccept = std::function<void(
+    std::unique_ptr<rsocket::DuplexConnection>,
+    bool framedConnection,
+    folly::EventBase&)>;
 
 /**
  * Common interface for a server that accepts connections and turns them into
@@ -61,4 +63,4 @@ class ConnectionAcceptor {
    */
   virtual folly::Optional<uint16_t> listeningPort() const = 0;
 };
-}
+} // namespace rsocket

--- a/src/ConnectionFactory.h
+++ b/src/ConnectionFactory.h
@@ -11,9 +11,10 @@ class EventBase;
 
 namespace rsocket {
 
-using OnDuplexConnectionConnect = folly::Function<
-    void(std::unique_ptr<rsocket::DuplexConnection>, bool framedConnection,
-         folly::EventBase&)>;
+using OnDuplexConnectionConnect = folly::Function<void(
+    std::unique_ptr<rsocket::DuplexConnection>,
+    bool framedConnection,
+    folly::EventBase&)>;
 
 /**
  * Common interface for a client to create connections and turn them into
@@ -44,4 +45,4 @@ class ConnectionFactory {
    */
   virtual void connect(OnDuplexConnectionConnect onConnect) = 0;
 };
-}
+} // namespace rsocket

--- a/src/ConnectionFactory.h
+++ b/src/ConnectionFactory.h
@@ -11,8 +11,9 @@ class EventBase;
 
 namespace rsocket {
 
-using OnConnect = folly::Function<
-    void(std::unique_ptr<rsocket::DuplexConnection>, folly::EventBase&)>;
+using OnDuplexConnectionConnect = folly::Function<
+    void(std::unique_ptr<rsocket::DuplexConnection>, bool framedConnection,
+         folly::EventBase&)>;
 
 /**
  * Common interface for a client to create connections and turn them into
@@ -41,6 +42,6 @@ class ConnectionFactory {
    *
    * Resource creation depends on the particular implementation.
    */
-  virtual void connect(OnConnect onConnect) = 0;
+  virtual void connect(OnDuplexConnectionConnect onConnect) = 0;
 };
 }

--- a/src/RSocketClient.cpp
+++ b/src/RSocketClient.cpp
@@ -4,10 +4,10 @@
 #include "src/RSocketRequester.h"
 #include "src/RSocketResponder.h"
 #include "src/RSocketStats.h"
-#include "src/internal/FollyKeepaliveTimer.h"
-#include "src/internal/RSocketConnectionManager.h"
 #include "src/framing/FrameTransport.h"
 #include "src/framing/FramedDuplexConnection.h"
+#include "src/internal/FollyKeepaliveTimer.h"
+#include "src/internal/RSocketConnectionManager.h"
 
 using namespace folly;
 
@@ -42,20 +42,18 @@ folly::Future<std::unique_ptr<RSocketRequester>> RSocketClient::connect(
     keepaliveTimer = std::move(keepaliveTimer),
     stats = std::move(stats),
     networkStats = std::move(networkStats),
-    promise = std::move(promise)](
-      std::unique_ptr<DuplexConnection> connection,
-      bool isFramedConnection,
-      folly::EventBase& eventBase) mutable {
+    promise = std::move(promise)
+  ](std::unique_ptr<DuplexConnection> connection,
+    bool isFramedConnection,
+    folly::EventBase& eventBase) mutable {
     VLOG(3) << "onConnect received DuplexConnection";
 
     std::unique_ptr<DuplexConnection> framedConnection;
-    if(isFramedConnection) {
+    if (isFramedConnection) {
       framedConnection = std::move(connection);
     } else {
       framedConnection = std::make_unique<FramedDuplexConnection>(
-          std::move(connection),
-          setupParameters.protocolVersion,
-          eventBase);
+          std::move(connection), setupParameters.protocolVersion, eventBase);
     }
 
     auto rsocket = fromConnection(
@@ -109,4 +107,4 @@ std::unique_ptr<RSocketRequester> RSocketClient::fromConnection(
   return std::make_unique<RSocketRequester>(std::move(rs), eventBase);
 }
 
-}
+} // namespace rsocket

--- a/src/RSocketClient.h
+++ b/src/RSocketClient.h
@@ -54,6 +54,7 @@ class RSocketClient {
 
   std::unique_ptr<RSocketRequester> fromConnection(
       std::unique_ptr<DuplexConnection> connection,
+      bool isFramedConnection,
       folly::EventBase& eventBase,
       SetupParameters setupParameters = SetupParameters(),
       std::shared_ptr<RSocketResponder> responder = std::shared_ptr<RSocketResponder>(),

--- a/src/framing/FramedDuplexConnection.cpp
+++ b/src/framing/FramedDuplexConnection.cpp
@@ -9,14 +9,6 @@ namespace rsocket {
 
 FramedDuplexConnection::FramedDuplexConnection(
     std::unique_ptr<DuplexConnection> connection,
-    folly::Executor& executor)
-    : FramedDuplexConnection(
-          std::move(connection),
-          FrameSerializer::getCurrentProtocolVersion(),
-          executor) {}
-
-FramedDuplexConnection::FramedDuplexConnection(
-    std::unique_ptr<DuplexConnection> connection,
     ProtocolVersion protocolVersion,
     folly::Executor& executor)
     : connection_(std::move(connection)),

--- a/src/framing/FramedDuplexConnection.h
+++ b/src/framing/FramedDuplexConnection.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <src/RSocketStats.h>
 #include <src/temporary_home/Executor.h>
 #include "src/DuplexConnection.h"
 #include "src/internal/Common.h"
@@ -15,10 +14,6 @@ struct ProtocolVersion;
 
 class FramedDuplexConnection : public virtual DuplexConnection {
  public:
-  // TODO: remove this ctor overload
-  FramedDuplexConnection(
-      std::unique_ptr<DuplexConnection> connection,
-      folly::Executor& executor);
   FramedDuplexConnection(
       std::unique_ptr<DuplexConnection> connection,
       ProtocolVersion protocolVersion,

--- a/src/transports/tcp/TcpConnectionAcceptor.cpp
+++ b/src/transports/tcp/TcpConnectionAcceptor.cpp
@@ -26,10 +26,8 @@ class TcpConnectionAcceptor::SocketCallback
 
     auto connection = std::make_unique<TcpDuplexConnection>(
         std::move(socket), inlineExecutor());
-    auto framedConnection = std::make_unique<FramedDuplexConnection>(
-        std::move(connection), ProtocolVersion::Unknown, inlineExecutor());
 
-    onAccept_(std::move(framedConnection), *eventBase());
+    onAccept_(std::move(connection), false, *eventBase());
   }
 
   void acceptError(const std::exception& ex) noexcept override {

--- a/src/transports/tcp/TcpConnectionFactory.cpp
+++ b/src/transports/tcp/TcpConnectionFactory.cpp
@@ -5,8 +5,6 @@
 #include <folly/io/async/AsyncSocket.h>
 #include <folly/io/async/EventBaseManager.h>
 #include <glog/logging.h>
-
-#include "src/framing/FramedDuplexConnection.h"
 #include "src/transports/tcp/TcpDuplexConnection.h"
 
 using namespace rsocket;
@@ -17,7 +15,7 @@ namespace {
 
 class ConnectCallback : public folly::AsyncSocket::ConnectCallback {
  public:
-  ConnectCallback(folly::SocketAddress address, OnConnect onConnect)
+  ConnectCallback(folly::SocketAddress address, OnDuplexConnectionConnect onConnect)
       : address_(address), onConnect_{std::move(onConnect)} {
     VLOG(2) << "Constructing ConnectCallback";
 
@@ -44,9 +42,10 @@ class ConnectCallback : public folly::AsyncSocket::ConnectCallback {
 
     VLOG(4) << "connectSuccess() on " << address_;
 
-    auto connection = TcpConnectionFactory::createDuplexConnectionFromSocket(
+    auto connection = std::make_unique<TcpDuplexConnection>(
         std::move(socket_), *evb, RSocketStats::noop());
-    onConnect_(std::move(connection), *evb);
+
+    onConnect_(std::move(connection), false, *evb);
   }
 
   void connectErr(const folly::AsyncSocketException& ex) noexcept override {
@@ -58,7 +57,7 @@ class ConnectCallback : public folly::AsyncSocket::ConnectCallback {
  private:
   folly::SocketAddress address_;
   folly::AsyncSocket::UniquePtr socket_;
-  OnConnect onConnect_;
+  OnDuplexConnectionConnect onConnect_;
 };
 
 } // namespace
@@ -72,27 +71,11 @@ TcpConnectionFactory::~TcpConnectionFactory() {
   VLOG(1) << "Destroying TcpConnectionFactory";
 }
 
-void TcpConnectionFactory::connect(OnConnect cb) {
+void TcpConnectionFactory::connect(OnDuplexConnectionConnect cb) {
   worker_.getEventBase()->runInEventBaseThread(
       [ this, fn = std::move(cb) ]() mutable {
         new ConnectCallback(address_, std::move(fn));
       });
-}
-
-std::unique_ptr<DuplexConnection>
-TcpConnectionFactory::createDuplexConnectionFromSocket(
-    folly::AsyncSocket::UniquePtr socket,
-    folly::EventBase& eventBase,
-    std::shared_ptr<RSocketStats> stats) {
-  if (!stats) {
-    stats = RSocketStats::noop();
-  }
-
-  auto connection = std::make_unique<TcpDuplexConnection>(
-      std::move(socket), eventBase, RSocketStats::noop());
-  auto framedConnection = std::make_unique<FramedDuplexConnection>(
-      std::move(connection), eventBase);
-  return std::move(framedConnection);
 }
 
 } // namespace rsocket

--- a/src/transports/tcp/TcpConnectionFactory.cpp
+++ b/src/transports/tcp/TcpConnectionFactory.cpp
@@ -15,7 +15,9 @@ namespace {
 
 class ConnectCallback : public folly::AsyncSocket::ConnectCallback {
  public:
-  ConnectCallback(folly::SocketAddress address, OnDuplexConnectionConnect onConnect)
+  ConnectCallback(
+      folly::SocketAddress address,
+      OnDuplexConnectionConnect onConnect)
       : address_(address), onConnect_{std::move(onConnect)} {
     VLOG(2) << "Constructing ConnectCallback";
 
@@ -76,6 +78,14 @@ void TcpConnectionFactory::connect(OnDuplexConnectionConnect cb) {
       [ this, fn = std::move(cb) ]() mutable {
         new ConnectCallback(address_, std::move(fn));
       });
+}
+
+std::unique_ptr<DuplexConnection>
+TcpConnectionFactory::createDuplexConnectionFromSocket(
+    folly::AsyncSocket::UniquePtr socket,
+    folly::EventBase& eventBase,
+    std::shared_ptr<RSocketStats> stats) {
+  return std::make_unique<TcpDuplexConnection>(std::move(socket), eventBase, std::move(stats));
 }
 
 } // namespace rsocket

--- a/src/transports/tcp/TcpConnectionFactory.h
+++ b/src/transports/tcp/TcpConnectionFactory.h
@@ -27,12 +27,7 @@ class TcpConnectionFactory : public ConnectionFactory {
    *
    * Each call to connect() creates a new AsyncSocket.
    */
-  void connect(OnConnect) override;
-
-  static std::unique_ptr<DuplexConnection> createDuplexConnectionFromSocket(
-      folly::AsyncSocket::UniquePtr socket,
-      folly::EventBase& eventBase,
-      std::shared_ptr<RSocketStats> stats = std::shared_ptr<RSocketStats>());
+  void connect(OnDuplexConnectionConnect) override;
 
  private:
   folly::SocketAddress address_;

--- a/src/transports/tcp/TcpConnectionFactory.h
+++ b/src/transports/tcp/TcpConnectionFactory.h
@@ -29,8 +29,13 @@ class TcpConnectionFactory : public ConnectionFactory {
    */
   void connect(OnDuplexConnectionConnect) override;
 
+  static std::unique_ptr<DuplexConnection> createDuplexConnectionFromSocket(
+      folly::AsyncSocket::UniquePtr socket,
+      folly::EventBase& eventBase,
+      std::shared_ptr<RSocketStats> stats = std::shared_ptr<RSocketStats>());
+
  private:
   folly::SocketAddress address_;
   folly::ScopedEventBaseThread worker_;
 };
-}
+} // namespace rsocket


### PR DESCRIPTION
As @lehecka suggested, I am splitting this PR into two: https://github.com/rsocket/rsocket-cpp/pull/509/files/e1ad97fa94dee680066277f3c78ca1798e591155#diff-f99ef4eeb8d8c84cdd6b217134f898e8 

Make FramedDuplexConnection an internal type which would not be used by the application code or implementors of DuplexConnection interface. Instead they will provide a boolean parameter to RSocketClient/RSocketServer whether the connection is framed or not (so far all implementations we have are not framed). Internally create FramedConnection.

The main motivator for this change is to avoid application code to specify protocol version for FramedDuplexConnection.
cc: Manikandan Somasundaram, Ondrej Lehecka