### PR TITLE
Try upgrading clang to 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,20 @@ language: cpp
 matrix:
 
    include:
-    - env: CLANG_VERSION=3.9 BUILD_TYPE=Debug CPP_VERSION=14 ASAN=On
+    - env: CLANG_VERSION=4.0 BUILD_TYPE=Debug CPP_VERSION=14 ASAN=On
       os: linux
-      addons: &clang39
+      addons:
         apt:
           packages:
-            - clang-3.9
+            - clang-4.0
             - valgrind
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.9
+            - llvm-toolchain-trusty-4.0
 
     - env: GCC_VERSION=4.9 BUILD_TYPE=Debug CPP_VERSION=14 ASAN=On
       os: linux
-      addons: &gcc49
+      addons:
         apt:
           packages:
             - g++-4.9
@@ -32,7 +32,7 @@ matrix:
 
     - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP_VERSION=14 ASAN=On
       os: linux
-      addons: &gcc5
+      addons:
         apt:
           packages:
             - g++-5
@@ -42,7 +42,7 @@ matrix:
 
     - env: GCC_VERSION=6 BUILD_TYPE=Debug CPP_VERSION=14 ASAN=On
       os: linux
-      addons: &gcc6
+      addons:
         apt:
           packages:
             - g++-6


### PR DESCRIPTION
Been getting strange linker errors from clang-3.9, want to see if clang-4.0
exists and if it is any better.  Switch the toolchain to trusty, to match the
distribution we're using.

Delete unused (Are they used?  I don't know yaml...) yaml anchors.