### PR TITLE
General FrameTransport cleanup

### DIFF
--- a/src/framing/FrameTransport.cpp
+++ b/src/framing/FrameTransport.cpp
@@ -1,8 +1,13 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "FrameTransport.h"
+
 #include <folly/ExceptionWrapper.h>
+#include <folly/io/IOBuf.h>
+#include <glog/logging.h>
+
 #include "src/DuplexConnection.h"
+#include "src/framing/FrameProcessor.h"
 
 namespace rsocket {
 
@@ -18,27 +23,26 @@ FrameTransport::~FrameTransport() {
 }
 
 void FrameTransport::connect() {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  Lock lock(mutex_);
 
   DCHECK(connection_);
 
   if (connectionOutput_) {
-    // already connected
+    // Already connected.
     return;
   }
 
   connectionOutput_ = connection_->getOutput();
   connectionOutput_->onSubscribe(yarpl::get_ref(this));
 
-  // the onSubscribe call on the previous line may have called the terminating
-  // signal which would call disconnect/close
+  // The onSubscribe call on the previous line may have called the terminating
+  // signal which would call disconnect/close.
   if (connection_) {
     // This may call ::onSubscribe in-line, which calls ::request on the
-    // provided
-    // subscription, which might deliver frames in-line.
-    // it can also call onComplete which will call disconnect/close and reset
-    // the connection_ while still inside of the connection_::setInput method.
-    // We will create a hard reference for that case and keep the object alive
+    // provided subscription, which might deliver frames in-line.  It can also
+    // call onComplete which will call disconnect/close and reset the
+    // connection_ while still inside of the connection_::setInput method.  We
+    // will create a hard reference for that case and keep the object alive
     // until setInput method returns
     auto connectionCopy = connection_;
     connectionCopy->setInput(yarpl::get_ref(this));
@@ -47,7 +51,7 @@ void FrameTransport::connect() {
 
 void FrameTransport::setFrameProcessor(
     std::shared_ptr<FrameProcessor> frameProcessor) {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  Lock lock(mutex_);
 
   frameProcessor_ = std::move(frameProcessor);
   if (frameProcessor_) {
@@ -55,18 +59,8 @@ void FrameTransport::setFrameProcessor(
     connect();
   }
 
-  drainOutputFramesQueue();
-  if (frameProcessor_) {
-    while (!pendingReads_.empty()) {
-      auto frame = std::move(pendingReads_.front());
-      pendingReads_.pop_front();
-      frameProcessor_->processFrame(std::move(frame));
-    }
-    if (pendingTerminal_) {
-      terminateFrameProcessor(std::move(*pendingTerminal_));
-      pendingTerminal_ = folly::none;
-    }
-  }
+  drainWrites(lock);
+  drainReads(lock);
 }
 
 void FrameTransport::close() {
@@ -82,7 +76,7 @@ void FrameTransport::closeWithError(folly::exception_wrapper ew) {
 }
 
 void FrameTransport::closeImpl(folly::exception_wrapper ew) {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  Lock lock(mutex_);
 
   // Make sure we never try to call back into the processor.
   frameProcessor_ = nullptr;
@@ -108,9 +102,8 @@ void FrameTransport::closeImpl(folly::exception_wrapper ew) {
   }
 }
 
-void FrameTransport::onSubscribe(
-    yarpl::Reference<Subscription> subscription) noexcept {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
+void FrameTransport::onSubscribe(yarpl::Reference<Subscription> subscription) {
+  Lock lock(mutex_);
 
   if (!connection_) {
     return;
@@ -122,8 +115,8 @@ void FrameTransport::onSubscribe(
   connectionInputSub_->request(kMaxRequestN);
 }
 
-void FrameTransport::onNext(std::unique_ptr<folly::IOBuf> frame) noexcept {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
+void FrameTransport::onNext(std::unique_ptr<folly::IOBuf> frame) {
+  Lock lock(mutex_);
 
   if (connection_ && frameProcessor_) {
     frameProcessor_->processFrame(std::move(frame));
@@ -132,12 +125,12 @@ void FrameTransport::onNext(std::unique_ptr<folly::IOBuf> frame) noexcept {
   }
 }
 
-void FrameTransport::terminateFrameProcessor(folly::exception_wrapper ex) {
-  // this method can be executed multiple times during terminating
+void FrameTransport::terminateProcessor(folly::exception_wrapper ex) {
+  // This method can be executed multiple times while terminating.
 
   std::shared_ptr<FrameProcessor> frameProcessor;
   {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    Lock lock(mutex_);
     if (!frameProcessor_) {
       pendingTerminal_ = std::move(ex);
       return;
@@ -151,22 +144,22 @@ void FrameTransport::terminateFrameProcessor(folly::exception_wrapper ex) {
   }
 }
 
-void FrameTransport::onComplete() noexcept {
+void FrameTransport::onComplete() {
   VLOG(6) << "onComplete";
-  terminateFrameProcessor(folly::exception_wrapper());
+  terminateProcessor(folly::exception_wrapper());
 }
 
-void FrameTransport::onError(std::exception_ptr ex) noexcept {
+void FrameTransport::onError(std::exception_ptr ex) {
   VLOG(6) << "onError" << folly::exceptionStr(ex);
-  terminateFrameProcessor(folly::exception_wrapper(std::move(ex)));
+  terminateProcessor(folly::exception_wrapper(std::move(ex)));
 }
 
-void FrameTransport::request(int64_t n) noexcept {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
+void FrameTransport::request(int64_t n) {
+  Lock lock(mutex_);
 
   if (!connection_) {
-    // request(n) can be delivered during disconnecting
-    // we don't care for it anymore
+    // request(n) can be delivered during disconnecting.  We don't care for it
+    // anymore.
     return;
   }
 
@@ -175,62 +168,60 @@ void FrameTransport::request(int64_t n) noexcept {
     // stack.
     return;
   }
-  drainOutputFramesQueue();
+
+  drainWrites(lock);
 }
 
-void FrameTransport::cancel() noexcept {
+void FrameTransport::cancel() {
   VLOG(6) << "cancel";
-  terminateFrameProcessor(folly::exception_wrapper());
+  terminateProcessor(folly::exception_wrapper());
 }
 
 void FrameTransport::outputFrameOrEnqueue(std::unique_ptr<folly::IOBuf> frame) {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  Lock lock(mutex_);
 
-  // We allow sending frames even without a frame processor so it's possible
-  // to send terminal frames without expecting anything in return
+  // We allow sending frames even without a frame processor so it's possible to
+  // send terminal frames without expecting anything in return.
   if (connection_) {
-    drainOutputFramesQueue();
+    drainWrites(lock);
     if (pendingWrites_.empty() && writeAllowance_.tryAcquire()) {
-      // TODO: temporary disabling VLOG as we don't know the correct
-      // frame serializer here. There is refactoring of this class planned
-      // which will allow enabling it again.
-      // VLOG(3) << this << " writing frame " << FrameHeader::peekType(*frame);
-
       connectionOutput_->onNext(std::move(frame));
       return;
     }
   }
-  // TODO: temporary disabling VLOG as we don't know the correct
-  // frame serializer here. There is refactoring of this class planned
-  // which will allow enabling it again.
-  // VLOG(3) << this << " queuing frame " << FrameHeader::peekType(*frame);
 
-  // We either have no allowance to perform the operation, or the queue has
-  // not been drained (e.g. we're looping in ::request).
-  // or we are disconnected
+  // We either have no allowance to perform the operation, or the queue has not
+  // been drained (e.g. we're looping in ::request), or we are disconnected.
   pendingWrites_.emplace_back(std::move(frame));
 }
 
-void FrameTransport::drainOutputFramesQueue() {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
+void FrameTransport::drainReads(const FrameTransport::Lock&) {
+  if (!frameProcessor_) {
+    return;
+  }
 
-  if (connection_) {
-    // Drain the queue or the allowance.
-    while (!pendingWrites_.empty() && writeAllowance_.tryAcquire()) {
-      auto frame = std::move(pendingWrites_.front());
-      // TODO: temporary disabling VLOG as we don't know the correct
-      // frame serializer here. There is refactoring of this class planned
-      // which will allow enabling it again.
-      // VLOG(3) << this << " flushing frame " << FrameHeader::peekType(*frame);
-      pendingWrites_.pop_front();
-      connectionOutput_->onNext(std::move(frame));
-    }
+  while (!pendingReads_.empty()) {
+    auto frame = std::move(pendingReads_.front());
+    pendingReads_.pop_front();
+    frameProcessor_->processFrame(std::move(frame));
+  }
+
+  if (pendingTerminal_) {
+    terminateProcessor(std::move(*pendingTerminal_));
+    pendingTerminal_ = folly::none;
   }
 }
 
-DuplexConnection* FrameTransport::duplexConnection() const {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
-  return connection_.get();
-}
+void FrameTransport::drainWrites(const FrameTransport::Lock&) {
+  if (!connection_) {
+    return;
+  }
 
-} // namespace rsocket
+  // Drain the queue or the allowance.
+  while (!pendingWrites_.empty() && writeAllowance_.tryAcquire()) {
+    auto frame = std::move(pendingWrites_.front());
+    pendingWrites_.pop_front();
+    connectionOutput_->onNext(std::move(frame));
+  }
+}
+}

--- a/src/framing/FrameTransport.cpp
+++ b/src/framing/FrameTransport.cpp
@@ -149,9 +149,15 @@ void FrameTransport::onComplete() {
   terminateProcessor(folly::exception_wrapper());
 }
 
-void FrameTransport::onError(std::exception_ptr ex) {
-  VLOG(6) << "onError" << folly::exceptionStr(ex);
-  terminateProcessor(folly::exception_wrapper(std::move(ex)));
+void FrameTransport::onError(std::exception_ptr eptr) {
+  VLOG(6) << "onError" << folly::exceptionStr(eptr);
+
+  try {
+    std::rethrow_exception(eptr);
+  } catch (const std::exception& exn) {
+    folly::exception_wrapper ew{std::move(eptr), exn};
+    terminateProcessor(std::move(ew));
+  }
 }
 
 void FrameTransport::request(int64_t n) {

--- a/src/statemachine/RSocketStateMachine.cpp
+++ b/src/statemachine/RSocketStateMachine.cpp
@@ -814,11 +814,6 @@ bool RSocketStateMachine::isClosed() const {
   return isClosed_;
 }
 
-DuplexConnection* RSocketStateMachine::duplexConnection() const {
-  debugCheckCorrectExecutor();
-  return frameTransport_ ? frameTransport_->duplexConnection() : nullptr;
-}
-
 void RSocketStateMachine::debugCheckCorrectExecutor() const {
   DCHECK(
       !dynamic_cast<folly::EventBase*>(&executor_) ||

--- a/src/statemachine/RSocketStateMachine.h
+++ b/src/statemachine/RSocketStateMachine.h
@@ -179,7 +179,6 @@ class RSocketStateMachine final
   bool isDisconnectedOrClosed() const;
   bool isClosed() const;
 
-  DuplexConnection* duplexConnection() const;
   StreamsFactory& streamsFactory() {
     return streamsFactory_;
   }

--- a/test/framing/FrameTransportTest.cpp
+++ b/test/framing/FrameTransportTest.cpp
@@ -9,17 +9,41 @@
 using namespace rsocket;
 using namespace testing;
 
-TEST(FrameTransport, Close) {
+namespace {
+
+/*
+ * Compare a `const folly::IOBuf&` against a `const std::string&`.
+ */
+MATCHER_P(IOBufStringEq, s, "") {
+  return folly::IOBufEqual()(*arg, *folly::IOBuf::copyBuffer(s));
+}
+
+/*
+ * Make a MockDuplexConnection, and run an arbitrary lambda on the subscriber it
+ * returns from getOutput().
+ */
+template <class SubscriberFn>
+std::unique_ptr<StrictMock<MockDuplexConnection>> makeConnection(
+    SubscriberFn fn) {
   auto connection = std::make_unique<StrictMock<MockDuplexConnection>>();
 
   EXPECT_CALL(*connection, setInput_(_));
   EXPECT_CALL(*connection, getOutput_()).WillOnce(Invoke([&] {
     auto subscriber = yarpl::make_ref<
         StrictMock<MockSubscriber<std::unique_ptr<folly::IOBuf>>>>();
-    EXPECT_CALL(*subscriber, onSubscribe_(_));
-    EXPECT_CALL(*subscriber, onComplete_());
+    fn(subscriber);
     return subscriber;
   }));
+
+  return connection;
+}
+}
+
+TEST(FrameTransport, Close) {
+  auto connection = makeConnection([](auto& subscriber) {
+    EXPECT_CALL(*subscriber, onSubscribe_(_));
+    EXPECT_CALL(*subscriber, onComplete_());
+  });
 
   auto transport = yarpl::make_ref<FrameTransport>(std::move(connection));
   transport->setFrameProcessor(
@@ -28,19 +52,54 @@ TEST(FrameTransport, Close) {
 }
 
 TEST(FrameTransport, CloseWithError) {
-  auto connection = std::make_unique<StrictMock<MockDuplexConnection>>();
-
-  EXPECT_CALL(*connection, setInput_(_));
-  EXPECT_CALL(*connection, getOutput_()).WillOnce(Invoke([&] {
-    auto subscriber = yarpl::make_ref<
-        StrictMock<MockSubscriber<std::unique_ptr<folly::IOBuf>>>>();
+  auto connection = makeConnection([](auto& subscriber) {
     EXPECT_CALL(*subscriber, onSubscribe_(_));
     EXPECT_CALL(*subscriber, onError_(_));
-    return subscriber;
-  }));
+  });
 
   auto transport = yarpl::make_ref<FrameTransport>(std::move(connection));
   transport->setFrameProcessor(
       std::make_shared<StrictMock<MockFrameProcessor>>());
   transport->closeWithError(std::runtime_error("Uh oh"));
+}
+
+TEST(FrameTransport, SimpleEnqueue) {
+  auto connection = makeConnection([](auto& subscriber) {
+    EXPECT_CALL(*subscriber, onSubscribe_(_));
+
+    EXPECT_CALL(*subscriber, onNext_(IOBufStringEq("Hello")));
+    EXPECT_CALL(*subscriber, onNext_(IOBufStringEq("World")));
+
+    EXPECT_CALL(*subscriber, onComplete_());
+  });
+
+  auto transport = yarpl::make_ref<FrameTransport>(std::move(connection));
+
+  transport->outputFrameOrEnqueue(folly::IOBuf::copyBuffer("Hello"));
+  transport->outputFrameOrEnqueue(folly::IOBuf::copyBuffer("World"));
+
+  transport->setFrameProcessor(
+      std::make_shared<StrictMock<MockFrameProcessor>>());
+  transport->close();
+}
+
+TEST(FrameTransport, SimpleNoQueue) {
+  auto connection = makeConnection([](auto& subscriber) {
+    EXPECT_CALL(*subscriber, onSubscribe_(_));
+
+    EXPECT_CALL(*subscriber, onNext_(IOBufStringEq("Hello")));
+    EXPECT_CALL(*subscriber, onNext_(IOBufStringEq("World")));
+
+    EXPECT_CALL(*subscriber, onComplete_());
+  });
+
+  auto transport = yarpl::make_ref<FrameTransport>(std::move(connection));
+
+  transport->setFrameProcessor(
+      std::make_shared<StrictMock<MockFrameProcessor>>());
+
+  transport->outputFrameOrEnqueue(folly::IOBuf::copyBuffer("Hello"));
+  transport->outputFrameOrEnqueue(folly::IOBuf::copyBuffer("World"));
+
+  transport->close();
 }


### PR DESCRIPTION
* Remove virtual methods and make it final, there are no subclasses.

* Rename drainOutputFramesQueue() to drainWrites(), add a matching drainReads().
  Both of them take a lock_guard<> as a parameter, as all of their uses were
  already within the scope of one.

* Delete FrameTransport::duplexConnection().  It's not safe to be called in the
  general case as we can't control when the connection will be closed, and it's
  not necessary in tests if mocks are being used.

* Remove out-of-date TODOs about re-enabling VLOGs that may or may not be
  useful.

* Comments and a few tests.