### PR TITLE
Re-disable ASAN for yarpl on macOS builds

### DIFF
--- a/yarpl/CMakeLists.txt
+++ b/yarpl/CMakeLists.txt
@@ -22,7 +22,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -momit-leaf-frame-pointer")
 # The yarpl-tests binary constantly fails with an ASAN error in gtest internal
 # code on macOS.
 if(APPLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-sanitize=address,undefined")
+  message("== macOS detected, disabling ASAN for yarpl")
+  add_compile_options("-fno-sanitize=address,undefined")
 endif()
 
 # Configuration for Debug build mode.


### PR DESCRIPTION
RSOCKET_ASAN uses `add_compile_options()`, which doesn't play nicely with
`set(CMAKE_CXX_FLAGS ...)`.

Successfully ran `tests`, `yarpl-tests`, and `yarpl-playground` on my local
macOS laptop.