### PR TITLE
[ConnectionFactory] Return future instead of taking callback

### DIFF
--- a/rsocket/ConnectionFactory.h
+++ b/rsocket/ConnectionFactory.h
@@ -14,8 +14,8 @@ class EventBase;
 namespace rsocket {
 
 struct ConnectionResult {
-  std::unique_ptr<rsocket::DuplexConnection> connection_;
-  folly::EventBase &evb_;
+  std::unique_ptr<rsocket::DuplexConnection> connection;
+  folly::EventBase &evb;
 };
 
 /**

--- a/rsocket/ConnectionFactory.h
+++ b/rsocket/ConnectionFactory.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <folly/Function.h>
+#include <folly/futures/Future.h>
+
 #include "rsocket/DuplexConnection.h"
 
 namespace folly {
@@ -11,9 +13,10 @@ class EventBase;
 
 namespace rsocket {
 
-using OnDuplexConnectionConnect = folly::Function<void(
-    std::unique_ptr<rsocket::DuplexConnection>,
-    folly::EventBase&)>;
+struct ConnectionResult {
+  std::unique_ptr<rsocket::DuplexConnection> connection_;
+  folly::EventBase &evb_;
+};
 
 /**
  * Common interface for a client to create connections and turn them into
@@ -27,7 +30,9 @@ using OnDuplexConnectionConnect = folly::Function<void(
 class ConnectionFactory {
  public:
   ConnectionFactory() = default;
+
   virtual ~ConnectionFactory() = default;
+
   ConnectionFactory(const ConnectionFactory&) = delete; // copy
   ConnectionFactory(ConnectionFactory&&) = delete; // move
   ConnectionFactory& operator=(const ConnectionFactory&) = delete; // copy
@@ -42,6 +47,6 @@ class ConnectionFactory {
    *
    * Resource creation depends on the particular implementation.
    */
-  virtual void connect(OnDuplexConnectionConnect onConnect) = 0;
+  virtual folly::Future<ConnectionResult> connect() = 0;
 };
 } // namespace rsocket

--- a/rsocket/RSocketClient.cpp
+++ b/rsocket/RSocketClient.cpp
@@ -32,33 +32,26 @@ folly::Future<std::unique_ptr<RSocketRequester>> RSocketClient::connect(
     std::shared_ptr<RSocketNetworkStats> networkStats) {
   VLOG(2) << "Starting connection";
 
-  folly::Promise<std::unique_ptr<RSocketRequester>> promise;
-  auto future = promise.getFuture();
-
-  connectionFactory_->connect()
-      .then([this,
-             setupParameters = std::move(setupParameters),
-             responder = std::move(responder),
-             keepaliveTimer = std::move(keepaliveTimer),
-             stats = std::move(stats),
-             networkStats = std::move(networkStats),
-             promise = std::move(promise)](ConnectionResult connResult) mutable {
+  return connectionFactory_->connect()
+      .then([
+        this,
+        setupParameters = std::move(setupParameters),
+        responder = std::move(responder),
+        keepaliveTimer = std::move(keepaliveTimer),
+        stats = std::move(stats),
+        networkStats = std::move(networkStats)
+      ](ConnectionResult connResult) mutable {
         VLOG(3) << "onConnect received DuplexConnection";
         auto rsocket = fromConnection(
-            std::move(connResult.connection_),
-            connResult.evb_,
+            std::move(connResult.connection),
+            connResult.evb,
             std::move(setupParameters),
             std::move(responder),
             std::move(keepaliveTimer),
             std::move(stats),
             std::move(networkStats));
-        promise.setValue(std::move(rsocket));
-      })
-      .onError([promise = std::move(promise)](folly::exception_wrapper ex) mutable {
-        promise.setException(ex);
+        return rsocket;
       });
-
-  return future;
 }
 
 std::unique_ptr<RSocketRequester> RSocketClient::fromConnection(

--- a/rsocket/RSocketClient.cpp
+++ b/rsocket/RSocketClient.cpp
@@ -35,28 +35,28 @@ folly::Future<std::unique_ptr<RSocketRequester>> RSocketClient::connect(
   folly::Promise<std::unique_ptr<RSocketRequester>> promise;
   auto future = promise.getFuture();
 
-  connectionFactory_->connect([
-    this,
-    setupParameters = std::move(setupParameters),
-    responder = std::move(responder),
-    keepaliveTimer = std::move(keepaliveTimer),
-    stats = std::move(stats),
-    networkStats = std::move(networkStats),
-    promise = std::move(promise)](
-      std::unique_ptr<DuplexConnection> connection,
-      folly::EventBase& eventBase) mutable {
-    VLOG(3) << "onConnect received DuplexConnection";
-
-    auto rsocket = fromConnection(
-        std::move(connection),
-        eventBase,
-        std::move(setupParameters),
-        std::move(responder),
-        std::move(keepaliveTimer),
-        std::move(stats),
-        std::move(networkStats));
-    promise.setValue(std::move(rsocket));
-  });
+  connectionFactory_->connect()
+      .then([this,
+             setupParameters = std::move(setupParameters),
+             responder = std::move(responder),
+             keepaliveTimer = std::move(keepaliveTimer),
+             stats = std::move(stats),
+             networkStats = std::move(networkStats),
+             promise = std::move(promise)](ConnectionResult connResult) mutable {
+        VLOG(3) << "onConnect received DuplexConnection";
+        auto rsocket = fromConnection(
+            std::move(connResult.connection_),
+            connResult.evb_,
+            std::move(setupParameters),
+            std::move(responder),
+            std::move(keepaliveTimer),
+            std::move(stats),
+            std::move(networkStats));
+        promise.setValue(std::move(rsocket));
+      })
+      .onError([promise = std::move(promise)](folly::exception_wrapper ex) mutable {
+        promise.setException(ex);
+      });
 
   return future;
 }

--- a/rsocket/transports/tcp/TcpConnectionFactory.h
+++ b/rsocket/transports/tcp/TcpConnectionFactory.h
@@ -28,7 +28,7 @@ class TcpConnectionFactory : public ConnectionFactory {
    *
    * Each call to connect() creates a new AsyncSocket.
    */
-  void connect(OnDuplexConnectionConnect) override;
+  folly::Future<ConnectionResult> connect() override;
 
   static std::unique_ptr<DuplexConnection> createDuplexConnectionFromSocket(
       folly::AsyncSocket::UniquePtr socket,

--- a/test/transport/TcpDuplexConnectionTest.cpp
+++ b/test/transport/TcpDuplexConnectionTest.cpp
@@ -43,11 +43,11 @@ makeSingleClientServer(
 
   auto client = std::make_unique<TcpConnectionFactory>(
       SocketAddress("localhost", port, true));
-  client->connect(
+  client->connect().then(
       [&clientPromise, &clientConnection, &clientEvb](
-          std::unique_ptr<DuplexConnection> connection, EventBase& eventBase) {
-        clientConnection = std::move(connection);
-        *clientEvb = &eventBase;
+          ConnectionResult connResult) {
+        clientConnection = std::move(connResult.connection_);
+        *clientEvb = &connResult.evb_;
         clientPromise.setValue();
       });
 


### PR DESCRIPTION
Makes error handling easier.  Fits with the result of the planned API changes