### PR TITLE
Use folly::humanify to eliminate unprintable characters to dirty the logs

### DIFF
--- a/src/Payload.cpp
+++ b/src/Payload.cpp
@@ -24,30 +24,27 @@ void Payload::checkFlags(FrameFlags flags) const {
 }
 
 std::ostream& operator<<(std::ostream& os, const Payload& payload) {
-  return os << "[Metadata("
+  return os << "Metadata("
             << (payload.metadata
                     ? folly::to<std::string>(
                           payload.metadata->computeChainDataLength())
                     : "0")
-            << (payload.metadata ? "): '" +
-                        payload.metadata->cloneAsValue()
-                            .moveToFbString()
-                            .substr(0, 40)
-                            .toStdString() +
+            << (payload.metadata
+                    ? "): '" +
+                        folly::humanify(
+                            payload.metadata->cloneAsValue().moveToFbString().substr(0, 80)) +
                         "'"
-                                 : "): <nullptr>")
+                    : "): <null>")
             << ", Data("
             << (payload.data ? folly::to<std::string>(
                                    payload.data->computeChainDataLength())
                              : "0")
-            << (payload.data ? "): '" +
-                        payload.data->cloneAsValue()
-                            .moveToFbString()
-                            .substr(0, 40)
-                            .toStdString() +
+            << (payload.data
+                    ? "): '" +
+                        folly::humanify(
+                            payload.data->cloneAsValue().moveToFbString().substr(0, 80)) +
                         "'"
-                             : "): <nullptr>")
-            << "]";
+                    : "): <null>");
 }
 
 std::string Payload::moveDataToString() {

--- a/src/framing/Frame.cpp
+++ b/src/framing/Frame.cpp
@@ -209,7 +209,7 @@ Frame_PAYLOAD Frame_PAYLOAD::complete(StreamId streamId) {
 }
 
 std::ostream& operator<<(std::ostream& os, const Frame_PAYLOAD& frame) {
-  return os << frame.header_ << ", (" << frame.payload_;
+  return os << frame.header_ << ", " << frame.payload_;
 }
 
 Frame_ERROR Frame_ERROR::unexpectedFrame() {
@@ -255,7 +255,7 @@ std::ostream& operator<<(std::ostream& os, const Frame_KEEPALIVE& frame) {
 
 std::ostream& operator<<(std::ostream& os, const Frame_SETUP& frame) {
   return os << frame.header_ << ", Version: " << frame.versionMajor_ << "."
-            << frame.versionMinor_ << ", (" << frame.payload_;
+            << frame.versionMinor_ << ", " << frame.payload_;
 }
 
 void Frame_SETUP::moveToSetupPayload(SetupParameters& setupPayload) {


### PR DESCRIPTION
It might be annoying for terminal output when payloads contain binary. Have you considered hex formatting or filtering unprintable characters?

This update tries to use folly::humanify function to eliminate publishing unprintable characters.
