### PR TITLE
Delete all remaining uses of folly::MoveWrapper

### DIFF
--- a/src/statemachine/RSocketStateMachine.cpp
+++ b/src/statemachine/RSocketStateMachine.cpp
@@ -3,7 +3,6 @@
 #include "RSocketStateMachine.h"
 
 #include <folly/ExceptionWrapper.h>
-#include <folly/MoveWrapper.h>
 #include <folly/Optional.h>
 #include <folly/String.h>
 #include <folly/io/async/EventBase.h>
@@ -410,9 +409,8 @@ void RSocketStateMachine::processFrameImpl(
 
 void RSocketStateMachine::onTerminal(folly::exception_wrapper ex) {
   auto thisPtr = this->shared_from_this();
-  auto movedEx = folly::makeMoveWrapper(ex);
-  runInExecutor([thisPtr, movedEx]() mutable {
-    thisPtr->onTerminalImpl(movedEx.move());
+  runInExecutor([ thisPtr, e = std::move(ex) ]() mutable {
+    thisPtr->onTerminalImpl(std::move(e));
   });
 }
 

--- a/src/statemachine/RequestResponseRequester.cpp
+++ b/src/statemachine/RequestResponseRequester.cpp
@@ -2,7 +2,6 @@
 
 #include "src/statemachine/RequestResponseRequester.h"
 #include <folly/ExceptionWrapper.h>
-#include <folly/MoveWrapper.h>
 #include "RSocketStateMachine.h"
 #include "src/internal/Common.h"
 

--- a/src/statemachine/StreamRequester.cpp
+++ b/src/statemachine/StreamRequester.cpp
@@ -1,7 +1,6 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "src/statemachine/StreamRequester.h"
-#include <folly/MoveWrapper.h>
 
 namespace rsocket {
 


### PR DESCRIPTION
I think these were purged before, but it seems a few stragglers still held on.