### PR TITLE
testing group:edge in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 
 sudo: false
 dist: trusty
+group: edge
 
 language: cpp
 


### PR DESCRIPTION
"PSA: Updates are coming to our sudo-enabled Trusty images! You can add group: edge to your .travis.yml file to test them out in advance. Stay tuned for a blog post with more details. "
No urgency to land, just testing as I got a travis CI popup
