### PR TITLE
Use container-based Travis infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,56 +1,84 @@
-# inspired by https://github.com/ericniebler/meta/blob/master/.travis.yml
+# Travis CI config for rsocket-cpp.
 
-sudo: required
+sudo: false
 dist: trusty
 
 language: cpp
 
-# Test matrix:
-matrix:
+os: linux
 
+addons:
+  apt:
+    sources: &common_srcs
+      - ubuntu-toolchain-r-test
+    packages: &common_deps
+      - lcov
+      - valgrind
+      # Folly dependencies
+      - autoconf
+      - autoconf-archive
+      - automake
+      - binutils-dev
+      - g++
+      - libboost-all-dev
+      - libdouble-conversion-dev
+      - libevent-dev
+      - libgflags-dev
+      - libgoogle-glog-dev
+      - libiberty-dev
+      - libjemalloc-dev
+      - liblz4-dev
+      - liblzma-dev
+      - libsnappy-dev
+      - libssl-dev
+      - libtool
+      - make
+      - pkg-config
+      - zlib1g-dev
+
+matrix:
    include:
-    - env: &clang_build CLANG_VERSION=4.0 BUILD_TYPE=Debug CPP_VERSION=14 ASAN=On
-      os: linux
+    - env: CLANG_VERSION=4.0 BUILD_TYPE=Debug CPP_VERSION=14 ASAN=On
       addons:
         apt:
+          sources:
+            - *common_srcs
+            - llvm-toolchain-trusty-4.0
           packages:
+            - *common_deps
             - clang-4.0
             - libstdc++-4.9-dev
-            - valgrind
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-4.0
 
     - env: GCC_VERSION=4.9 BUILD_TYPE=Debug CPP_VERSION=14 ASAN=On
-      os: linux
       addons:
         apt:
-          packages:
-            - g++-4.9
-            - valgrind
           sources:
-            - ubuntu-toolchain-r-test
+            - *common_srcs
+          packages:
+            - *common_deps
+            - g++-4.9
 
     - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP_VERSION=14 ASAN=On
-      os: linux
       addons:
         apt:
-          packages:
-            - g++-5
-            - valgrind
           sources:
-            - ubuntu-toolchain-r-test
+            - *common_srcs
+          packages:
+            - *common_deps
+            - g++-5
 
     - env: GCC_VERSION=6 BUILD_TYPE=Debug CPP_VERSION=14 ASAN=On
-      os: linux
       addons:
         apt:
-          packages:
-            - g++-6
-            - valgrind
           sources:
-            - ubuntu-toolchain-r-test
+            - *common_srcs
+          packages:
+            - *common_deps
+            - g++-6
 
+cache:
+  directories:
+    - $HOME/folly
 
 before_script:
   - ./scripts/build_folly.sh
@@ -60,14 +88,9 @@ before_script:
   - which $CC
   - which valgrind
   - $CXX --version
-  # install latest LCOV (1.9 was failing for me) [1]
-  - wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz
-  - tar xf lcov_1.11.orig.tar.gz
-  - sudo make -C lcov-1.11/ install
   # install lcov to coveralls conversion + upload tool
   - gem install coveralls-lcov
   - lcov --directory . --zerocounters
-
 
 script:
   - mkdir -p build
@@ -77,7 +100,7 @@ script:
   - if [ -n "$GCC_VERSION" -a "$ASAN" == "On" ]; then echo "turning on ASAN sanitize=address,undefined"; fi
   - if [ -n "$GCC_VERSION" -a "$ASAN" == "On" ]; then CXX_FLAGS="${CXX_FLAGS} -fsanitize=address,undefined -fuse-ld=gold"; fi
   - if [ -n "$GCC_VERSION" ]; then CXX_FLAGS="${CXX_FLAGS} --coverage"; fi # enable code coverage on GCC builds
-  - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCMAKE_EXE_LINKER_FLAGS="${CXX_LINKER_FLAGS}" -DMETA_CXX_STD=$CPP_VERSION
+  - cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DMETA_CXX_STD=$CPP_VERSION -DFOLLY_INSTALL_DIR=$HOME/folly
   - make -j8 VERBOSE=1
   - ./tests
   - ./yarpl/yarpl-tests

--- a/cmake/FindFolly.cmake
+++ b/cmake/FindFolly.cmake
@@ -2,10 +2,15 @@ cmake_minimum_required(VERSION 3.2)
 
 include(FindPackageHandleStandardArgs)
 
