### PR TITLE
Add *.jar to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ BUILD_MODE
 
 # Vagrant
 .vagrant/
+
+# TCK test artifacts
+*.jar


### PR DESCRIPTION
Recent changes to tck build cause reactivesocket-tck-drivers-0.9-SNAPSHOT.jar to
show up in the working directory.  Ignore it.