### PR TITLE
Fix rsocket-server to send ERROR frame for unsupported resumption

### DIFF
--- a/src/RSocketServer.cpp
+++ b/src/RSocketServer.cpp
@@ -111,16 +111,11 @@ void RSocketServer::onRSocketSetup(
   onRSocketSetup(setup);
 }
 
-void RSocketServer::onRSocketResume(
+bool RSocketServer::onRSocketResume(
     OnRSocketResume,
-    std::shared_ptr<FrameTransport> frameTransport,
+    std::shared_ptr<FrameTransport>,
     ResumeParameters) {
-  // We don't need to check for isShutdown_ here since all callbacks are
-  // processed by this time.
-
-  LOG(ERROR) << "onRSocketResume: not implemented";
-  frameTransport->close(
-      folly::make_exception_wrapper<std::runtime_error>("not_implemented"));
+  return false;
 }
 
 void RSocketServer::startAndPark(OnRSocketSetup onRSocketSetup) {

--- a/src/RSocketServer.h
+++ b/src/RSocketServer.h
@@ -97,7 +97,7 @@ class RSocketServer {
       OnRSocketSetup onRSocketSetup,
       std::shared_ptr<rsocket::FrameTransport> frameTransport,
       rsocket::SetupParameters setupPayload);
-  void onRSocketResume(
+  bool onRSocketResume(
       OnRSocketResume onRSocketResume,
       std::shared_ptr<rsocket::FrameTransport> frameTransport,
       rsocket::ResumeParameters setupPayload);

--- a/src/framing/Frame.cpp
+++ b/src/framing/Frame.cpp
@@ -92,6 +92,8 @@ std::ostream& operator<<(std::ostream& os, ErrorCode errorCode) {
       return os << "UNSUPPORTED_SETUP";
     case ErrorCode::CONNECTION_ERROR:
       return os << "CONNECTION_ERROR";
+    case ErrorCode::REJECTED_RESUME:
+      return os << "REJECTED_RESUME";
   }
   return os << "ErrorCode(" << static_cast<uint32_t>(errorCode) << ")";
 }
@@ -227,6 +229,10 @@ Frame_ERROR Frame_ERROR::badSetupFrame(const std::string& message) {
 
 Frame_ERROR Frame_ERROR::connectionError(const std::string& message) {
   return Frame_ERROR(0, ErrorCode::CONNECTION_ERROR, Payload(message));
+}
+
+Frame_ERROR Frame_ERROR::rejectedResume(const std::string& message) {
+  return Frame_ERROR(0, ErrorCode::REJECTED_RESUME, Payload(message));
 }
 
 Frame_ERROR Frame_ERROR::error(StreamId streamId, Payload&& payload) {

--- a/src/framing/Frame.h
+++ b/src/framing/Frame.h
@@ -59,6 +59,9 @@ enum class ErrorCode : uint32_t {
   // The server rejected the setup, it can specify the reason in the payload.
   // Stream ID MUST be 0.
   REJECTED_SETUP = 0x00000003,
+  // The server rejected the resume, it can specify the reason in the payload.
+  // Stream ID MUST be 0.
+  REJECTED_RESUME = 0x00000004,
   // The connection is being terminated. Stream ID MUST be 0.
   CONNECTION_ERROR = 0x00000101,
   // Application layer logic generating a Reactive Streams onError event.
@@ -387,6 +390,7 @@ class Frame_ERROR {
   static Frame_ERROR invalidFrame();
   static Frame_ERROR badSetupFrame(const std::string& message);
   static Frame_ERROR connectionError(const std::string& message);
+  static Frame_ERROR rejectedResume(const std::string& message);
   static Frame_ERROR error(StreamId streamId, Payload&& payload);
   static Frame_ERROR applicationError(StreamId streamId, Payload&& payload);
 

--- a/src/internal/SetupResumeAcceptor.h
+++ b/src/internal/SetupResumeAcceptor.h
@@ -29,7 +29,7 @@ class SetupResumeAcceptor final {
   using OnSetup =
       std::function<void(std::shared_ptr<FrameTransport>, SetupParameters)>;
   using OnResume =
-      std::function<void(std::shared_ptr<FrameTransport>, ResumeParameters)>;
+      std::function<bool(std::shared_ptr<FrameTransport>, ResumeParameters)>;
 
   explicit SetupResumeAcceptor(
       ProtocolVersion defaultProtocolVersion,

--- a/src/statemachine/RSocketStateMachine.cpp
+++ b/src/statemachine/RSocketStateMachine.cpp
@@ -492,7 +492,9 @@ void RSocketStateMachine::handleConnectionFrame(
 
       // TODO: handle INVALID_SETUP, UNSUPPORTED_SETUP, REJECTED_SETUP
 
-      if (frame.errorCode_ == ErrorCode::CONNECTION_ERROR && resumeCallback_) {
+      if ((frame.errorCode_ == ErrorCode::CONNECTION_ERROR ||
+           frame.errorCode_ == ErrorCode::REJECTED_RESUME) &&
+          resumeCallback_) {
         resumeCallback_->onResumeError(
             std::runtime_error(frame.payload_.moveDataToString()));
         resumeCallback_.reset();


### PR DESCRIPTION
Previously, the rsocket-server would just crash on receiving RESUME frame.  With this change it would send out an ERROR frame to the client and close the DuplexConnection.

Testing:
Ran a client which attempts resumption against this server.  Without this change the server crashes.  With this change the server sends out ERROR and closes the connection 
<img width="457" alt="screen shot 2017-06-29 at 4 47 47 pm" src="https://user-images.githubusercontent.com/11081860/27715265-d3bdfab6-5cea-11e7-9451-c81f6059f0a3.png">
