### PR TITLE
s|const std::exception_ptr|std::exception_ptr|g

### DIFF
--- a/examples/util/ExampleSubscriber.cpp
+++ b/examples/util/ExampleSubscriber.cpp
@@ -55,7 +55,7 @@ void ExampleSubscriber::onComplete() noexcept {
   terminalEventCV_.notify_all();
 }
 
-void ExampleSubscriber::onError(const std::exception_ptr ex) noexcept {
+void ExampleSubscriber::onError(std::exception_ptr ex) noexcept {
   try {
     std::rethrow_exception(ex);
   } catch (const std::exception& e) {

--- a/examples/util/ExampleSubscriber.h
+++ b/examples/util/ExampleSubscriber.h
@@ -24,7 +24,7 @@ class ExampleSubscriber : public yarpl::flowable::Subscriber<rsocket::Payload> {
                        subscription) noexcept override;
   void onNext(rsocket::Payload) noexcept override;
   void onComplete() noexcept override;
-  void onError(const std::exception_ptr ex) noexcept override;
+  void onError(std::exception_ptr ex) noexcept override;
 
   void awaitTerminalEvent();
 

--- a/src/internal/ScheduledSingleObserver.h
+++ b/src/internal/ScheduledSingleObserver.h
@@ -50,7 +50,7 @@ class ScheduledSingleObserver : public yarpl::single::SingleObserver<T> {
   }
 
   // No further calls to the subscription after this method is invoked.
-  void onError(const std::exception_ptr ex) override {
+  void onError(std::exception_ptr ex) override {
     if (eventBase_.isInEventBaseThread()) {
       inner_->onError(std::move(ex));
     } else {
@@ -92,7 +92,7 @@ class ScheduledSubscriptionSingleObserver : public yarpl::single::SingleObserver
   }
 
   // No further calls to the subscription after this method is invoked.
-  void onError(const std::exception_ptr ex) override {
+  void onError(std::exception_ptr ex) override {
     inner_->onError(std::move(ex));
   }
 

--- a/src/internal/ScheduledSubscriber.h
+++ b/src/internal/ScheduledSubscriber.h
@@ -50,7 +50,7 @@ class ScheduledSubscriber : public yarpl::flowable::Subscriber<T> {
     }
   }
 
-  void onError(const std::exception_ptr ex) override {
+  void onError(std::exception_ptr ex) override {
     if (eventBase_.isInEventBaseThread()) {
       inner_->onError(std::move(ex));
     } else {
@@ -104,7 +104,7 @@ class ScheduledSubscriptionSubscriber : public yarpl::flowable::Subscriber<T> {
     inner_->onComplete();
   }
 
-  void onError(const std::exception_ptr ex) override {
+  void onError(std::exception_ptr ex) override {
     inner_->onError(std::move(ex));
   }
 

--- a/src/statemachine/ChannelRequester.cpp
+++ b/src/statemachine/ChannelRequester.cpp
@@ -57,7 +57,7 @@ void ChannelRequester::onComplete() noexcept {
   tryCompleteChannel();
 }
 
-void ChannelRequester::onError(const std::exception_ptr ex) noexcept {
+void ChannelRequester::onError(std::exception_ptr ex) noexcept {
   if (!requested_) {
     closeStream(StreamCompletionSignal::CANCEL);
     return;

--- a/src/statemachine/ChannelRequester.h
+++ b/src/statemachine/ChannelRequester.h
@@ -28,7 +28,7 @@ class ChannelRequester : public ConsumerBase,
                        subscription) noexcept override;
   void onNext(Payload) noexcept override;
   void onComplete() noexcept override;
-  void onError(const std::exception_ptr) noexcept override;
+  void onError(std::exception_ptr) noexcept override;
 
   // implementation from ConsumerBase::SubscriptionBase
   void request(int64_t) noexcept override;

--- a/src/statemachine/ChannelResponder.cpp
+++ b/src/statemachine/ChannelResponder.cpp
@@ -24,7 +24,7 @@ void ChannelResponder::onComplete() noexcept {
   tryCompleteChannel();
 }
 
-void ChannelResponder::onError(const std::exception_ptr ex) noexcept {
+void ChannelResponder::onError(std::exception_ptr ex) noexcept {
   publisherComplete();
   applicationError(yarpl::exceptionStr(ex));
   tryCompleteChannel();

--- a/src/statemachine/ChannelResponder.h
+++ b/src/statemachine/ChannelResponder.h
@@ -28,7 +28,7 @@ class ChannelResponder : public ConsumerBase,
                        subscription) noexcept override;
   void onNext(Payload) noexcept override;
   void onComplete() noexcept override;
-  void onError(const std::exception_ptr) noexcept override;
+  void onError(std::exception_ptr) noexcept override;
 
   // implementation from ConsumerBase::SubscriptionBase
   void request(int64_t n) noexcept override;

--- a/src/statemachine/RequestResponseResponder.cpp
+++ b/src/statemachine/RequestResponseResponder.cpp
@@ -35,7 +35,7 @@ void RequestResponseResponder::onSuccess(Payload response) noexcept {
   }
 }
 
-void RequestResponseResponder::onError(const std::exception_ptr ex) noexcept {
+void RequestResponseResponder::onError(std::exception_ptr ex) noexcept {
   DCHECK(producingSubscription_);
   producingSubscription_ = nullptr;
   switch (state_) {

--- a/src/statemachine/RequestResponseResponder.h
+++ b/src/statemachine/RequestResponseResponder.h
@@ -21,7 +21,7 @@ class RequestResponseResponder : public StreamStateMachineBase,
   void onSubscribe(yarpl::Reference<yarpl::single::SingleSubscription>
                        subscription) noexcept override;
   void onSuccess(Payload) noexcept override;
-  void onError(const std::exception_ptr) noexcept override;
+  void onError(std::exception_ptr) noexcept override;
 
   void handleCancel() override;
 

--- a/src/statemachine/StreamResponder.cpp
+++ b/src/statemachine/StreamResponder.cpp
@@ -24,7 +24,7 @@ void StreamResponder::onComplete() noexcept {
   closeStream(StreamCompletionSignal::COMPLETE);
 }
 
-void StreamResponder::onError(const std::exception_ptr ex) noexcept {
+void StreamResponder::onError(std::exception_ptr ex) noexcept {
   publisherComplete();
   applicationError(yarpl::exceptionStr(ex));
   closeStream(StreamCompletionSignal::ERROR);

--- a/src/statemachine/StreamResponder.h
+++ b/src/statemachine/StreamResponder.h
@@ -28,7 +28,7 @@ class StreamResponder : public StreamStateMachineBase,
                        subscription) noexcept override;
   void onNext(Payload) noexcept override;
   void onComplete() noexcept override;
-  void onError(const std::exception_ptr) noexcept override;
+  void onError(std::exception_ptr) noexcept override;
 
 //  void pauseStream(RequestHandler&) override;
 //  void resumeStream(RequestHandler&) override;

--- a/test/test_utils/Mocks.h
+++ b/test/test_utils/Mocks.h
@@ -35,7 +35,7 @@ class MockSubscriber : public Subscriber<T> {
   MOCK_METHOD1(onSubscribe_, void(yarpl::Reference<Subscription> subscription));
   MOCK_METHOD1_T(onNext_, void(T& value));
   MOCK_METHOD0(onComplete_, void());
-  MOCK_METHOD1_T(onError_, void(const std::exception_ptr ex));
+  MOCK_METHOD1_T(onError_, void(std::exception_ptr ex));
 
   void onSubscribe(
       yarpl::Reference<Subscription> subscription) override {
@@ -55,7 +55,7 @@ class MockSubscriber : public Subscriber<T> {
     subscription_ = nullptr;
   }
 
-  void onError(const std::exception_ptr ex) override {
+  void onError(std::exception_ptr ex) override {
     onError_(ex);
     checkpoint_.Call();
     subscription_ = nullptr;

--- a/yarpl/examples/ObservableExamples.cpp
+++ b/yarpl/examples/ObservableExamples.cpp
@@ -35,7 +35,7 @@ void ObservableExamples::run() {
   //      std::cout << "onComplete" << std::endl;
   //    }
   //
-  //    void onError(const std::exception_ptr error) override {}
+  //    void onError(std::exception_ptr) override {}
   //  };
   //
   //  // the most basic Observable (and that ignores cancellation)
@@ -143,7 +143,7 @@ void ObservableExamples::run() {
       std::cout << "onComplete " << std::endl;
     }
 
-    void onError(const std::exception_ptr error) override {
+    void onError(std::exception_ptr) override {
       std::cout << "onError " << std::endl;
     }
 

--- a/yarpl/include/yarpl/flowable/Flowable.h
+++ b/yarpl/include/yarpl/flowable/Flowable.h
@@ -49,7 +49,7 @@ class Flowable : public virtual Refcounted {
       typename Error,
       typename = typename std::enable_if<
           std::is_callable<Next(T), void>::value &&
-          std::is_callable<Error(const std::exception_ptr), void>::value>::type>
+          std::is_callable<Error(std::exception_ptr), void>::value>::type>
   void subscribe(
       Next&& next,
       Error&& error,
@@ -68,7 +68,7 @@ class Flowable : public virtual Refcounted {
       typename Complete,
       typename = typename std::enable_if<
           std::is_callable<Next(T), void>::value &&
-          std::is_callable<Error(const std::exception_ptr), void>::value &&
+          std::is_callable<Error(std::exception_ptr), void>::value &&
           std::is_callable<Complete(), void>::value>::type>
   void subscribe(
       Next&& next,
@@ -214,7 +214,7 @@ class Flowable : public virtual Refcounted {
       // we're following the Subscription's protocol instead.
     }
 
-    void onError(const std::exception_ptr error) override {
+    void onError(std::exception_ptr error) override {
       // we will set the flag first to save a potential call to lock.try_lock()
       // in the process method via cancel or request methods
       auto old = requested_.exchange(kCanceled, std::memory_order_relaxed);

--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -83,7 +83,7 @@ class FlowableOperator : public Flowable<D> {
       Refcounted::decRef(*this);
     }
 
-    void onError(const std::exception_ptr error) override {
+    void onError(std::exception_ptr error) override {
       assert(upstream_ && "subscription was already terminated");
       upstream_.reset(); // breaking the cycle
       subscriber_->onError(error);

--- a/yarpl/include/yarpl/flowable/Subscriber.h
+++ b/yarpl/include/yarpl/flowable/Subscriber.h
@@ -25,7 +25,7 @@ class Subscriber : public virtual Refcounted {
   }
 
   // No further calls to the subscription after this method is invoked.
-  virtual void onError(const std::exception_ptr) {
+  virtual void onError(std::exception_ptr) {
     subscription_.reset();
   }
 

--- a/yarpl/include/yarpl/flowable/Subscribers.h
+++ b/yarpl/include/yarpl/flowable/Subscribers.h
@@ -36,7 +36,7 @@ class Subscribers {
       typename Error,
       typename = typename std::enable_if<
           std::is_callable<Next(T), void>::value &&
-          std::is_callable<Error(const std::exception_ptr), void>::value>::type>
+          std::is_callable<Error(std::exception_ptr), void>::value>::type>
   static auto
   create(Next&& next, Error&& error, int64_t batch = kNoFlowControl) {
     return Reference<Subscriber<T>>(new WithError<T, Next, Error>(
@@ -50,7 +50,7 @@ class Subscribers {
       typename Complete,
       typename = typename std::enable_if<
           std::is_callable<Next(T), void>::value &&
-          std::is_callable<Error(const std::exception_ptr), void>::value &&
+          std::is_callable<Error(std::exception_ptr), void>::value &&
           std::is_callable<Complete(), void>::value>::type>
   static auto create(
       Next&& next,

--- a/yarpl/include/yarpl/flowable/TestSubscriber.h
+++ b/yarpl/include/yarpl/flowable/TestSubscriber.h
@@ -85,7 +85,7 @@ class TestSubscriber : public Subscriber<T> {
     terminalEventCV_.notify_all();
   }
 
-  void onError(const std::exception_ptr ex) override {
+  void onError(std::exception_ptr ex) override {
     if (delegate_) {
       delegate_->onError(ex);
     }

--- a/yarpl/include/yarpl/observable/Observable.h
+++ b/yarpl/include/yarpl/observable/Observable.h
@@ -52,7 +52,7 @@ class Observable : public virtual Refcounted {
       typename Error,
       typename = typename std::enable_if<
           std::is_callable<Next(T), void>::value &&
-          std::is_callable<Error(const std::exception_ptr), void>::value>::type>
+          std::is_callable<Error(std::exception_ptr), void>::value>::type>
   void subscribe(Next&& next, Error&& error) {
     subscribe(Observers::create<T>(next, error));
   }
@@ -66,7 +66,7 @@ class Observable : public virtual Refcounted {
       typename Complete,
       typename = typename std::enable_if<
           std::is_callable<Next(T), void>::value &&
-          std::is_callable<Error(const std::exception_ptr), void>::value &&
+          std::is_callable<Error(std::exception_ptr), void>::value &&
           std::is_callable<Complete(), void>::value>::type>
   void subscribe(Next&& next, Error&& error, Complete&& complete) {
     subscribe(Observers::create<T>(next, error, complete));

--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -76,7 +76,7 @@ class ObservableOperator : public Observable<D> {
           Reference<::yarpl::observable::Subscription>(this));
     }
 
-    void onError(const std::exception_ptr error) override {
+    void onError(std::exception_ptr error) override {
       observer_->onError(error);
       upstream_.reset(); // breaking the cycle
     }

--- a/yarpl/include/yarpl/observable/Observer.h
+++ b/yarpl/include/yarpl/observable/Observer.h
@@ -24,7 +24,7 @@ class Observer : public virtual Refcounted {
   }
 
   // No further calls to the subscription after this method is invoked.
-  virtual void onError(const std::exception_ptr) {
+  virtual void onError(std::exception_ptr) {
     subscription_.reset();
   }
 

--- a/yarpl/include/yarpl/observable/TestObserver.h
+++ b/yarpl/include/yarpl/observable/TestObserver.h
@@ -65,7 +65,7 @@ class TestObserver : public yarpl::observable::Observer<T>,
   void onSubscribe(Subscription* s) override;
   void onNext(const T& t) override;
   void onComplete() override;
-  void onError(const std::exception_ptr ex) override;
+  void onError(std::exception_ptr ex) override;
 
   /**
    * Get a unique Observer<T> that can be passed into the Observable.subscribe
@@ -174,7 +174,7 @@ void TestObserver<T>::onComplete() {
 }
 
 template <typename T>
-void TestObserver<T>::onError(const std::exception_ptr ex) {
+void TestObserver<T>::onError(std::exception_ptr ex) {
   if (delegate_) {
     delegate_->onError(ex);
   }
@@ -211,7 +211,7 @@ TestObserver<T>::unique_observer() {
       ts_->onNext(t);
     }
 
-    void onError(const std::exception_ptr e) override {
+    void onError(std::exception_ptr e) override {
       ts_->onError(e);
     }
 

--- a/yarpl/include/yarpl/single/Single.h
+++ b/yarpl/include/yarpl/single/Single.h
@@ -46,7 +46,7 @@ class Single : public virtual Refcounted {
       typename Error,
       typename = typename std::enable_if<
           std::is_callable<Success(T), void>::value &&
-          std::is_callable<Error(const std::exception_ptr), void>::value>::type>
+          std::is_callable<Error(std::exception_ptr), void>::value>::type>
   void subscribe(Success&& next, Error&& error) {
     subscribe(SingleObservers::create<T>(next, error));
   }
@@ -114,7 +114,7 @@ class Single<void> : public virtual Refcounted {
       }
 
       // No further calls to the subscription after this method is invoked.
-      virtual void onError(const std::exception_ptr eptr) override {
+      virtual void onError(std::exception_ptr eptr) override {
         SingleObserver<void>::onError(eptr);
       }
 

--- a/yarpl/include/yarpl/single/SingleObserver.h
+++ b/yarpl/include/yarpl/single/SingleObserver.h
@@ -24,7 +24,7 @@ class SingleObserver : public virtual Refcounted {
   }
 
   // No further calls to the subscription after this method is invoked.
-  virtual void onError(const std::exception_ptr) {
+  virtual void onError(std::exception_ptr) {
     subscription_.reset();
   }
 
@@ -55,7 +55,7 @@ class SingleObserver<void> : public virtual Refcounted {
   }
 
   // No further calls to the subscription after this method is invoked.
-  virtual void onError(const std::exception_ptr) {
+  virtual void onError(std::exception_ptr) {
     subscription_.reset();
   }
 

--- a/yarpl/include/yarpl/single/SingleOperator.h
+++ b/yarpl/include/yarpl/single/SingleOperator.h
@@ -62,7 +62,7 @@ class SingleOperator : public Single<D> {
           Reference<::yarpl::single::SingleSubscription>(this));
     }
 
-    void onError(const std::exception_ptr error) override {
+    void onError(std::exception_ptr error) override {
       observer_->onError(error);
       upstreamSubscription_.reset(); // should break the cycle to this
     }

--- a/yarpl/include/yarpl/single/SingleTestObserver.h
+++ b/yarpl/include/yarpl/single/SingleTestObserver.h
@@ -107,7 +107,7 @@ class SingleTestObserver : public yarpl::single::SingleObserver<T> {
     terminalEventCV_.notify_all();
   }
 
-  void onError(const std::exception_ptr ex) override {
+  void onError(std::exception_ptr ex) override {
     if (delegate_) {
       // Do NOT hold the mutex while emitting
       delegate_->onError(ex);

--- a/yarpl/src/yarpl/flowable/sources/Flowable_FromObservable.h
+++ b/yarpl/src/yarpl/flowable/sources/Flowable_FromObservable.h
@@ -88,7 +88,7 @@ class FlowableFromObservableSubscription
   }
 
   // Observer override
-  void onError(const std::exception_ptr error) override {
+  void onError(std::exception_ptr error) override {
     subscriber_->onError(error);
     release();
   }

--- a/yarpl/test/FlowableChaining_test.cpp
+++ b/yarpl/test/FlowableChaining_test.cpp
@@ -37,7 +37,7 @@ TEST(FlowableChaining, Lift) {
       std::cout << "onComplete " << std::endl;
     }
 
-    void onError(const std::exception_ptr error) {
+    void onError(std::exception_ptr error) {
       std::cout << "onError " << std::endl;
     }
 
@@ -80,7 +80,7 @@ TEST(FlowableChaining, Map) {
       std::cout << "onComplete " << std::endl;
     }
 
-    void onError(const std::exception_ptr error) {
+    void onError(std::exception_ptr error) {
       std::cout << "onError " << std::endl;
     }
   };

--- a/yarpl/test/FlowableCreateSubscribe_test.cpp
+++ b/yarpl/test/FlowableCreateSubscribe_test.cpp
@@ -67,7 +67,7 @@ TEST(FlowableCreateSubscribe, SubscribeRequestAndCancel) {
         subscription->cancel();
       }
     }
-    void onError(const std::exception_ptr e) override {}
+    void onError(std::exception_ptr e) override {}
     void onComplete() override {}
     void onSubscribe(Subscription* s) override {
       std::cout << "onSubscribe in subscriber" << std::endl;
@@ -199,7 +199,7 @@ TEST(
                 << std::this_thread::get_id() << std::endl;
     }
 
-    void onError(const std::exception_ptr e) override {}
+    void onError(std::exception_ptr e) override {}
     void onComplete() override {}
     void onSubscribe(Subscription* s) override {
       subscription_ = std::move(s);

--- a/yarpl/test/FlowableTest.cpp
+++ b/yarpl/test/FlowableTest.cpp
@@ -34,7 +34,7 @@ class CollectingSubscriber : public Subscriber<T> {
     complete_ = true;
   }
 
-  void onError(const std::exception_ptr ex) override {
+  void onError(std::exception_ptr ex) override {
     Subscriber<T>::onError(ex);
     error_ = true;
     errorMsg_ = yarpl::exceptionStr(ex);

--- a/yarpl/test/Flowable_lifecycle.cpp
+++ b/yarpl/test/Flowable_lifecycle.cpp
@@ -73,7 +73,7 @@ TEST(FlowableLifecycle, DISABLED_HandlerClass) {
       std::cout << "onComplete " << std::endl;
     }
 
-    void onError(const std::exception_ptr error) {
+    void onError(std::exception_ptr) {
       std::cout << "onError " << std::endl;
     }
 

--- a/yarpl/test/Flowable_range_test.cpp
+++ b/yarpl/test/Flowable_range_test.cpp
@@ -65,7 +65,7 @@ TEST(FlowableRange, 1_to_100_in_concurrent_jumps) {
       std::cout << "onComplete " << std::endl;
     }
 
-    void onError(const std::exception_ptr error) {
+    void onError(std::exception_ptr) {
       std::cout << "onError " << std::endl;
     }
 

--- a/yarpl/test/Observable_test.cpp
+++ b/yarpl/test/Observable_test.cpp
@@ -123,7 +123,7 @@ TEST(Observable, OnError) {
 
   a->subscribe(Observers::create<int>(
       [](int value) { /* do nothing */ },
-      [&errorMessage](const std::exception_ptr e) {
+      [&errorMessage](std::exception_ptr e) {
         try {
           std::rethrow_exception(e);
         } catch (const std::runtime_error& ex) {
@@ -226,7 +226,7 @@ class TakeObserver : public Observer<int> {
     }
   }
 
-  void onError(const std::exception_ptr e) override {}
+  void onError(std::exception_ptr) override {}
   void onComplete() override {}
 };
 


### PR DESCRIPTION
Don't put `const` on a class type in a function's parameter list.