### PR TITLE
Replace almost all uses of CollectingSubscriber with TestSubscriber

### DIFF
--- a/yarpl/include/yarpl/flowable/TestSubscriber.h
+++ b/yarpl/include/yarpl/flowable/TestSubscriber.h
@@ -9,6 +9,7 @@
 
 #include "Flowable.h"
 #include "Subscriber.h"
+#include "yarpl/utils/ExceptionString.h"
 #include "yarpl/utils/credits.h"
 
 namespace yarpl {
@@ -137,6 +138,13 @@ class TestSubscriber : public Subscriber<T> {
 
   bool isError() const {
     return terminated_ && e_;
+  }
+
+  std::string getErrorMsg() const {
+    if (e_ == nullptr) {
+      return "";
+    }
+    return exceptionStr(e_);
   }
 
   void assertValueAt(int64_t index, T expected) {

--- a/yarpl/include/yarpl/flowable/TestSubscriber.h
+++ b/yarpl/include/yarpl/flowable/TestSubscriber.h
@@ -24,20 +24,23 @@ namespace flowable {
  * flowable->subscribe(to);
  * ts->awaitTerminalEvent();
  * ts->assert...
- *
- * @tparam T
  */
 template <typename T>
 class TestSubscriber : public Subscriber<T> {
  public:
+  static_assert(
+      std::is_copy_constructible<T>::value,
+      "Requires copyable types in case of a delegate subscriber");
+
+  constexpr static auto kCanceled = credits::kCanceled;
+  constexpr static auto kNoFlowControl = credits::kNoFlowControl;
+
   /**
    * Create a TestSubscriber that will subscribe and store the value it
    * receives.
-   *
-   * @return
    */
-  static Reference<TestSubscriber<T>> create() {
-    return make_ref<TestSubscriber<T>>();
+  static Reference<TestSubscriber<T>> create(int64_t initial = kNoFlowControl) {
+    return make_ref<TestSubscriber<T>>(initial);
   }
 
   /**
@@ -45,17 +48,20 @@ class TestSubscriber : public Subscriber<T> {
    * to the provided Subscriber.
    *
    * This will store the value it receives to allow assertions.
-   * @return
    */
   static Reference<TestSubscriber<T>> create(
-      Reference<Subscriber<T>> delegate) {
-    return make_ref<TestSubscriber<T>>(std::move(delegate));
+      Reference<Subscriber<T>> delegate,
+      int64_t initial = kNoFlowControl) {
+    return make_ref<TestSubscriber<T>>(std::move(delegate), initial);
   }
 
-  TestSubscriber() : delegate_(nullptr) {}
+  explicit TestSubscriber(int64_t initial = kNoFlowControl)
+      : TestSubscriber(Reference<Subscriber<T>>{}, initial) {}
 
-  explicit TestSubscriber(Reference<Subscriber<T>> delegate)
-      : delegate_(std::move(delegate)) {}
+  explicit TestSubscriber(
+      Reference<Subscriber<T>> delegate,
+      int64_t initial = kNoFlowControl)
+      : delegate_(std::move(delegate)), initial_{initial} {}
 
   void onSubscribe(Reference<Subscription> subscription) override {
     if (delegate_) {
@@ -64,7 +70,7 @@ class TestSubscriber : public Subscriber<T> {
     } else {
       subscription_ = std::move(subscription);
     }
-    subscription_->request(credits::kNoFlowControl);
+    subscription_->request(initial_);
   }
 
   void onNext(T t) override {
@@ -117,13 +123,25 @@ class TestSubscriber : public Subscriber<T> {
     return values_.size();
   }
 
-  T& getValueAt(size_t index) {
-    return values_[index];
+  std::vector<T>& values() {
+    return values_;
+  }
+
+  const std::vector<T>& values() const {
+    return values_;
+  }
+
+  bool isComplete() const {
+    return terminated_ && !e_;
+  }
+
+  bool isError() const {
+    return terminated_ && e_;
   }
 
   void assertValueAt(int64_t index, T expected) {
     if (index < getValueCount()) {
-      T& v = getValueAt(index);
+      auto& v = values_[index];
       if (expected != v) {
         std::stringstream ss;
         ss << "Expected: " << expected << " Actual: " << v;
@@ -183,6 +201,7 @@ class TestSubscriber : public Subscriber<T> {
   Reference<Subscriber<T>> delegate_;
   std::vector<T> values_;
   std::exception_ptr e_;
+  int64_t initial_{kNoFlowControl};
   bool terminated_{false};
   std::mutex m_;
   std::condition_variable terminalEventCV_;

--- a/yarpl/test/FlowableTest.cpp
+++ b/yarpl/test/FlowableTest.cpp
@@ -3,17 +3,18 @@
 #include <type_traits>
 #include <vector>
 #include <gtest/gtest.h>
+
 #include "yarpl/Flowable.h"
+#include "yarpl/flowable/TestSubscriber.h"
 #include "yarpl/utils/ExceptionString.h"
 
 namespace yarpl {
 namespace flowable {
 namespace {
 
-void unreachable() {
-  EXPECT_TRUE(false);
-}
-
+/*
+ * Used in place of TestSubscriber where we have move-only types.
+ */
 template <typename T>
 class CollectingSubscriber : public Subscriber<T> {
  public:
@@ -44,11 +45,11 @@ class CollectingSubscriber : public Subscriber<T> {
     return values_;
   }
 
-  bool complete() const {
+  bool isComplete() const {
     return complete_;
   }
 
-  bool error() const {
+  bool isError() const {
     return error_;
   }
 
@@ -68,16 +69,16 @@ class CollectingSubscriber : public Subscriber<T> {
   int64_t requestCount_;
 };
 
-/// Construct a pipeline with a collecting subscriber against the supplied
+/// Construct a pipeline with a test subscriber against the supplied
 /// flowable.  Return the items that were sent to the subscriber.  If some
 /// exception was sent, the exception is thrown.
 template <typename T>
 std::vector<T> run(
     Reference<Flowable<T>> flowable,
-    uint64_t requestCount = 100) {
-  auto collector = make_ref<CollectingSubscriber<T>>(requestCount);
-  flowable->subscribe(collector);
-  return std::move(collector->values());
+    int64_t requestCount = 100) {
+  auto subscriber = make_ref<TestSubscriber<T>>(requestCount);
+  flowable->subscribe(subscriber);
+  return std::move(subscriber->values());
 }
 
 } // namespace
@@ -93,14 +94,15 @@ TEST(FlowableTest, SingleMovableFlowable) {
   auto flowable = Flowables::justOnce(std::move(value));
   EXPECT_EQ(std::size_t{1}, flowable->count());
 
-  auto values = run(std::move(flowable));
-  EXPECT_EQ(
-      values.size(),
-      size_t(1));
+  size_t received = 0;
+  auto subscriber =
+      Subscribers::create<std::unique_ptr<int>>([&](std::unique_ptr<int> p) {
+        EXPECT_EQ(*p, 123456);
+        received++;
+      });
 
-  EXPECT_EQ(
-      *values[0],
-      123456);
+  flowable->subscribe(std::move(subscriber));
+  EXPECT_EQ(received, 1u);
 }
 
 TEST(FlowableTest, JustFlowable) {
@@ -187,11 +189,11 @@ TEST(FlowableTest, RangeWithReduceOneItem) {
 TEST(FlowableTest, RangeWithReduceNoItem) {
   auto flowable = Flowables::range(0, 0)
     ->reduce([](int64_t acc, int64_t v) { return acc + v; });
-  auto collector = make_ref<CollectingSubscriber<int64_t>>(100);
-  flowable->subscribe(collector);
-  EXPECT_EQ(collector->error(), false);
-  EXPECT_EQ(
-    collector->values(), std::vector<int64_t>({}));
+  auto subscriber = make_ref<TestSubscriber<int64_t>>(100);
+  flowable->subscribe(subscriber);
+
+  EXPECT_TRUE(subscriber->isComplete());
+  EXPECT_EQ(subscriber->values(), std::vector<int64_t>({}));
 }
 
 TEST(FlowableTest, RangeWithFilterAndReduce) {
@@ -263,12 +265,12 @@ TEST(FlowableTest, OverflowSkip) {
 }
 
 TEST(FlowableTest, SkipPartial) {
-  auto collector = make_ref<CollectingSubscriber<int64_t>>(2);
+  auto subscriber = make_ref<TestSubscriber<int64_t>>(2);
   auto flowable = Flowables::range(0, 10)->skip(5);
-  flowable->subscribe(collector);
+  flowable->subscribe(subscriber);
 
-  EXPECT_EQ(collector->values(), std::vector<int64_t>({5, 6}));
-  collector->cancelSubscription();
+  EXPECT_EQ(subscriber->values(), std::vector<int64_t>({5, 6}));
+  subscriber->cancel();
 }
 
 TEST(FlowableTest, IgnoreElements) {
@@ -279,75 +281,78 @@ TEST(FlowableTest, IgnoreElements) {
 }
 
 TEST(FlowableTest, IgnoreElementsPartial) {
-  auto collector = make_ref<CollectingSubscriber<int64_t>>(5);
+  auto subscriber = make_ref<TestSubscriber<int64_t>>(5);
   auto flowable = Flowables::range(0, 10)->ignoreElements();
-  flowable->subscribe(collector);
+  flowable->subscribe(subscriber);
 
-  EXPECT_EQ(
-      collector->values(),
-      std::vector<int64_t>({}));
-  EXPECT_EQ(collector->complete(), false);
-  collector->cancelSubscription();
+  EXPECT_EQ(subscriber->values(), std::vector<int64_t>({}));
+  EXPECT_FALSE(subscriber->isComplete());
+  EXPECT_FALSE(subscriber->isError());
 
-  flowable.reset();
-  collector.reset();
+  subscriber->cancel();
 }
 
 TEST(FlowableTest, IgnoreElementsError) {
-  auto collector = make_ref<CollectingSubscriber<int>>();
-  auto flowable = Flowables::error<int>(std::runtime_error("Failure"));
-  flowable->subscribe(collector);
-  EXPECT_EQ(collector->error(), true);
-  EXPECT_EQ(collector->errorMsg(), "Failure");
+  constexpr auto kMsg = "Failure";
+
+  auto subscriber = make_ref<TestSubscriber<int>>();
+  auto flowable = Flowables::error<int>(std::runtime_error(kMsg));
+  flowable->subscribe(subscriber);
+
+  EXPECT_TRUE(subscriber->isError());
+  subscriber->assertOnErrorMessage(kMsg);
 }
 
 TEST(FlowableTest, FlowableError) {
-  auto flowable = Flowables::error<int>(std::runtime_error("something broke!"));
-  auto collector = make_ref<CollectingSubscriber<int>>();
-  flowable->subscribe(collector);
+  constexpr auto kMsg = "something broke!";
 
-  EXPECT_EQ(collector->complete(), false);
-  EXPECT_EQ(collector->error(), true);
-  EXPECT_EQ(collector->errorMsg(), "something broke!");
+  auto flowable = Flowables::error<int>(std::runtime_error(kMsg));
+  auto subscriber = make_ref<TestSubscriber<int>>();
+  flowable->subscribe(subscriber);
+
+  EXPECT_FALSE(subscriber->isComplete());
+  EXPECT_TRUE(subscriber->isError());
+  subscriber->assertOnErrorMessage(kMsg);
 }
 
 TEST(FlowableTest, FlowableErrorPtr) {
-  auto flowable = Flowables::error<int>(
-      std::make_exception_ptr(std::runtime_error("something broke!")));
-  auto collector = make_ref<CollectingSubscriber<int>>();
-  flowable->subscribe(collector);
+  constexpr auto kMsg = "something broke!";
 
-  EXPECT_EQ(collector->complete(), false);
-  EXPECT_EQ(collector->error(), true);
-  EXPECT_EQ(collector->errorMsg(), "something broke!");
+  auto flowable = Flowables::error<int>(
+      std::make_exception_ptr(std::runtime_error(kMsg)));
+  auto subscriber = make_ref<TestSubscriber<int>>();
+  flowable->subscribe(subscriber);
+
+  EXPECT_FALSE(subscriber->isComplete());
+  EXPECT_TRUE(subscriber->isError());
+  subscriber->assertOnErrorMessage(kMsg);
 }
 
 TEST(FlowableTest, FlowableEmpty) {
   auto flowable = Flowables::empty<int>();
-  auto collector = make_ref<CollectingSubscriber<int>>();
-  flowable->subscribe(collector);
+  auto subscriber = make_ref<TestSubscriber<int>>();
+  flowable->subscribe(subscriber);
 
-  EXPECT_EQ(collector->complete(), true);
-  EXPECT_EQ(collector->error(), false);
+  EXPECT_TRUE(subscriber->isComplete());
+  EXPECT_FALSE(subscriber->isError());
 }
 
 TEST(FlowableTest, FlowableFromGenerator) {
   auto flowable = Flowables::fromGenerator<std::unique_ptr<int>>(
-      [] {return std::unique_ptr<int>();}
-  );
+      [] { return std::unique_ptr<int>(); });
 
-  auto collector = make_ref<CollectingSubscriber<std::unique_ptr<int>>>(10);
-  flowable->subscribe(collector);
+  auto subscriber = make_ref<CollectingSubscriber<std::unique_ptr<int>>>(10);
+  flowable->subscribe(subscriber);
 
-  EXPECT_EQ(collector->complete(), false);
-  EXPECT_EQ(collector->error(), false);
-  EXPECT_EQ(std::size_t{10}, collector->values().size());
+  EXPECT_FALSE(subscriber->isComplete());
+  EXPECT_FALSE(subscriber->isError());
+  EXPECT_EQ(std::size_t{10}, subscriber->values().size());
 
-  collector->cancelSubscription();
+  subscriber->cancelSubscription();
 }
 
 TEST(FlowableTest, FlowableFromGeneratorException) {
-  constexpr const char* errorMsg = "error from generator";
+  constexpr auto errorMsg = "error from generator";
   int count = 5;
   auto flowable = Flowables::fromGenerator<std::unique_ptr<int>>(
   [&] {
@@ -355,40 +360,27 @@ TEST(FlowableTest, FlowableFromGeneratorException) {
     throw std::runtime_error(errorMsg);
   });
 
-  auto collector = make_ref<CollectingSubscriber<std::unique_ptr<int>>>(10);
-  flowable->subscribe(collector);
+  auto subscriber = make_ref<CollectingSubscriber<std::unique_ptr<int>>>(10);
+  flowable->subscribe(subscriber);
 
-  EXPECT_EQ(collector->complete(), false);
-  EXPECT_EQ(collector->error(), true);
-  EXPECT_EQ(collector->errorMsg(), errorMsg);
-  EXPECT_EQ(std::size_t{5}, collector->values().size());
+  EXPECT_FALSE(subscriber->isComplete());
+  EXPECT_TRUE(subscriber->isError());
+  EXPECT_EQ(subscriber->errorMsg(), errorMsg);
+  EXPECT_EQ(std::size_t{5}, subscriber->values().size());
 }
 
 TEST(FlowableTest, SubscribersComplete) {
   auto flowable = Flowables::empty<int>();
-
-  bool completed = false;
-
   auto subscriber = Subscribers::create<int>(
-      [](int) { unreachable(); },
-      [](std::exception_ptr) { unreachable(); },
-      [&] { completed = true; });
-
+      [](int) { FAIL(); }, [](std::exception_ptr) { FAIL(); }, [&] {});
   flowable->subscribe(std::move(subscriber));
-  EXPECT_TRUE(completed);
 }
 
 TEST(FlowableTest, SubscribersError) {
   auto flowable = Flowables::error<int>(std::runtime_error("Whoops"));
-  bool errored = false;
-
   auto subscriber = Subscribers::create<int>(
-      [](int) { unreachable(); },
-      [&](std::exception_ptr) { errored = true; },
-      [] { unreachable(); });
-
+      [](int) { FAIL(); }, [&](std::exception_ptr) {}, [] { FAIL(); });
   flowable->subscribe(std::move(subscriber));
-  EXPECT_TRUE(errored);
 }
 
 TEST(FlowableTest, FlowableCompleteInTheMiddle) {
@@ -400,12 +392,12 @@ TEST(FlowableTest, FlowableCompleteInTheMiddle) {
         return std::make_tuple(int64_t(1), true);
       })->map([](int v) { return std::to_string(v); });
 
-  auto collector = make_ref<CollectingSubscriber<std::string>>(10);
-  flowable->subscribe(collector);
+  auto subscriber = make_ref<TestSubscriber<std::string>>(10);
+  flowable->subscribe(subscriber);
 
-  EXPECT_EQ(collector->complete(), true);
-  EXPECT_EQ(collector->error(), false);
-  EXPECT_EQ(std::size_t{1}, collector->values().size());
+  EXPECT_TRUE(subscriber->isComplete());
+  EXPECT_FALSE(subscriber->isError());
+  EXPECT_EQ(std::size_t{1}, subscriber->values().size());
 }
 
 } // flowable

--- a/yarpl/test/FlowableTest.cpp
+++ b/yarpl/test/FlowableTest.cpp
@@ -300,7 +300,7 @@ TEST(FlowableTest, IgnoreElementsError) {
   flowable->subscribe(subscriber);
 
   EXPECT_TRUE(subscriber->isError());
-  subscriber->assertOnErrorMessage(kMsg);
+  EXPECT_EQ(subscriber->getErrorMsg(), kMsg);
 }
 
 TEST(FlowableTest, FlowableError) {
@@ -312,7 +312,7 @@ TEST(FlowableTest, FlowableError) {
 
   EXPECT_FALSE(subscriber->isComplete());
   EXPECT_TRUE(subscriber->isError());
-  subscriber->assertOnErrorMessage(kMsg);
+  EXPECT_EQ(subscriber->getErrorMsg(), kMsg);
 }
 
 TEST(FlowableTest, FlowableErrorPtr) {
@@ -325,7 +325,7 @@ TEST(FlowableTest, FlowableErrorPtr) {
 
   EXPECT_FALSE(subscriber->isComplete());
   EXPECT_TRUE(subscriber->isError());
-  subscriber->assertOnErrorMessage(kMsg);
+  EXPECT_EQ(subscriber->getErrorMsg(), kMsg);
 }
 
 TEST(FlowableTest, FlowableEmpty) {


### PR DESCRIPTION
The remaining places are where we use noncopyable types, something which
TestSubscriber doesn't support.