### PR TITLE
Add -g flag to common CXX flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ set(CMAKE_CXX_STANDARD 14)
 # Common configuration for all build modes.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 
 set(EXTRA_CXX_FLAGS ${EXTRA_CXX_FLAGS} -Werror)
 


### PR DESCRIPTION
Noticed ASAN errors in Vagrant VM were missing line numbers.  Adding -g did the
trick.  Good to have on all builds, debug and opt.