### PR TITLE
Fix mishandling future in TcpConnectionAcceptor::start()

### DIFF
--- a/src/transports/tcp/TcpConnectionAcceptor.cpp
+++ b/src/transports/tcp/TcpConnectionAcceptor.cpp
@@ -86,7 +86,7 @@ folly::Future<folly::Unit> TcpConnectionAcceptor::start(
   serverSocket_.reset(
       new folly::AsyncServerSocket(serverThread_->getEventBase()));
 
-  serverThread_->getEventBase()->runInEventBaseThread([this] {
+  return via(serverThread_->getEventBase()).then([this] {
     folly::SocketAddress addr;
     addr.setFromLocalPort(options_.port);
 
@@ -102,9 +102,9 @@ folly::Future<folly::Unit> TcpConnectionAcceptor::start(
     for (auto& i : serverSocket_->getAddresses()) {
       LOG(INFO) << "Listening on " << i.describe();
     }
-  });
 
-  return folly::unit;
+    return folly::unit;
+  });
 }
 
 void TcpConnectionAcceptor::stop() {

--- a/test/RSocketClientServerTest.cpp
+++ b/test/RSocketClientServerTest.cpp
@@ -14,6 +14,20 @@ TEST(RSocketClientServer, StartAndShutdown) {
   makeClient(randPort());
 }
 
+TEST(RSocketClientServer, ServerPortCollision) {
+  auto const port = randPort();
+  auto responder = std::make_shared<HelloStreamRequestHandler>();
+
+  try {
+    auto server1 = makeServer(port, responder);
+    auto server2 = makeServer(port, responder);
+  } catch (const std::exception& exn) {
+    return;
+  }
+
+  FAIL() << "Expected port collision";
+}
+
 TEST(RSocketClientServer, ConnectOne) {
   auto const port = randPort();
   auto server = makeServer(port, std::make_shared<HelloStreamRequestHandler>());


### PR DESCRIPTION
It's supposed to return a future that will be fulfilled once the acceptor is
done initializing.  However what we're doing instead is making a manual call to
runInEventBaseThread() and then returning folly::unit synchronously.

Use via() to tie the asynchronous runInEventBaseThread() to the return future
value.  Also add a test for port collision to vet that we can guarantee we hit
it with two servers on the same port, without racing on when the acceptors
actually initialize.