### PR TITLE
Add test for server binding to an invalid port

### DIFF
--- a/test/RSocketClientServerTest.cpp
+++ b/test/RSocketClientServerTest.cpp
@@ -11,6 +11,24 @@ TEST(RSocketClientServer, StartAndShutdown) {
   auto client = makeClient(*server->listeningPort());
 }
 
+TEST(RSocketClientServer, InvalidPort) {
+  // Port 1 should always be invalid.
+  TcpConnectionAcceptor::Options opts;
+  opts.port = 1;
+
+  auto rs = RSocket::createServer(
+      std::make_unique<TcpConnectionAcceptor>(std::move(opts)));
+
+  try {
+    rs->start([](auto& setup) {
+      setup.createRSocket(std::make_shared<HelloStreamRequestHandler>());
+    });
+    FAIL();
+  } catch (const std::exception& exn) {
+    LOG(INFO) << "Caught error: " << exn.what();
+  }
+}
+
 TEST(RSocketClientServer, ConnectOne) {
   auto server = makeServer(std::make_shared<HelloStreamRequestHandler>());
   auto client = makeClient(*server->listeningPort());


### PR DESCRIPTION
TcpConnectionAcceptor::start() should throw when it fails to bind to the port.

Note - I don't actually want to land this diff as is.  I'm looking to see if
anyone can tell me why the changes to TcpConnectionAcceptor::start() are
necessary for the test to pass in Linux/ASAN/gcc builds.