### PR TITLE
Warm-resumption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -634,6 +634,34 @@ target_link_libraries(
   ${GFLAGS_LIBRARY}
   ${GLOG_LIBRARY})
 
+# warm-resumption
+
+add_executable(
+  example_warm-resumption-server
+  examples/warm-resumption/WarmResumption_Server.cpp
+)
+
+target_link_libraries(
+  example_warm-resumption-server
+  ReactiveSocket
+  reactivesocket_examples_util
+  yarpl
+  ${GFLAGS_LIBRARY}
+  ${GLOG_LIBRARY})
+
+add_executable(
+  example_warm-resumption-client
+  examples/warm-resumption/WarmResumption_Client.cpp
+)
+
+target_link_libraries(
+  example_warm-resumption-client
+  ReactiveSocket
+  reactivesocket_examples_util
+  yarpl
+  ${GFLAGS_LIBRARY}
+  ${GLOG_LIBRARY})
+
 
 ########################################
 # End Examples

--- a/examples/warm-resumption/WarmResumption_Client.cpp
+++ b/examples/warm-resumption/WarmResumption_Client.cpp
@@ -1,0 +1,118 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <iostream>
+
+#include <folly/init/Init.h>
+#include <folly/io/async/ScopedEventBaseThread.h>
+#include <folly/portability/GFlags.h>
+
+#include "examples/util/ExampleSubscriber.h"
+#include "src/RSocket.h"
+#include "src/transports/tcp/TcpConnectionFactory.h"
+
+#include "yarpl/Flowable.h"
+
+using namespace rsocket_example;
+using namespace rsocket;
+
+DEFINE_string(host, "localhost", "host to connect to");
+DEFINE_int32(port, 9898, "host:port to connect to");
+
+namespace {
+
+class HelloSubscriber : public virtual yarpl::Refcounted,
+                        public yarpl::flowable::Subscriber<Payload> {
+ public:
+  void request(int n) {
+    LOG(INFO) << "... requesting " << n;
+    while (!subscription_) {
+      std::this_thread::yield();
+    }
+    subscription_->request(n);
+  }
+
+  void cancel() {
+    if (auto subscription = std::move(subscription_)) {
+      subscription->cancel();
+    }
+  }
+
+  int rcvdCount() const {
+    return count_;
+  };
+
+ protected:
+  void onSubscribe(yarpl::Reference<yarpl::flowable::Subscription>
+                       subscription) noexcept override {
+    subscription_ = subscription;
+  }
+
+  void onNext(Payload element) noexcept override {
+    LOG(INFO) << "Received: " << element.moveDataToString() << std::endl;
+    count_++;
+  }
+
+  void onComplete() noexcept override {
+    LOG(INFO) << "Received: onComplete";
+  }
+
+  void onError(std::exception_ptr) noexcept override {
+    LOG(INFO) << "Received: onError ";
+  }
+
+ private:
+  yarpl::Reference<yarpl::flowable::Subscription> subscription_{nullptr};
+  std::atomic<int> count_{0};
+};
+}
+
+int main(int argc, char* argv[]) {
+  FLAGS_logtostderr = true;
+  FLAGS_minloglevel = 0;
+  folly::init(&argc, &argv);
+
+  folly::SocketAddress address;
+  address.setFromHostPort(FLAGS_host, FLAGS_port);
+
+  // create a client which can then make connections below
+  auto client = RSocket::createClient(
+      std::make_unique<TcpConnectionFactory>(std::move(address)));
+
+  // connect and wait for connection
+  SetupParameters setupParameters;
+  setupParameters.resumable = true;
+  auto rs = client->connect(std::move(setupParameters)).get();
+
+  // subscriber
+  auto subscriber = yarpl::make_ref<HelloSubscriber>();
+
+  // perform request on connected RSocket
+  rs->requestStream(Payload("Jane"))->subscribe(subscriber);
+
+  subscriber->request(7);
+
+  while (subscriber->rcvdCount() < 3) {
+    std::this_thread::yield();
+  }
+
+  client->disconnect(std::runtime_error("disconnect triggered from client"));
+
+  // This request should get buffered
+  subscriber->request(3);
+
+  client->resume(std::make_unique<DefaultResumeCallback>());
+
+  subscriber->request(3);
+
+  while (subscriber->rcvdCount() < 13) {
+    std::this_thread::yield();
+  }
+
+  std::getchar();
+
+  subscriber->cancel();
+
+  std::getchar();
+
+  return 0;
+}

