### PR TITLE
Disallow failures on clang build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,6 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-   allow_failures:
-      - env: *clang_build
-
 
 before_script:
   - ./scripts/build_folly.sh


### PR DESCRIPTION
Clang build has been fixed in #526, so we no longer need `allow_failures`.