-find_library(FOLLY_LIBRARY folly PATHS ${FOLLY_LIBRARYDIR})
-find_path(FOLLY_INCLUDE_DIR "folly/String.h" PATHS ${FOLLY_INCLUDEDIR})
+if (FOLLY_INSTALL_DIR)
+  set(lib_paths ${FOLLY_INSTALL_DIR}/lib)
+  set(include_paths ${FOLLY_INSTALL_DIR}/include)
+endif ()
+
+find_library(FOLLY_LIBRARY folly PATHS ${lib_paths})
+find_path(FOLLY_INCLUDE_DIR "folly/String.h" PATHS ${include_paths})
 
 set(FOLLY_LIBRARIES ${FOLLY_LIBRARY})
 
 find_package_handle_standard_args(Folly
-  REQUIRED_ARGS FOLLY_INCLUDE_DIR FOLLY_LIBRARIES)
+  DEFAULT_MSG FOLLY_LIBRARY FOLLY_INCLUDE_DIR)

--- a/scripts/Vagrantfile
+++ b/scripts/Vagrantfile
@@ -7,15 +7,15 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
 
   config.vm.provider "virtualbox" do |vb|
-    # Need more than 512MB to compile folly.
-    vb.memory = "1024"
+    # Need more than 2048 MiB to compile folly.
+    vb.memory = "4096"
   end
 
   config.vm.provision "shell", inline: <<-SHELL
     apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
     apt-get update
     apt-get -y install \
-      autoconf autoconf-archive automake binutils-dev g++-4.9 git lcov \
+      autoconf autoconf-archive automake binutils-dev cmake3 g++-4.9 git lcov \
       libboost-all-dev  libdouble-conversion-dev libevent-dev libgflags-dev \
       libgoogle-glog-dev libiberty-dev libjemalloc-dev liblz4-dev liblzma-dev \
       libsnappy-dev libssl-dev libtool make pkg-config valgrind zlib1g-dev

--- a/scripts/build_folly.sh
+++ b/scripts/build_folly.sh
@@ -1,26 +1,10 @@
-if [ -z "$OSX_LOCAL" ]; then
-  # libs required for Folly
-  sudo apt-get -y install \
-      g++ \
-      automake \
-      autoconf \
-      autoconf-archive \
-      libtool \
-      libboost-all-dev \
-      libevent-dev \
-      libdouble-conversion-dev \
-      libgoogle-glog-dev \
-      libgflags-dev \
-      liblz4-dev \
-      liblzma-dev \
-      libsnappy-dev \
-      make \
-      zlib1g-dev \
-      binutils-dev \
-      libjemalloc-dev \
-      libssl-dev \
-      libiberty-dev
-else
+install_dir=$HOME/folly
+if [ -d "$install_dir/include" ]; then
+  echo "Using cache $install_dir"
+  exit 0
+fi
+
+if [ -n "$OSX_LOCAL" ]; then
   export CPPFLAGS="-I/usr/local/opt/openssl/include"
   export LDFLAGS="-L/usr/local/opt/openssl/lib"
 fi
@@ -60,9 +44,9 @@ folly_compile=`cat <<EOF
 mv ../*googletest* folly/test/gtest \
 && cd folly \
 && autoreconf -ivf \
-&& ./configure \
+&& ./configure --prefix=$install_dir \
 && make -j 4 \
-&& sudo make install \\
+&& make install \\
 )
 EOF
 `


### PR DESCRIPTION
This PR migrates the Travis config from legacy to [container-based infrastructure](https://docs.travis-ci.com/user/migrating-from-legacy/) and caches built folly binaries giving almost 4x build speed up (from ~16 min to ~4 min).

Before:
<img width="876" alt="screenshot 2017-06-19 18 33 19 1" src="https://user-images.githubusercontent.com/576385/27312803-8375d7fe-551f-11e7-90c8-18f532e9a683.png">

After:
<img width="863" alt="screenshot 2017-06-19 18 40 48" src="https://user-images.githubusercontent.com/576385/27312835-ab47367e-551f-11e7-9f6a-7bb1d0a6eb6f.png">

Other improvements:
* Cleaned up and reduced duplication in `.travis.yml`.
* Corrected memory requirements in `Vagrantfile`.
* Replaced `FOLLY_LIBRARYDIR` and `FOLLY_INCLUDEDIR` with a single `FOLLY_INSTALL_DIR` CMake variable.
