### PR TITLE
Fix lambda using `auto&` instead of `auto`

### DIFF
--- a/test/framing/FrameTransportTest.cpp
+++ b/test/framing/FrameTransportTest.cpp
@@ -110,7 +110,7 @@ TEST(FrameTransport, InputSendsError) {
     EXPECT_CALL(*subscriber, onComplete_());
   });
 
-  ON_CALL(*connection, setInput_(_)).WillByDefault(Invoke([](auto& subscriber) {
+  ON_CALL(*connection, setInput_(_)).WillByDefault(Invoke([](auto subscriber) {
     auto subscription = yarpl::make_ref<StrictMock<MockSubscription>>();
     EXPECT_CALL(*subscription, request_(_));
     EXPECT_CALL(*subscription, cancel_());


### PR DESCRIPTION
Technically the type here is
`yarpl::Reference<Subscriber<std::unique_ptr<folly::IOBuf>>>`.  It seems like
some combinations of gcc+gmock get angry at using `auto&` with this.  Use `auto`
which appears to work in all cases.