### PR TITLE
Add Mocks for Flowable, Subscription and Subscriber

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,8 @@ add_executable(
   test/RequestResponseTest.cpp
   test/RequestStreamTest.cpp
   test/RequestChannelTest.cpp
+  test/test_utils/Mocks.h
+  test/MocksTest.cpp
 )
 
 target_link_libraries(

--- a/test/MocksTest.cpp
+++ b/test/MocksTest.cpp
@@ -1,0 +1,45 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "test/test_utils/Mocks.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+using namespace rsocket;
+using namespace yarpl::flowable;
+
+TEST(MocksTest, SelfManagedMocks) {
+  // Best run with ASAN, to detect potential leaks, use-after-free or
+  // double-free bugs.
+  int value = 42;
+
+  MockFlowable<int> flowable;
+  auto subscription = yarpl::make_ref<MockSubscription>();
+  auto subscriber = yarpl::make_ref<MockSubscriber<int>>();
+  {
+    InSequence dummy;
+    EXPECT_CALL(flowable, subscribe_(_))
+        .WillOnce(Invoke([&](yarpl::Reference<Subscriber<int>> consumer) {
+          consumer->onSubscribe(subscription);
+        }));
+    EXPECT_CALL(*subscriber, onSubscribe_(_));
+    EXPECT_CALL(*subscription, request_(1));
+    EXPECT_CALL(*subscription, cancel_()).WillOnce(Invoke([&]() {
+      // We must have received Subscription::request(1), hence we can
+      // deliver one element, despite Subscription::cancel() has been
+      // called.
+      subscriber->onNext(value);
+      // This Publisher never spontaneously terminates the subscription,
+      // hence we can respond with onComplete unconditionally.
+      subscriber->onComplete();
+      subscriber = nullptr;
+    }));
+    EXPECT_CALL(*subscriber, onNext_(value));
+    EXPECT_CALL(*subscriber, onComplete_());
+  }
+  flowable.subscribe(subscriber);
+  subscription->request(1);
+  subscription->cancel();
+  subscription = nullptr;
+}

--- a/test/test_utils/Mocks.h
+++ b/test/test_utils/Mocks.h
@@ -1,0 +1,100 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <cassert>
+#include <exception>
+
+#include <gmock/gmock.h>
+
+#include "yarpl/flowable/Flowable.h"
+
+namespace rsocket {
+
+using namespace yarpl::flowable;
+
+/// GoogleMock-compatible Publisher implementation for fast prototyping.
+/// UnmanagedMockPublisher's lifetime MUST be managed externally.
+template <typename T>
+class MockFlowable : public Flowable<T> {
+ public:
+  MOCK_METHOD1_T(subscribe_, void(yarpl::Reference<Subscriber<T>> subscriber));
+
+  void subscribe(yarpl::Reference<Subscriber<T>> subscriber) noexcept override {
+    subscribe_(std::move(subscriber));
+  }
+};
+
+/// GoogleMock-compatible Subscriber implementation for fast prototyping.
+/// MockSubscriber MUST be heap-allocated, as it manages its own lifetime.
+/// For the same reason putting mock instance in a smart pointer is a poor idea.
+/// Can only be instanciated for CopyAssignable E type.
+template <typename T>
+class MockSubscriber : public Subscriber<T> {
+ public:
+  MOCK_METHOD1(onSubscribe_, void(yarpl::Reference<Subscription> subscription));
+  MOCK_METHOD1_T(onNext_, void(T& value));
+  MOCK_METHOD0(onComplete_, void());
+  MOCK_METHOD1_T(onError_, void(const std::exception_ptr ex));
+
+  void onSubscribe(
+      yarpl::Reference<Subscription> subscription) override {
+    subscription_ = subscription;
+    // We allow registering the same subscriber with multiple Publishers.
+    EXPECT_CALL(checkpoint_, Call());
+    onSubscribe_(subscription);
+  }
+
+  void onNext(T element) override {
+    onNext_(element);
+  }
+
+  void onComplete() override {
+    onComplete_();
+    checkpoint_.Call();
+    subscription_ = nullptr;
+  }
+
+  void onError(const std::exception_ptr ex) override {
+    onError_(ex);
+    checkpoint_.Call();
+    subscription_ = nullptr;
+  }
+
+  Subscription* subscription() const {
+    return subscription_.get();
+  }
+
+ private:
+  yarpl::Reference<Subscription> subscription_;
+  testing::MockFunction<void()> checkpoint_;
+};
+
+/// GoogleMock-compatible Subscriber implementation for fast prototyping.
+/// MockSubscriber MUST be heap-allocated, as it manages its own lifetime.
+/// For the same reason putting mock instance in a smart pointer is a poor idea.
+class MockSubscription : public Subscription {
+ public:
+  MOCK_METHOD1(request_, void(int64_t n));
+  MOCK_METHOD0(cancel_, void());
+
+  void request(int64_t n) override {
+    if (!requested_) {
+      requested_ = true;
+      EXPECT_CALL(checkpoint_, Call()).Times(1);
+    }
+
+    request_(n);
+  }
+
+  void cancel() override {
+    cancel_();
+    checkpoint_.Call();
+  }
+
+ private:
+  bool requested_{false};
+  testing::MockFunction<void()> checkpoint_;
+};
+
+} // namespace rsocket


### PR DESCRIPTION
Mainly copied from reactivesocket.

I am going to use these Mock objects in the unittests that I am writing. 

      auto subscription = yarpl::make_ref<MockSubcription>();
      output->onSubscribe(subscription);
      EXPECT_CALL(*subscription, request_(1));
