### PR TITLE
Build system improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ matrix:
 
 env:
   global:
-    - BUILD_TYPE=Debug CPP_VERSION=14 ASAN=On
+    - BUILD_TYPE=Debug ASAN=On
     - secure: |-
         DOPCvF/oFMkzTHcE1U7jJ1z3isJYKySiJfuzZQqY6IUmjvVxJuE2k4rvz1pURdqYIXs/3k
         OHhtf59q0VJcCsdurpGXrF+E51JLQyG6SM1L3JzjVjEZ60a7laUyPer7rNnrj6g4K7CK0K
@@ -105,9 +105,8 @@ before_script:
 script:
   - mkdir build &&
     cd build &&
-    cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DMETA_CXX_STD=$CPP_VERSION
-          -DRSOCKET_CC=$COMPILER -DRSOCKET_ASAN=$ASAN
-          -DRSOCKET_INSTALL_DEPS=True .. &&
+    cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DRSOCKET_CC=$COMPILER
+          -DRSOCKET_ASAN=$ASAN -DRSOCKET_INSTALL_DEPS=True .. &&
     make -j8 VERBOSE=1
   - ./tests
   - ./yarpl/yarpl-tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,19 +87,33 @@ if (NOT FOLLY_INSTALL_DIR)
   set(FOLLY_INSTALL_DIR $ENV{HOME}/folly)
 endif ()
 
-if (RSOCKET_INSTALL_DEPS AND NOT EXISTS ${FOLLY_INSTALL_DIR}/include/folly)
+# Check if the correct version of folly is already installed.
+set(FOLLY_VERSION v2017.06.19.00)
+set(FOLLY_VERSION_FILE ${FOLLY_INSTALL_DIR}/${FOLLY_VERSION})
+if (RSOCKET_INSTALL_DEPS)
+  if (NOT EXISTS ${FOLLY_VERSION_FILE})
+    # Remove the old version of folly.
+    file(REMOVE_RECURSE ${FOLLY_INSTALL_DIR})
+    set(INSTALL_FOLLY True)
+  endif ()
+endif ()
+
+if (INSTALL_FOLLY)
   # Build and install folly.
   ExternalProject_Add(
     folly-ext
     GIT_REPOSITORY https://github.com/facebook/folly
-    GIT_TAG v2017.03.06.00
+    GIT_TAG ${FOLLY_VERSION}
     BINARY_DIR folly-ext-prefix/src/folly-ext/folly
     CONFIGURE_COMMAND autoreconf -ivf
-      COMMAND ./configure --prefix=${FOLLY_INSTALL_DIR}
-    BUILD_COMMAND make -j4)
+      COMMAND ./configure CXX=${CMAKE_CXX_COMPILER}
+                          --prefix=${FOLLY_INSTALL_DIR}
+    BUILD_COMMAND make -j4
+    INSTALL_COMMAND make install
+      COMMAND cmake -E touch ${FOLLY_VERSION_FILE})
 
   set(FOLLY_INCLUDE_DIR ${FOLLY_INSTALL_DIR}/include)
-  set(lib ${CMAKE_STATIC_LIBRARY_PREFIX}folly${CMAKE_STATIC_LIBRARY_SUFFIX})
+  set(lib ${CMAKE_SHARED_LIBRARY_PREFIX}folly${CMAKE_SHARED_LIBRARY_SUFFIX})
   set(FOLLY_LIBRARY ${FOLLY_INSTALL_DIR}/lib/${lib})
 
   # CMake requires directories listed in INTERFACE_INCLUDE_DIRECTORIES to exist.
@@ -109,11 +123,14 @@ else ()
   find_package(Folly REQUIRED)
 endif ()
 
-add_library(folly STATIC IMPORTED)
+find_package(Threads)
+find_library(EVENT_LIBRARY event)
+
+add_library(folly SHARED IMPORTED)
 set_property(TARGET folly PROPERTY IMPORTED_LOCATION ${FOLLY_LIBRARY})
 set_property(TARGET folly
   APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-  ${EXTRA_LINK_FLAGS} ${CMAKE_THREAD_LIBS_INIT})
