### PR TITLE
Fix RSocketClientServer.ConnectManyAsync test

### DIFF
--- a/test/RSocketClientServerTest.cpp
+++ b/test/RSocketClientServerTest.cpp
@@ -29,16 +29,17 @@ TEST(RSocketClientServer, ConnectManySync) {
   }
 }
 
-// TODO: Investigate why this hangs (even with i < 2).
-TEST(RSocketClientServer, DISABLED_ConnectManyAsync) {
+TEST(RSocketClientServer, ConnectManyAsync) {
   auto server = makeServer(std::make_shared<HelloStreamRequestHandler>());
 
+  std::vector<std::unique_ptr<RSocketClient>> clients;
   std::vector<folly::Future<folly::Unit>> futures;
 
   for (size_t i = 0; i < 100; ++i) {
     auto client = makeClient(*server->listeningPort());
     auto requester = client->connect();
 
+    clients.push_back(std::move(client));
     futures.push_back(requester.unit());
   }
 


### PR DESCRIPTION
It would create a vector of RSocketRequester futures, but destroy the clients
they were bound to.  As such the clients would get destructed before they could
fulfill any of the requesters.