### PR TITLE
Ensure server and client are in sync about resumability

### DIFF
--- a/src/statemachine/RSocketStateMachine.cpp
+++ b/src/statemachine/RSocketStateMachine.cpp
@@ -62,14 +62,15 @@ RSocketStateMachine::~RSocketStateMachine() {
 
 void RSocketStateMachine::setResumable(bool resumable) {
   debugCheckCorrectExecutor();
-  DCHECK(isDisconnectedOrClosed()); // we allow to set this flag before we are
-  // connected
+  // We should set this flag before we are connected
+  DCHECK(isDisconnectedOrClosed()); 
   remoteResumeable_ = isResumable_ = resumable;
 }
 
 bool RSocketStateMachine::connectServer(
     std::shared_ptr<FrameTransport> frameTransport,
     const SetupParameters& setupParams) {
+  setResumable(setupParams.resumable);
   return connect(std::move(frameTransport), true, setupParams.protocolVersion);
 }
 


### PR DESCRIPTION
If the client is running in a resumable mode, the server should be aware of it.  This is especially important in RSocket v0.1, since the the KEEPALIVE frame serialization format depends on whether resumption is enabled or not.  If the client has resumption enabled and the server is not aware of it, then it could result in mangled KEEPALIVE frames.