### PR TITLE
Delete TcpConnectionFactory::createDuplexConnectionFromSocket()

### DIFF
--- a/src/transports/tcp/TcpConnectionFactory.cpp
+++ b/src/transports/tcp/TcpConnectionFactory.cpp
@@ -80,12 +80,4 @@ void TcpConnectionFactory::connect(OnDuplexConnectionConnect cb) {
       });
 }
 
-std::unique_ptr<DuplexConnection>
-TcpConnectionFactory::createDuplexConnectionFromSocket(
-    folly::AsyncSocket::UniquePtr socket,
-    folly::EventBase& eventBase,
-    std::shared_ptr<RSocketStats> stats) {
-  return std::make_unique<TcpDuplexConnection>(std::move(socket), eventBase, std::move(stats));
-}
-
 } // namespace rsocket

--- a/src/transports/tcp/TcpConnectionFactory.h
+++ b/src/transports/tcp/TcpConnectionFactory.h
@@ -29,11 +29,6 @@ class TcpConnectionFactory : public ConnectionFactory {
    */
   void connect(OnDuplexConnectionConnect) override;
 
-  static std::unique_ptr<DuplexConnection> createDuplexConnectionFromSocket(
-      folly::AsyncSocket::UniquePtr socket,
-      folly::EventBase& eventBase,
-      std::shared_ptr<RSocketStats> stats = std::shared_ptr<RSocketStats>());
-
  private:
   folly::SocketAddress address_;
   folly::ScopedEventBaseThread worker_;

--- a/src/transports/tcp/TcpDuplexConnection.h
+++ b/src/transports/tcp/TcpDuplexConnection.h
@@ -3,7 +3,8 @@
 #pragma once
 
 #include <folly/io/async/AsyncSocket.h>
-#include <src/RSocketStats.h>
+
+#include "src/RSocketStats.h"
 #include "src/DuplexConnection.h"
 #include "src/internal/ReactiveStreamsCompat.h"
 
@@ -13,7 +14,7 @@ class TcpReaderWriter;
 
 class TcpDuplexConnection : public DuplexConnection {
  public:
-  explicit TcpDuplexConnection(
+  TcpDuplexConnection(
       folly::AsyncSocket::UniquePtr&& socket,
       folly::Executor& executor,
       std::shared_ptr<RSocketStats> stats = RSocketStats::noop());
@@ -36,4 +37,4 @@ class TcpDuplexConnection : public DuplexConnection {
   std::shared_ptr<RSocketStats> stats_;
   folly::Executor& executor_;
 };
-} // reactivesocket
+} // rsocket


### PR DESCRIPTION
It's a very verbose way of doing std::make_unique\<TcpDuplexConnection\>(...)