### PR TITLE
Removing unused named parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ endif()
 # Common configuration for all build modes.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${META_CXX_STD} -pedantic")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter -Woverloaded-virtual")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual")
 
 set(EXTRA_CXX_FLAGS ${EXTRA_CXX_FLAGS} -Werror)
 

--- a/examples/channel-hello-world/ChannelHelloWorld_Server.cpp
+++ b/examples/channel-hello-world/ChannelHelloWorld_Server.cpp
@@ -21,7 +21,7 @@ class HelloChannelRequestResponder : public rsocket::RSocketResponder {
   yarpl::Reference<Flowable<rsocket::Payload>> handleRequestChannel(
       rsocket::Payload initialPayload,
       yarpl::Reference<Flowable<rsocket::Payload>> request,
-      rsocket::StreamId streamId) override {
+      rsocket::StreamId) override {
     std::cout << "Initial request " << initialPayload.cloneDataToString()
               << std::endl;
 

--- a/examples/conditional-request-handling/JsonRequestHandler.cpp
+++ b/examples/conditional-request-handling/JsonRequestHandler.cpp
@@ -9,7 +9,7 @@ using namespace yarpl::flowable;
 
 /// Handles a new inbound Stream requested by the other end.
 yarpl::Reference<Flowable<rsocket::Payload>>
-JsonRequestResponder::handleRequestStream(Payload request, StreamId streamId) {
+JsonRequestResponder::handleRequestStream(Payload request, StreamId) {
   LOG(INFO) << "JsonRequestResponder.handleRequestStream " << request;
 
   // string from payload data

--- a/examples/conditional-request-handling/TextRequestHandler.cpp
+++ b/examples/conditional-request-handling/TextRequestHandler.cpp
@@ -9,7 +9,7 @@ using namespace yarpl::flowable;
 
 /// Handles a new inbound Stream requested by the other end.
 yarpl::Reference<Flowable<rsocket::Payload>>
-TextRequestResponder::handleRequestStream(Payload request, StreamId streamId) {
+TextRequestResponder::handleRequestStream(Payload request, StreamId) {
   LOG(INFO) << "TextRequestResponder.handleRequestStream " << request;
 
   // string from payload data

--- a/examples/fire-and-forget-hello-world/FireAndForgetHelloWorld_Server.cpp
+++ b/examples/fire-and-forget-hello-world/FireAndForgetHelloWorld_Server.cpp
@@ -18,7 +18,7 @@ DEFINE_int32(port, 9898, "port to connect to");
 
 class HelloFireAndForgetRequestResponder : public rsocket::RSocketResponder {
  public:
-  void handleFireAndForget(Payload request, StreamId streamId) override {
+  void handleFireAndForget(Payload request, StreamId) override {
     std::cout << "Received fireAndForget: " << request.moveDataToString()
               << std::endl;
   }

--- a/examples/request-response-hello-world/RequestResponseHelloWorld_Server.cpp
+++ b/examples/request-response-hello-world/RequestResponseHelloWorld_Server.cpp
@@ -18,9 +18,8 @@ DEFINE_int32(port, 9898, "port to connect to");
 
 class HelloRequestResponseRequestResponder : public rsocket::RSocketResponder {
  public:
-  Reference<Single<Payload>> handleRequestResponse(
-      Payload request,
-      StreamId streamId) override {
+  Reference<Single<Payload>> handleRequestResponse(Payload request, StreamId)
+      override {
     std::cout << "HelloRequestResponseRequestResponder.handleRequestResponse "
               << request << std::endl;
 

--- a/examples/stream-hello-world/StreamHelloWorld_Server.cpp
+++ b/examples/stream-hello-world/StreamHelloWorld_Server.cpp
@@ -20,7 +20,7 @@ class HelloStreamRequestResponder : public rsocket::RSocketResponder {
   /// Handles a new inbound Stream requested by the other end.
   yarpl::Reference<Flowable<rsocket::Payload>> handleRequestStream(
       rsocket::Payload request,
-      rsocket::StreamId streamId) override {
+      rsocket::StreamId) override {
     std::cout << "HelloStreamRequestResponder.handleRequestStream " << request
               << std::endl;
 

--- a/examples/stream-observable-to-flowable/StreamObservableToFlowable_Server.cpp
+++ b/examples/stream-observable-to-flowable/StreamObservableToFlowable_Server.cpp
@@ -24,7 +24,7 @@ class PushStreamRequestResponder : public rsocket::RSocketResponder {
   /// Handles a new inbound Stream requested by the other end.
   yarpl::Reference<Flowable<Payload>> handleRequestStream(
       Payload request,
-      rsocket::StreamId streamId) override {
+      rsocket::StreamId) override {
     std::cout << "PushStreamRequestResponder.handleRequestStream " << request
               << std::endl;
 

--- a/src/RSocketResponder.cpp
+++ b/src/RSocketResponder.cpp
@@ -6,40 +6,34 @@
 namespace rsocket {
 
 yarpl::Reference<yarpl::single::Single<rsocket::Payload>>
-RSocketResponder::handleRequestResponse(
-    rsocket::Payload request,
-    rsocket::StreamId streamId) {
+RSocketResponder::handleRequestResponse(rsocket::Payload, rsocket::StreamId) {
   return yarpl::single::Singles::error<rsocket::Payload>(
       std::logic_error("handleRequestResponse not implemented"));
 }
 
 yarpl::Reference<yarpl::flowable::Flowable<rsocket::Payload>>
-RSocketResponder::handleRequestStream(
-    rsocket::Payload request,
-    rsocket::StreamId streamId) {
+RSocketResponder::handleRequestStream(rsocket::Payload, rsocket::StreamId) {
   return yarpl::flowable::Flowables::error<rsocket::Payload>(
       std::logic_error("handleRequestStream not implemented"));
 }
 
 yarpl::Reference<yarpl::flowable::Flowable<rsocket::Payload>>
 RSocketResponder::handleRequestChannel(
-    rsocket::Payload request,
-    yarpl::Reference<yarpl::flowable::Flowable<rsocket::Payload>>
-        requestStream,
-    rsocket::StreamId streamId) {
+    rsocket::Payload,
+    yarpl::Reference<yarpl::flowable::Flowable<rsocket::Payload>>,
+    rsocket::StreamId) {
   return yarpl::flowable::Flowables::error<rsocket::Payload>(
       std::logic_error("handleRequestChannel not implemented"));
 }
 
 void RSocketResponder::handleFireAndForget(
-    rsocket::Payload request,
-    rsocket::StreamId streamId) {
-  // no default implementation, no error response to provide
+    rsocket::Payload,
+    rsocket::StreamId) {
+  // No default implementation, no error response to provide.
 }
 
-void RSocketResponder::handleMetadataPush(
-    std::unique_ptr<folly::IOBuf> metadata) {
-  // no default implementation, no error response to provide
+void RSocketResponder::handleMetadataPush(std::unique_ptr<folly::IOBuf>) {
+  // No default implementation, no error response to provide.
 }
 
 /// Handles a new Channel requested by the other end.

--- a/src/RSocketServer.cpp
+++ b/src/RSocketServer.cpp
@@ -70,7 +70,7 @@ void RSocketServer::start(OnRSocketSetup onRSocketSetup) {
 
 void RSocketServer::acceptConnection(
     std::unique_ptr<DuplexConnection> connection,
-    folly::EventBase & eventBase,
+    folly::EventBase&,
     OnRSocketSetup onRSocketSetup) {
   if (isShutdown_) {
     // connection is getting out of scope and terminated
@@ -113,11 +113,11 @@ void RSocketServer::onRSocketSetup(
 }
 
 void RSocketServer::onRSocketResume(
-    OnRSocketResume onRSocketResume,
-    std::shared_ptr<FrameTransport> frameTransport,
-    ResumeParameters setupPayload) {
-  // we don't need to check for isShutdown_ here since all callbacks are
-  // processed by this time
+    OnRSocketResume,
+    std::shared_ptr<FrameTransport>,
+    ResumeParameters) {
+  // We don't need to check for isShutdown_ here since all callbacks are
+  // processed by this time.
 
   CHECK(false) << "not implemented";
 }

--- a/src/RSocketStats.cpp
+++ b/src/RSocketStats.cpp
@@ -11,19 +11,18 @@ class NoopStats : public RSocketStats {
 
   void socketCreated() override {}
   void socketDisconnected() override {}
-  void socketClosed(StreamCompletionSignal signal) override {}
+  void socketClosed(StreamCompletionSignal) override {}
 
-  void duplexConnectionCreated(
-      const std::string& type,
-      rsocket::DuplexConnection* connection) override {}
-  void duplexConnectionClosed(
-      const std::string& type,
-      rsocket::DuplexConnection* connection) override {}
+  void duplexConnectionCreated(const std::string&, rsocket::DuplexConnection*)
+      override {}
 
-  void bytesWritten(size_t bytes) override {}
-  void bytesRead(size_t bytes) override {}
-  void frameWritten(FrameType frameType) override {}
-  void frameRead(FrameType frameType) override {}
+  void duplexConnectionClosed(const std::string&, rsocket::DuplexConnection*)
+      override {}
+
+  void bytesWritten(size_t) override {}
+  void bytesRead(size_t) override {}
+  void frameWritten(FrameType) override {}
+  void frameRead(FrameType) override {}
 
   void resumeBufferChanged(int, int) override {}
   void streamBufferChanged(int64_t, int64_t) override {}
@@ -34,7 +33,7 @@ class NoopStats : public RSocketStats {
   }
 
  private:
-  NoopStats(const NoopStats& other) = delete; // non construction-copyable
+  NoopStats(const NoopStats&) = delete; // non construction-copyable
   NoopStats& operator=(const NoopStats&) = delete; // non copyable
   NoopStats& operator=(const NoopStats&&) = delete; // non movable
   NoopStats(NoopStats&&) = delete; // non construction-movable

--- a/src/statemachine/StreamStateMachineBase.cpp
+++ b/src/statemachine/StreamStateMachineBase.cpp
@@ -7,19 +7,15 @@
 
 namespace rsocket {
 
-void StreamStateMachineBase::handlePayload(
-    Payload&& payload,
-    bool complete,
-    bool flagsNext) {
+void StreamStateMachineBase::handlePayload(Payload&&, bool, bool) {
   VLOG(4) << "Unexpected handlePayload";
 }
 
-void StreamStateMachineBase::handleRequestN(uint32_t n) {
+void StreamStateMachineBase::handleRequestN(uint32_t) {
   VLOG(4) << "Unexpected handleRequestN";
 }
 
-void StreamStateMachineBase::handleError(
-    folly::exception_wrapper errorPayload) {
+void StreamStateMachineBase::handleError(folly::exception_wrapper) {
   closeStream(StreamCompletionSignal::ERROR);
 }
 

--- a/test/RequestChannelTest.cpp
+++ b/test/RequestChannelTest.cpp
@@ -23,7 +23,7 @@ class TestHandlerHello : public rsocket::RSocketResponder {
   yarpl::Reference<Flowable<rsocket::Payload>> handleRequestChannel(
       rsocket::Payload initialPayload,
       yarpl::Reference<Flowable<rsocket::Payload>> request,
-      rsocket::StreamId streamId) override {
+      rsocket::StreamId) override {
     // say "Hello" to each name on the input stream
     return request->map([initialPayload = std::move(initialPayload)](
         Payload p) {

--- a/test/RequestResponseTest.cpp
+++ b/test/RequestResponseTest.cpp
@@ -18,9 +18,8 @@ using namespace std::chrono_literals;
 namespace {
 class TestHandlerHello : public rsocket::RSocketResponder {
  public:
-  Reference<Single<Payload>> handleRequestResponse(
-      Payload request,
-      StreamId streamId) override {
+  Reference<Single<Payload>> handleRequestResponse(Payload request, StreamId)
+      override {
     auto requestString = request.moveDataToString();
     return Single<Payload>::create([name = std::move(requestString)](
         auto subscriber) {
@@ -55,9 +54,8 @@ class TestHandlerCancel : public rsocket::RSocketResponder {
       std::shared_ptr<folly::Baton<>> onCancel,
       std::shared_ptr<folly::Baton<>> onSubscribe)
       : onCancel_(std::move(onCancel)), onSubscribe_(std::move(onSubscribe)) {}
-  Reference<Single<Payload>> handleRequestResponse(
-      Payload request,
-      StreamId streamId) override {
+  Reference<Single<Payload>> handleRequestResponse(Payload request, StreamId)
+      override {
     // used to signal to the client when the subscribe is received
     onSubscribe_->post();
     // used to block this responder thread until a cancel is sent from client

--- a/test/RequestStreamTest.cpp
+++ b/test/RequestStreamTest.cpp
@@ -17,7 +17,7 @@ class TestHandlerSync : public rsocket::RSocketResponder {
  public:
   Reference<Flowable<Payload>> handleRequestStream(
       Payload request,
-      StreamId streamId) override {
+      StreamId) override {
     // string from payload data
     auto requestString = request.moveDataToString();
 
@@ -51,7 +51,7 @@ class TestHandlerAsync : public rsocket::RSocketResponder {
  public:
   Reference<Flowable<Payload>> handleRequestStream(
       Payload request,
-      StreamId streamId) override {
+      StreamId) override {
     // string from payload data
     auto requestString = request.moveDataToString();
 

--- a/test/handlers/HelloStreamRequestHandler.cpp
+++ b/test/handlers/HelloStreamRequestHandler.cpp
@@ -14,7 +14,7 @@ namespace tests {
 Reference<Flowable<rsocket::Payload>>
 HelloStreamRequestHandler::handleRequestStream(
     rsocket::Payload request,
-    rsocket::StreamId streamId) {
+    rsocket::StreamId) {
   LOG(INFO) << "HelloStreamRequestHandler.handleRequestStream " << request;
 
   // string from payload data

--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -366,7 +366,7 @@ class IgnoreElementsOperator : public FlowableOperator<T, T> {
         Reference<Subscriber<T>> subscriber)
         : Super(std::move(flowable), std::move(subscriber)) {}
 
-    void onNext(T value) override {}
+    void onNext(T) override {}
   };
 };
 

--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -347,7 +347,7 @@ class IgnoreElementsOperator : public ObservableOperator<T, T> {
               std::move(observable),
               std::move(observer)) {}
 
-    void onNext(T value) override {}
+    void onNext(T) override {}
   };
 };
 


### PR DESCRIPTION
Don't use it, don't name it.  Vast majority of these cases were `StreamId
streamId` in an override of handleRequestStream().

Remove our use of -Wno-unused-parameter.