### PR TITLE
Don't return a folly::Future from ConnectionAcceptor::start()

### DIFF
--- a/src/ConnectionAcceptor.h
+++ b/src/ConnectionAcceptor.h
@@ -3,10 +3,12 @@
 #pragma once
 
 #include <folly/Optional.h>
-#include <folly/futures/Future.h>
-#include <folly/io/async/EventBase.h>
 
 #include "src/DuplexConnection.h"
+
+namespace folly {
+class EventBase;
+}
 
 namespace rsocket {
 
@@ -39,15 +41,11 @@ class ConnectionAcceptor {
 
   /**
    * Allocate/start required resources (threads, sockets, etc) and begin
-   * listening for new connections.
-   *
-   * Will return an empty future on success, otherwise the future will contain
-   * the error.
+   * listening for new connections.  Must be synchronous.
    *
    * This can only be called once.
    */
-  virtual folly::Future<folly::Unit> start(
-      OnDuplexConnectionAccept onAccept) = 0;
+  virtual void start(OnDuplexConnectionAccept) = 0;
 
   /**
    * Stop listening for new connections.

--- a/src/RSocketServer.cpp
+++ b/src/RSocketServer.cpp
@@ -62,8 +62,8 @@ void RSocketServer::start(OnRSocketSetup onRSocketSetup) {
 
   LOG(INFO) << "Starting RSocketServer";
 
-  duplexConnectionAcceptor_
-      ->start([ this, onRSocketSetup = std::move(onRSocketSetup) ](
+  duplexConnectionAcceptor_->start(
+      [ this, onRSocketSetup = std::move(onRSocketSetup) ](
           std::unique_ptr<DuplexConnection> connection,
           bool isFramedConnection,
           folly::EventBase& eventBase) {
@@ -74,9 +74,9 @@ void RSocketServer::start(OnRSocketSetup onRSocketSetup) {
           framedConnection = std::make_unique<FramedDuplexConnection>(
               std::move(connection), ProtocolVersion::Unknown, eventBase);
         }
-        acceptConnection(std::move(framedConnection), eventBase, onRSocketSetup);
-      })
-      .get(); // block until finished and return or throw
+        acceptConnection(
+            std::move(framedConnection), eventBase, onRSocketSetup);
+      });
 }
 
 void RSocketServer::acceptConnection(

--- a/src/transports/tcp/TcpConnectionAcceptor.cpp
+++ b/src/transports/tcp/TcpConnectionAcceptor.cpp
@@ -3,6 +3,7 @@
 #include "TcpConnectionAcceptor.h"
 
 #include <folly/ThreadName.h>
+#include <folly/futures/Future.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
 
 #include "src/framing/FramedDuplexConnection.h"
@@ -59,11 +60,9 @@ TcpConnectionAcceptor::~TcpConnectionAcceptor() {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-folly::Future<folly::Unit> TcpConnectionAcceptor::start(
-    OnDuplexConnectionAccept onAccept) {
+void TcpConnectionAcceptor::start(OnDuplexConnectionAccept onAccept) {
   if (onAccept_ != nullptr) {
-    return folly::makeFuture<folly::Unit>(
-        std::runtime_error("TcpConnectionAcceptor::start() already called"));
+    throw std::runtime_error("TcpConnectionAcceptor::start() already called");
   }
 
   onAccept_ = std::move(onAccept);
@@ -84,25 +83,29 @@ folly::Future<folly::Unit> TcpConnectionAcceptor::start(
   serverSocket_.reset(
       new folly::AsyncServerSocket(serverThread_->getEventBase()));
 
-  return via(serverThread_->getEventBase()).then([this] {
-    folly::SocketAddress addr;
-    addr.setFromLocalPort(options_.port);
+  // The AsyncServerSocket needs to be accessed from the listener thread only.
+  // This will propagate out any exceptions the listener throws.
+  folly::via(
+      serverThread_->getEventBase(),
+      [this] {
+        folly::SocketAddress addr;
+        addr.setFromLocalPort(options_.port);
 
-    serverSocket_->bind(addr);
+        serverSocket_->bind(addr);
 
-    for (auto const& callback : callbacks_) {
-      serverSocket_->addAcceptCallback(callback.get(), callback->eventBase());
-    }
+        for (auto const& callback : callbacks_) {
+          serverSocket_->addAcceptCallback(
+              callback.get(), callback->eventBase());
+        }
 
-    serverSocket_->listen(options_.backlog);
-    serverSocket_->startAccepting();
+        serverSocket_->listen(options_.backlog);
+        serverSocket_->startAccepting();
 
-    for (auto& i : serverSocket_->getAddresses()) {
-      LOG(INFO) << "Listening on " << i.describe();
-    }
-
-    return folly::unit;
-  });
+        for (auto& i : serverSocket_->getAddresses()) {
+          LOG(INFO) << "Listening on " << i.describe();
+        }
+      })
+      .get();
 }
 
 void TcpConnectionAcceptor::stop() {

--- a/src/transports/tcp/TcpConnectionAcceptor.h
+++ b/src/transports/tcp/TcpConnectionAcceptor.h
@@ -46,7 +46,7 @@ class TcpConnectionAcceptor : public ConnectionAcceptor {
   /**
    * Bind an AsyncServerSocket and start accepting TCP connections.
    */
-  folly::Future<folly::Unit> start(OnDuplexConnectionAccept) override;
+  void start(OnDuplexConnectionAccept) override;
 
   /**
    * Shutdown the AsyncServerSocket and associated listener thread.


### PR DESCRIPTION
Starting a ConnectionAcceptor should be synchronous.  Returning a folly::Future
was mostly a convenient way of wrapping up thrown exceptions so users would be
forced to handle them.  The reality ended up being every user just did .get() on
the future and rethrew any exceptions anyway.