--- a/examples/warm-resumption/WarmResumption_Client.cpp
+++ b/examples/warm-resumption/WarmResumption_Client.cpp
@@ -7,6 +7,7 @@
 #include <folly/portability/GFlags.h>
 
 #include "examples/util/ExampleSubscriber.h"
+#include "src/internal/ClientResumeStatusCallback.h"
 #include "src/RSocket.h"
 #include "src/transports/tcp/TcpConnectionFactory.h"
 

--- a/examples/warm-resumption/WarmResumption_Server.cpp
+++ b/examples/warm-resumption/WarmResumption_Server.cpp
@@ -55,7 +55,7 @@ int main(int argc, char* argv[]) {
   auto serverThread = std::thread([=] {
     // start accepting connections
     rawRs->startAndPark([responder](auto& setup) {
-      setup.createRSocket(responder, FLAGS_resumable);
+      setup.createRSocket(responder, ServerOptions(FLAGS_resumable));
     });
   });
 

--- a/examples/warm-resumption/WarmResumption_Server.cpp
+++ b/examples/warm-resumption/WarmResumption_Server.cpp
@@ -1,0 +1,69 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <iostream>
+#include <thread>
+
+#include <folly/init/Init.h>
+#include <folly/portability/GFlags.h>
+
+#include "src/RSocket.h"
+#include "src/transports/tcp/TcpConnectionAcceptor.h"
+#include "yarpl/Flowable.h"
+
+using namespace rsocket;
+using namespace yarpl::flowable;
+
+DEFINE_int32(port, 9898, "Port to accept connections on");
+DEFINE_bool(resumable, true, "Whether the server supports resumption");
+
+class HelloStreamRequestResponder : public rsocket::RSocketResponder {
+ public:
+  /// Handles a new inbound Stream requested by the other end.
+  yarpl::Reference<Flowable<rsocket::Payload>> handleRequestStream(
+      rsocket::Payload request,
+      rsocket::StreamId) override {
+    // string from payload data
+    auto requestString = request.moveDataToString();
+
+    return Flowables::range(1, 1000)->map([name = std::move(requestString)](
+        int64_t v) {
+      std::stringstream ss;
+      ss << "Hello " << name << " " << v << "!";
+      std::string s = ss.str();
+      return Payload(s, "metadata");
+    });
+  }
+};
+
+int main(int argc, char* argv[]) {
+  FLAGS_logtostderr = true;
+  FLAGS_minloglevel = 0;
+  folly::init(&argc, &argv);
+
+  TcpConnectionAcceptor::Options opts;
+  opts.port = FLAGS_port;
+  opts.threads = 1;
+
+  // RSocket server accepting on TCP
+  auto rs = RSocket::createServer(
+      std::make_unique<TcpConnectionAcceptor>(std::move(opts)));
+
+  // global request responder
+  auto responder = std::make_shared<HelloStreamRequestResponder>();
+
+  auto rawRs = rs.get();
+  auto serverThread = std::thread([=] {
+    // start accepting connections
+    rawRs->startAndPark([responder](auto& setup) {
+      setup.createRSocket(responder, FLAGS_resumable);
+    });
+  });
+
+  // Wait for a newline on the console to terminate the server.
+  std::getchar();
+
+  rs->unpark();
+  serverThread.join();
+
+  return 0;
+}

--- a/src/RSocketClient.cpp
+++ b/src/RSocketClient.cpp
@@ -85,9 +85,6 @@ folly::Future<folly::Unit> RSocketClient::resume() {
       void onResumeError(folly::exception_wrapper ex) noexcept override {
         promise_.setException(ex);
       }
-      void onConnectionError(folly::exception_wrapper ex) noexcept override {
-        promise_.setException(ex);
-      }
       folly::Promise<folly::Unit> promise_;
     };
 

--- a/src/RSocketClient.h
+++ b/src/RSocketClient.h
@@ -62,7 +62,7 @@ class RSocketClient {
       std::shared_ptr<RSocketStats> stats = std::shared_ptr<RSocketStats>(),
       std::shared_ptr<RSocketNetworkStats> networkStats = std::shared_ptr<RSocketNetworkStats>());
 
-  void resume(std::unique_ptr<ClientResumeStatusCallback> resumeCallback);
+  folly::Future<folly::Unit> resume();
 
   void disconnect(folly::exception_wrapper ex);
 

--- a/src/RSocketClient.h
+++ b/src/RSocketClient.h
@@ -8,7 +8,6 @@
 #include "src/RSocketNetworkStats.h"
 #include "src/RSocketParameters.h"
 #include "src/RSocketStats.h"
-#include "src/internal/ClientResumeStatusCallback.h"
 
 namespace rsocket {
 

--- a/src/RSocketClient.h
+++ b/src/RSocketClient.h
@@ -72,6 +72,7 @@ class RSocketClient {
 
   std::shared_ptr<RSocketStateMachine> stateMachine_;
   folly::EventBase* evb_;
+  ProtocolVersion protocolVersion_;
   ResumeIdentificationToken resumeToken_;
 };
 }

--- a/src/RSocketClient.h
+++ b/src/RSocketClient.h
@@ -8,6 +8,7 @@
 #include "src/RSocketNetworkStats.h"
 #include "src/RSocketParameters.h"
 #include "src/RSocketStats.h"
+#include "src/internal/ClientResumeStatusCallback.h"
 
 namespace rsocket {
 
@@ -61,8 +62,16 @@ class RSocketClient {
       std::shared_ptr<RSocketStats> stats = std::shared_ptr<RSocketStats>(),
       std::shared_ptr<RSocketNetworkStats> networkStats = std::shared_ptr<RSocketNetworkStats>());
 
+  void resume(std::unique_ptr<ClientResumeStatusCallback> resumeCallback);
+
+  void disconnect(folly::exception_wrapper ex);
+
  private:
   std::unique_ptr<ConnectionFactory> connectionFactory_;
   std::unique_ptr<RSocketConnectionManager> connectionManager_;
+
+  std::shared_ptr<RSocketStateMachine> stateMachine_;
+  folly::EventBase* evb_;
+  ResumeIdentificationToken resumeToken_;
 };
 }