+  ${EXTRA_LINK_FLAGS} ${EVENT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
 if (TARGET folly-ext)
   add_dependencies(folly folly-ext)
 endif ()
@@ -153,8 +170,6 @@ ExternalProject_Add(
     "-DCMAKE_EXE_LINKER_FLAGS=${CXX_LINKER_FLAGS}"
 )
 
-find_package(Threads)
-
 string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWER)
 
 if(APPLE)
@@ -164,14 +179,10 @@ if(APPLE)
   endif()
 endif()
 
-if(NOT META_CXX_STD)
-  # Defaults to C++14 if not set:
-  set(META_CXX_STD 14)
-endif()
+set(CMAKE_CXX_STANDARD 14)
 
 # Common configuration for all build modes.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${META_CXX_STD} -pedantic")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual")
 
 set(EXTRA_CXX_FLAGS ${EXTRA_CXX_FLAGS} -Werror)
@@ -355,11 +366,9 @@ target_link_libraries(
   tests
   ReactiveSocket
   yarpl
-  ${FOLLY_LIBRARIES}
   ${GMOCK_LIBS}
   ${GFLAGS_LIBRARY}
-  ${GLOG_LIBRARY}
-  ${CMAKE_THREAD_LIBS_INIT})
+  ${GLOG_LIBRARY})
 
 target_compile_options(
   tests
@@ -394,10 +403,8 @@ target_link_libraries(
   tckclient
   ReactiveSocket
   yarpl
-  ${FOLLY_LIBRARIES}
   ${GFLAGS_LIBRARY}
-  ${GLOG_LIBRARY}
-  ${CMAKE_THREAD_LIBS_INIT})
+  ${GLOG_LIBRARY})
 
 add_executable(
   tckserver
@@ -412,12 +419,10 @@ target_link_libraries(
   tckserver
   ReactiveSocket
   yarpl
-  ${FOLLY_LIBRARIES}
   ${GFLAGS_LIBRARY}
   ${GMOCK_LIBS}
   ${GLOG_LIBRARY}
-  ${DOUBLE-CONVERSION}
-  ${CMAKE_THREAD_LIBS_INIT})
+  ${DOUBLE-CONVERSION})
 
 ########################################
 # Examples
@@ -433,11 +438,8 @@ target_link_libraries(
   reactivesocket_examples_util
   yarpl
   ReactiveSocket
-  ${FOLLY_LIBRARIES}
   ${GFLAGS_LIBRARY}
-  ${GLOG_LIBRARY}
-  ${CMAKE_THREAD_LIBS_INIT}
-)
+  ${GLOG_LIBRARY})
 
 # request-response-hello-world
 
@@ -451,10 +453,8 @@ target_link_libraries(
   ReactiveSocket
   reactivesocket_examples_util
   yarpl
-  ${FOLLY_LIBRARIES}
   ${GFLAGS_LIBRARY}
-  ${GLOG_LIBRARY}
-  ${CMAKE_THREAD_LIBS_INIT})
+  ${GLOG_LIBRARY})
 
 add_executable(
   example_request-response-hello-world-client
@@ -466,10 +466,8 @@ target_link_libraries(
   ReactiveSocket
   reactivesocket_examples_util
   yarpl
-  ${FOLLY_LIBRARIES}
   ${GFLAGS_LIBRARY}
-  ${GLOG_LIBRARY}
-  ${CMAKE_THREAD_LIBS_INIT})
+  ${GLOG_LIBRARY})
 
 # fire-and-forget-hello-world
 
