### PR TITLE
Fix coveage and ignore test directories and dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,6 +118,6 @@ script:
 
 after_success:
     # Upload to coveralls.
-  - if [ -f build/coverage.info ]; then
-      coveralls-lcov --repo-token ${COVERALLS_TOKEN} build/coverage.info;
+  - if [ -f coverage.info ]; then
+      coveralls-lcov --repo-token=${COVERALLS_TOKEN} coverage.info;
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
     # Capture coverage info.
     COMMAND lcov --directory . --capture --output-file ${COVERAGE_INFO}
     # Filter out system and test code.
-    COMMAND lcov --remove ${COVERAGE_INFO} 'tests/*' '/usr/*' --output-file
+    COMMAND lcov --remove ${COVERAGE_INFO} 'tests/*' 'test/*' 'tck-test/*' '/usr/*' 'gmock/*' 'folly/*' --output-file
                  ${COVERAGE_INFO}
     # Debug before upload.
     COMMAND lcov --list ${COVERAGE_INFO})


### PR DESCRIPTION
Turns out coveralls upload wasn't working because we were running it from the wrong directory (so the coverage file wasn't found).