--- a/src/RSocketParameters.h
+++ b/src/RSocketParameters.h
@@ -61,4 +61,11 @@ class ResumeParameters : public RSocketParameters {
   ResumePosition clientPosition;
 };
 
+class ServerOptions {
+ public:
+  ServerOptions(bool _resumable = false) : resumable(_resumable) {}
+
+  bool resumable;
+};
+
 } // reactivesocket

--- a/src/RSocketRequester.cpp
+++ b/src/RSocketRequester.cpp
@@ -26,14 +26,6 @@ RSocketRequester::~RSocketRequester() {
   }
 }
 
-void RSocketRequester::closeSocket() {
-  eventBase_.add([stateMachine = std::move(stateMachine_)]{
-    VLOG(2) << "Closing RSocketStateMachine on EventBase";
-    stateMachine->close(
-        folly::exception_wrapper(), StreamCompletionSignal::SOCKET_CLOSED);
-  });
-}
-
 yarpl::Reference<yarpl::flowable::Flowable<rsocket::Payload>>
 RSocketRequester::requestChannel(
     yarpl::Reference<yarpl::flowable::Flowable<rsocket::Payload>>

--- a/src/RSocketRequester.h
+++ b/src/RSocketRequester.h
@@ -92,8 +92,6 @@ class RSocketRequester {
    */
   void metadataPush(std::unique_ptr<folly::IOBuf> metadata);
 
-  void closeSocket();
-
  private:
   std::shared_ptr<rsocket::RSocketStateMachine> stateMachine_;
   folly::EventBase& eventBase_;

--- a/src/RSocketServer.cpp
+++ b/src/RSocketServer.cpp
@@ -7,6 +7,7 @@
 #include "src/framing/FrameTransport.h"
 #include "src/framing/FramedDuplexConnection.h"
 #include "src/internal/RSocketConnectionManager.h"
+#include "src/statemachine/RSocketStateMachine.h"
 
 namespace rsocket {
 
@@ -131,8 +132,14 @@ void RSocketServer::onRSocketSetup(
 
 bool RSocketServer::onRSocketResume(
     OnRSocketResume,
-    yarpl::Reference<FrameTransport>,
-    ResumeParameters) {
+    std::shared_ptr<FrameTransport> frameTransport,
+    ResumeParameters resumeParams) {
+  auto rsocketStateMachine =
+      connectionManager_->getConnection(resumeParams.token);
+  if (rsocketStateMachine) {
+    return rsocketStateMachine->resumeServer(
+        std::move(frameTransport), std::move(resumeParams));
+  }
   return false;
 }
 

--- a/src/RSocketServer.cpp
+++ b/src/RSocketServer.cpp
@@ -132,7 +132,7 @@ void RSocketServer::onRSocketSetup(
 
 bool RSocketServer::onRSocketResume(
     OnRSocketResume,
-    std::shared_ptr<FrameTransport> frameTransport,
+    yarpl::Reference<FrameTransport> frameTransport,
     ResumeParameters resumeParams) {
   auto rsocketStateMachine =
       connectionManager_->getConnection(resumeParams.token);

--- a/src/RSocketServer.h
+++ b/src/RSocketServer.h
@@ -92,7 +92,6 @@ class RSocketServer {
   folly::Optional<uint16_t> listeningPort() const;
 
  private:
-
   void onRSocketSetup(
       OnRSocketSetup onRSocketSetup,
       yarpl::Reference<rsocket::FrameTransport> frameTransport,

--- a/src/RSocketSetup.cpp
+++ b/src/RSocketSetup.cpp
@@ -34,15 +34,23 @@ std::unique_ptr<RSocketRequester> RSocketSetup::createRSocketRequester(
     std::shared_ptr<RSocketResponder> requestResponder,
     std::shared_ptr<RSocketStats> stats,
     std::shared_ptr<RSocketNetworkStats> networkStats) {
-  auto rs = createRSocketStateMachine(std::move(requestResponder), std::move(stats), std::move(networkStats));
+  auto rs = createRSocketStateMachine(
+      std::move(requestResponder), std::move(stats), std::move(networkStats));
+  connectionManager_.manageConnection(rs, eventBase_, setupParams_.token);
+  rs->connectServer(std::move(frameTransport_), setupParams_);
   return std::make_unique<RSocketRequester>(std::move(rs), eventBase_);
 }
 
 void RSocketSetup::createRSocket(
     std::shared_ptr<RSocketResponder> requestResponder,
+    bool resumable,
     std::shared_ptr<RSocketStats> stats,
     std::shared_ptr<RSocketNetworkStats> networkStats) {
-  createRSocketStateMachine(std::move(requestResponder), std::move(stats), std::move(networkStats));
+  auto rs = createRSocketStateMachine(
+      std::move(requestResponder), std::move(stats), std::move(networkStats));
+  rs->setResumable(resumable);
+  connectionManager_.manageConnection(rs, eventBase_, setupParams_.token);
+  rs->connectServer(std::move(frameTransport_), setupParams_);
 }
 
 std::shared_ptr<RSocketStateMachine> RSocketSetup::createRSocketStateMachine(
@@ -61,17 +69,13 @@ std::shared_ptr<RSocketStateMachine> RSocketSetup::createRSocketStateMachine(
     stats = RSocketStats::noop();
   }
 
-  auto rs = std::make_shared<RSocketStateMachine>(
+  return std::make_shared<RSocketStateMachine>(
       eventBase_,
       std::move(requestResponder),
       nullptr,
       ReactiveSocketMode::SERVER,
       std::move(stats),
       std::move(networkStats));
-
-  connectionManager_.manageConnection(rs, eventBase_);
-  rs->connectServer(std::move(frameTransport_), setupParams_);
-  return rs;
 }
 
 void RSocketSetup::error(const RSocketError& error) {

--- a/src/RSocketSetup.cpp
+++ b/src/RSocketSetup.cpp
@@ -43,12 +43,12 @@ std::unique_ptr<RSocketRequester> RSocketSetup::createRSocketRequester(
 
 void RSocketSetup::createRSocket(
     std::shared_ptr<RSocketResponder> requestResponder,
-    bool resumable,
+    ServerOptions serverOptions,
     std::shared_ptr<RSocketStats> stats,
     std::shared_ptr<RSocketNetworkStats> networkStats) {
   auto rs = createRSocketStateMachine(
       std::move(requestResponder), std::move(stats), std::move(networkStats));
-  rs->setResumable(resumable);
+  rs->setResumable(serverOptions.resumable);
   connectionManager_.manageConnection(rs, eventBase_, setupParams_.token);
   rs->connectServer(std::move(frameTransport_), setupParams_);
 }

--- a/src/RSocketSetup.h
+++ b/src/RSocketSetup.h
@@ -35,7 +35,7 @@ class RSocketSetup {
 
   void createRSocket(
       std::shared_ptr<RSocketResponder> requestResponder,
-      bool resumable = false,
+      ServerOptions serverOptions = ServerOptions(),
       std::shared_ptr<RSocketStats> stats = std::shared_ptr<RSocketStats>(),
       std::shared_ptr<RSocketNetworkStats> networkStats = std::shared_ptr<RSocketNetworkStats>());
 

--- a/src/RSocketSetup.h
+++ b/src/RSocketSetup.h
@@ -35,6 +35,7 @@ class RSocketSetup {
 
   void createRSocket(
       std::shared_ptr<RSocketResponder> requestResponder,
+      bool resumable = false,
       std::shared_ptr<RSocketStats> stats = std::shared_ptr<RSocketStats>(),
       std::shared_ptr<RSocketNetworkStats> networkStats = std::shared_ptr<RSocketNetworkStats>());
 

--- a/src/framing/Frame.cpp
+++ b/src/framing/Frame.cpp
@@ -295,7 +295,8 @@ std::ostream& operator<<(std::ostream& os, const Frame_REQUEST_CHANNEL& frame) {
 }
 
 std::ostream& operator<<(std::ostream& os, const Frame_REQUEST_STREAM& frame) {
-  return os << frame.header_ << ", " << frame.payload_;
+  return os << frame.header_ << ", initialRequestN(" << frame.requestN_ << "), "
+            << frame.payload_;
 }
 
 } // namespace rsocket

--- a/src/internal/ClientResumeStatusCallback.h
+++ b/src/internal/ClientResumeStatusCallback.h
@@ -24,4 +24,10 @@ class ClientResumeStatusCallback {
   virtual void onConnectionError(folly::exception_wrapper ex) noexcept = 0;
 };
 
+class DefaultResumeCallback : public rsocket::ClientResumeStatusCallback {
+  void onResumeOk() noexcept override {}
+  void onResumeError(folly::exception_wrapper) noexcept override {}
+  void onConnectionError(folly::exception_wrapper) noexcept override {}
+};
+
 } // reactivesocket

--- a/src/internal/ClientResumeStatusCallback.h
+++ b/src/internal/ClientResumeStatusCallback.h
@@ -24,10 +24,4 @@ class ClientResumeStatusCallback {
   virtual void onConnectionError(folly::exception_wrapper ex) noexcept = 0;
 };
 
-class DefaultResumeCallback : public rsocket::ClientResumeStatusCallback {
-  void onResumeOk() noexcept override {}
-  void onResumeError(folly::exception_wrapper) noexcept override {}
-  void onConnectionError(folly::exception_wrapper) noexcept override {}
-};
-
 } // reactivesocket

--- a/src/internal/ClientResumeStatusCallback.h
+++ b/src/internal/ClientResumeStatusCallback.h
@@ -6,6 +6,20 @@
 
 namespace rsocket {
 
+// Thrown when an ERROR frame with CONNECTION_ERROR is received during
+// resuming operation.
+// TODO: in this case we should get the DuplexConnection back to
+// create a new instance of RS with it
+class ResumptionException : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+// Thrown when the resume operation was interrupted due to network
+// the application code may try to resume again.
+class ConnectionException : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
 class ClientResumeStatusCallback {
  public:
   virtual ~ClientResumeStatusCallback() = default;
@@ -13,15 +27,8 @@ class ClientResumeStatusCallback {
   // Called when a RESUME_OK frame is received during resuming operation
   virtual void onResumeOk() noexcept = 0;
 
-  // Called when an ERROR frame with CONNECTION_ERROR is received during
-  // resuming operation
-  // TODO: in this case we should get the DuplexConnection back to
-  // create a new instance of RS with it
+  // The exception could be one of ResumptionException or ConnectionException
   virtual void onResumeError(folly::exception_wrapper ex) noexcept = 0;
-
-  // Called when the resume operation was interrupted due to network
-  // the application code may try to resume again.
-  virtual void onConnectionError(folly::exception_wrapper ex) noexcept = 0;
 };
 
 } // reactivesocket

--- a/src/internal/RSocketConnectionManager.h
+++ b/src/internal/RSocketConnectionManager.h
@@ -8,6 +8,8 @@
 #include <folly/Optional.h>
 #include <folly/Synchronized.h>
 
+#include "Common.h"
+
 namespace folly {
 class EventBase;
 }
@@ -22,7 +24,11 @@ class RSocketConnectionManager {
 
   void manageConnection(
       std::shared_ptr<rsocket::RSocketStateMachine>,
-      folly::EventBase&);
+      folly::EventBase&,
+      ResumeIdentificationToken);
+
+  std::shared_ptr<rsocket::RSocketStateMachine> getConnection(
+      ResumeIdentificationToken) const;
 
  private:
   void removeConnection(const std::shared_ptr<rsocket::RSocketStateMachine>&);
@@ -31,7 +37,7 @@ class RSocketConnectionManager {
   folly::Synchronized<
       std::unordered_map<
           std::shared_ptr<rsocket::RSocketStateMachine>,
-          folly::EventBase&>,
+          std::pair<folly::EventBase&, ResumeIdentificationToken>>,
       std::mutex>
       sockets_;
 

--- a/src/internal/SetupResumeAcceptor.cpp
+++ b/src/internal/SetupResumeAcceptor.cpp
@@ -210,11 +210,11 @@ SetupResumeAcceptor::getOrAutodetectFrameSerializer(
 
   auto serializer = FrameSerializer::createAutodetectedSerializer(firstFrame);
   if (!serializer) {
-    LOG(ERROR) << "unable to detect protocol version";
+    LOG(ERROR) << "Unable to detect ProtocolVersion";
     return nullptr;
   }
 
-  VLOG(2) << "detected protocol version" << serializer->protocolVersion();
+  VLOG(2) << "Detected ProtocolVersion v" << serializer->protocolVersion();
   return std::move(serializer);
 }
 

--- a/src/statemachine/RSocketStateMachine.cpp
+++ b/src/statemachine/RSocketStateMachine.cpp
@@ -178,7 +178,7 @@ void RSocketStateMachine::close(
 
   if (resumeCallback_) {
     resumeCallback_->onResumeError(
-        std::runtime_error(ex ? ex.what().c_str() : "RS closing"));
+        ConnectionException(ex ? ex.what().c_str() : "RS closing"));
     resumeCallback_.reset();
   }
 
@@ -205,8 +205,8 @@ void RSocketStateMachine::closeFrameTransport(
   }
 
   if (resumeCallback_) {
-    resumeCallback_->onConnectionError(
-        std::runtime_error(ex ? ex.what().c_str() : "connection closing"));
+    resumeCallback_->onResumeError(
+        ConnectionException(ex ? ex.what().c_str() : "connection closing"));
     resumeCallback_.reset();
   }
 
@@ -499,7 +499,7 @@ void RSocketStateMachine::handleConnectionFrame(
            frame.errorCode_ == ErrorCode::REJECTED_RESUME) &&
           resumeCallback_) {
         resumeCallback_->onResumeError(
-            std::runtime_error(frame.payload_.moveDataToString()));
+            ResumptionException(frame.payload_.moveDataToString()));
         resumeCallback_.reset();
         // fall through
       }

--- a/src/statemachine/RSocketStateMachine.cpp
+++ b/src/statemachine/RSocketStateMachine.cpp
@@ -75,7 +75,7 @@ bool RSocketStateMachine::connectServer(
 }
 
 bool RSocketStateMachine::resumeServer(
-    std::shared_ptr<FrameTransport> frameTransport,
+    yarpl::Reference<FrameTransport> frameTransport,
     const ResumeParameters& resumeParams) {
   return connect(
              std::move(frameTransport), false, resumeParams.protocolVersion) &&

--- a/src/statemachine/RSocketStateMachine.cpp
+++ b/src/statemachine/RSocketStateMachine.cpp
@@ -52,7 +52,7 @@ RSocketStateMachine::~RSocketStateMachine() {
   // automatons destroyed on different threads can be the last ones referencing
   // this.
 
-  VLOG(6) << "RSocketStateMachine";
+  VLOG(6) << "~RSocketStateMachine";
   // We rely on SubscriptionPtr and SubscriberPtr to dispatch appropriate
   // terminal signals.
   DCHECK(!resumeCallback_);
@@ -72,6 +72,15 @@ bool RSocketStateMachine::connectServer(
     const SetupParameters& setupParams) {
   setResumable(setupParams.resumable);
   return connect(std::move(frameTransport), true, setupParams.protocolVersion);
+}
+
+bool RSocketStateMachine::resumeServer(
+    std::shared_ptr<FrameTransport> frameTransport,
+    const ResumeParameters& resumeParams) {
+  return connect(
+             std::move(frameTransport), false, resumeParams.protocolVersion) &&
+      resumeFromPositionOrClose(
+             resumeParams.serverPosition, resumeParams.clientPosition);
 }
 
 bool RSocketStateMachine::connect(

--- a/src/statemachine/RSocketStateMachine.h
+++ b/src/statemachine/RSocketStateMachine.h
@@ -76,6 +76,10 @@ class RSocketStateMachine final
       yarpl::Reference<FrameTransport>,
       const SetupParameters& setupParams);
 
+  bool resumeServer(
+      std::shared_ptr<FrameTransport>,
+      const ResumeParameters& resumeParams);
+
   /// Disconnects DuplexConnection from the stateMachine.
   /// Existing streams will stay intact.
   void disconnect(folly::exception_wrapper ex);

--- a/src/statemachine/RSocketStateMachine.h
+++ b/src/statemachine/RSocketStateMachine.h
@@ -77,7 +77,7 @@ class RSocketStateMachine final
       const SetupParameters& setupParams);
 
   bool resumeServer(
-      std::shared_ptr<FrameTransport>,
+      yarpl::Reference<FrameTransport>,
       const ResumeParameters& resumeParams);
 
   /// Disconnects DuplexConnection from the stateMachine.


### PR DESCRIPTION
## API
### Client:
```
auto client = RSocket::createClient(...);
auto requester = client->connect();
...
client->disconnect();
...
client->resume()
  .via(my_evb)
  .then([]{ 
    // resumption succeeded; continue with the same requester 
  })
  .onError([] { 
    // resumption failure; create a new client
  });
```
Previously RSocketClient::connect() would return a new RSocketRequester everytime. It seemed a little unconventional, as you typically connect() a client only once and disconnect() it before attempting to reconnect.  With this implementation, the application can call connect() only once (if connect is successful).  And then it can resume()/disconnect() on the connection.  If application wants multiple RSocketRequesters, it has to create multiple RSocketClients.

### Server:
The ConnectionManager class holds the RSocketStateMachines and the ResumptionTokens.  So the server can resume connections without the application having to do anything.  In a subsequent diff I will let `RSocketServer::start()` take a callback which will be invoked for each resumption attempt.  The server-application can then decide (using that callback) whether to allow resumption or not.  This will be useful in cases where the server does not want to resume any further connections because of load or any other reason.  It is helpful even just for stats.

## Testing
Wrote a simple warm-resumption server and client. The server can be started in resumable/non-resumable modes.  Verified the correct behavior with both v1.0 and v0.1 interactions.  The frames get buffered in StreamState when the FrameTransport is disconnected.  The Frames get resent if the client/server request older positions.  The server sends ERROR frames for non-resumable cases. 

## TODO
* Ability to migrate RSocketStateMachine to different eventBase (this is needed to run multiple worker threads for the server)
* Add resumeCallback for RSocketServer::start()
* Make RSocketClient thread safe
* Write integration tests for warm-resumption
* Add more checks
* The sample warm-resumption client/server could be more exhaustive in handling the different cases.