@@ -483,10 +481,8 @@ target_link_libraries(
   ReactiveSocket
   reactivesocket_examples_util
   yarpl
-  ${FOLLY_LIBRARIES}
   ${GFLAGS_LIBRARY}
-  ${GLOG_LIBRARY}
-  ${CMAKE_THREAD_LIBS_INIT})
+  ${GLOG_LIBRARY})
 
 add_executable(
   example_fire-and-forget-hello-world-client
@@ -498,10 +494,8 @@ target_link_libraries(
   ReactiveSocket
   reactivesocket_examples_util
   yarpl
-  ${FOLLY_LIBRARIES}
   ${GFLAGS_LIBRARY}
-  ${GLOG_LIBRARY}
-  ${CMAKE_THREAD_LIBS_INIT})
+  ${GLOG_LIBRARY})
 
 
 # stream-hello-world
@@ -516,10 +510,8 @@ target_link_libraries(
   ReactiveSocket
   reactivesocket_examples_util
   yarpl
-  ${FOLLY_LIBRARIES}
   ${GFLAGS_LIBRARY}
-  ${GLOG_LIBRARY}
-  ${CMAKE_THREAD_LIBS_INIT})
+  ${GLOG_LIBRARY})
 
 add_executable(
   example_stream-hello-world-client
@@ -531,11 +523,8 @@ target_link_libraries(
   ReactiveSocket
   reactivesocket_examples_util
   yarpl
-  ${FOLLY_LIBRARIES}
   ${GFLAGS_LIBRARY}
-  ${GLOG_LIBRARY}
-  ${CMAKE_THREAD_LIBS_INIT})
-
+  ${GLOG_LIBRARY})
 
 # channel-hello-world
 
@@ -549,10 +538,8 @@ target_link_libraries(
   ReactiveSocket
   reactivesocket_examples_util
   yarpl
-  ${FOLLY_LIBRARIES}
   ${GFLAGS_LIBRARY}
-  ${GLOG_LIBRARY}
-  ${CMAKE_THREAD_LIBS_INIT})
+  ${GLOG_LIBRARY})
 
 add_executable(
   example_channel-hello-world-client
@@ -564,10 +551,8 @@ target_link_libraries(
   ReactiveSocket
   reactivesocket_examples_util
   yarpl
-  ${FOLLY_LIBRARIES}
   ${GFLAGS_LIBRARY}
-  ${GLOG_LIBRARY}
-  ${CMAKE_THREAD_LIBS_INIT})
+  ${GLOG_LIBRARY})
 
 # stream-observable-to-flowable
 
@@ -581,10 +566,8 @@ target_link_libraries(
   ReactiveSocket
   reactivesocket_examples_util
   yarpl
-  ${FOLLY_LIBRARIES}
   ${GFLAGS_LIBRARY}
-  ${GLOG_LIBRARY}
-  ${CMAKE_THREAD_LIBS_INIT})
+  ${GLOG_LIBRARY})
 
 add_executable(
   example_observable-to-flowable-client
@@ -596,10 +579,8 @@ target_link_libraries(
   ReactiveSocket
   reactivesocket_examples_util
   yarpl
-  ${FOLLY_LIBRARIES}
   ${GFLAGS_LIBRARY}
-  ${GLOG_LIBRARY}
-  ${CMAKE_THREAD_LIBS_INIT})
+  ${GLOG_LIBRARY})
 
 # conditional-request-handling
 
@@ -617,10 +598,8 @@ target_link_libraries(
   ReactiveSocket
   reactivesocket_examples_util
   yarpl
-  ${FOLLY_LIBRARIES}
   ${GFLAGS_LIBRARY}
-  ${GLOG_LIBRARY}
-  ${CMAKE_THREAD_LIBS_INIT})
+  ${GLOG_LIBRARY})
 
 add_executable(
   example_conditional-request-handling-client
@@ -632,10 +611,8 @@ target_link_libraries(
   ReactiveSocket
   reactivesocket_examples_util
   yarpl
-  ${FOLLY_LIBRARIES}
   ${GFLAGS_LIBRARY}
-  ${GLOG_LIBRARY}
-  ${CMAKE_THREAD_LIBS_INIT})
+  ${GLOG_LIBRARY})
 
 
 ########################################
@@ -671,10 +648,8 @@ if(BUILD_BENCHMARKS)
           ReactiveSocket
           yarpl
           ${GOOGLE_BENCHMARK_LIBS}
-          ${FOLLY_LIBRARIES}
           ${GFLAGS_LIBRARY}
-          ${GLOG_LIBRARY}
-          ${CMAKE_THREAD_LIBS_INIT})
+          ${GLOG_LIBRARY})
       add_dependencies(
           ${name}
           ReactiveStreams

--- a/cmake/FindFolly.cmake
+++ b/cmake/FindFolly.cmake
@@ -10,7 +10,5 @@ endif ()
 find_library(FOLLY_LIBRARY folly PATHS ${lib_paths})
 find_path(FOLLY_INCLUDE_DIR "folly/String.h" PATHS ${include_paths})
 
-set(FOLLY_LIBRARIES ${FOLLY_LIBRARY})
-
 find_package_handle_standard_args(Folly
   DEFAULT_MSG FOLLY_LIBRARY FOLLY_INCLUDE_DIR)

--- a/scripts/Vagrantfile
+++ b/scripts/Vagrantfile
@@ -3,6 +3,12 @@
 # Vagrant configuration that creates Travis-CI compatible build environment
 # for rsocket.
 
+# Get the APT dependencies from the Travis config.
+require 'yaml'
+yml = YAML.load_file(File.dirname(__dir__) + '/.travis.yml')
+apt = yml['addons']['apt']
+packages = apt['packages'] + ['git', 'cmake3']
+
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
 
@@ -12,12 +18,8 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provision "shell", inline: <<-SHELL
-    apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+    apt-add-repository -y "apt['sources'].join(' ')"
     apt-get update
-    apt-get -y install \
-      autoconf autoconf-archive automake binutils-dev cmake3 g++-4.9 git lcov \
-      libboost-all-dev  libdouble-conversion-dev libevent-dev libgflags-dev \
-      libgoogle-glog-dev libiberty-dev libjemalloc-dev liblz4-dev liblzma-dev \
-      libsnappy-dev libssl-dev libtool make pkg-config valgrind zlib1g-dev
+    apt-get -y install #{packages.join(' ')}
   SHELL
 end

--- a/yarpl/CMakeLists.txt
+++ b/yarpl/CMakeLists.txt
@@ -97,7 +97,7 @@ target_include_directories(
         PUBLIC "${PROJECT_SOURCE_DIR}/src" # allow include paths such as "yarpl/flowable/FlowableRange.h"
         )
 
-target_link_libraries(yarpl ${CMAKE_THREAD_LIBS_INIT} folly)
+target_link_libraries(yarpl folly)
 
 # Executable for Experimenting
 add_executable(
@@ -140,11 +140,8 @@ add_executable(
 target_link_libraries(
         yarpl-tests
         yarpl
-        ${FOLLY_LIBRARIES} # inherited from rsocket-cpp CMake
         ${GMOCK_LIBS} # inherited from rsocket-cpp CMake
-        ${GLOG_LIBRARY}
-        ${CMAKE_THREAD_LIBS_INIT}
-)
+        ${GLOG_LIBRARY})
 
 target_include_directories(
         yarpl-tests


### PR DESCRIPTION
* Rebuild folly if version changes and update to version v2017.06.19.00.
* Use the same C++ compiler to compile both folly and rsocket, because folly v2017.06.19.00 fails to compile with the default g++-4.8 compiler.
* Add libevent and libpthreads to folly's interface link libraries.
* Use automatic dependency propagation for folly and pthreads instead of listing link libraries manually which is tedious and error-prone.
* Read the list of apt packages from .travis.yml in Vagrantfile.
* Set C++ standard version to 14 in CMake instead of Travis config as discussed in #540.