### PR TITLE
RSocket Client API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,7 +323,8 @@ add_library(
   rsocket/RSocketSetup.cpp
   rsocket/RSocketSetup.h
   rsocket/ResumeManager.h
-  rsocket/ColdResumeHandler.h)
+  rsocket/ColdResumeHandler.h
+  rsocket/Exception.h)
 
 target_include_directories(ReactiveSocket PUBLIC "${PROJECT_SOURCE_DIR}/yarpl/include")
 target_include_directories(ReactiveSocket PUBLIC "${PROJECT_SOURCE_DIR}/yarpl/src")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,7 +321,9 @@ add_library(
   rsocket/internal/RSocketConnectionManager.cpp
   rsocket/internal/RSocketConnectionManager.h
   rsocket/RSocketSetup.cpp
-  rsocket/RSocketSetup.h)
+  rsocket/RSocketSetup.h
+  rsocket/ResumeManager.h
+  rsocket/ColdResumeHandler.h)
 
 target_include_directories(ReactiveSocket PUBLIC "${PROJECT_SOURCE_DIR}/yarpl/include")
 target_include_directories(ReactiveSocket PUBLIC "${PROJECT_SOURCE_DIR}/yarpl/src")

--- a/benchmarks/StreamThroughput.cpp
+++ b/benchmarks/StreamThroughput.cpp
@@ -184,12 +184,12 @@ BENCHMARK_DEFINE_F(BM_RsFixture, BM_Stream_Throughput)
 
   auto s = make_ref<BM_Subscriber>(state.range(0));
 
-  std::unique_ptr<RSocketClient> client;
+  std::shared_ptr<RSocketClient> client;
 
   RSocket::createConnectedClient(
       std::make_unique<TcpConnectionFactory>(std::move(address)))
       .then([&client, s = std::move(s) ](
-          std::unique_ptr<RSocketClient> cl) mutable {
+          std::shared_ptr<RSocketClient> cl) mutable {
         LOG(INFO) << "Connected";
         client = std::move(cl);
         client->getRequester()

--- a/benchmarks/StreamThroughput.cpp
+++ b/benchmarks/StreamThroughput.cpp
@@ -195,6 +195,10 @@ BENCHMARK_DEFINE_F(BM_RsFixture, BM_Stream_Throughput)
         client->getRequester()
             ->requestStream(Payload("BM_Stream"))
             ->subscribe(std::move(s));
+      })
+      .onError([](folly::exception_wrapper ex) {
+        LOG(INFO) << "Exception received " << ex;
+        return;
       });
 
   while (state.KeepRunning()) {

--- a/examples/channel-hello-world/ChannelHelloWorld_Client.cpp
+++ b/examples/channel-hello-world/ChannelHelloWorld_Client.cpp
@@ -27,11 +27,11 @@ int main(int argc, char* argv[]) {
   folly::SocketAddress address;
   address.setFromHostPort(FLAGS_host, FLAGS_port);
 
-  std::unique_ptr<RSocketClient> client;
+  std::shared_ptr<RSocketClient> client;
 
   RSocket::createConnectedClient(
       std::make_unique<TcpConnectionFactory>(std::move(address)))
-      .then([&client](std::unique_ptr<RSocketClient> cl) mutable {
+      .then([&client](std::shared_ptr<RSocketClient> cl) mutable {
         client = std::move(cl);
         client->getRequester()
             ->requestChannel(Flowables::justN({"initialPayload", "Bob", "Jane"})

--- a/examples/channel-hello-world/ChannelHelloWorld_Client.cpp
+++ b/examples/channel-hello-world/ChannelHelloWorld_Client.cpp
@@ -27,20 +27,24 @@ int main(int argc, char* argv[]) {
   folly::SocketAddress address;
   address.setFromHostPort(FLAGS_host, FLAGS_port);
 
-  // create a client which can then make connections below
-  auto rsf = RSocket::createClient(
-      std::make_unique<TcpConnectionFactory>(std::move(address)));
+  std::unique_ptr<RSocketClient> client;
 
-  auto rs = rsf->connect().get();
-
-  // send stream of strings to the server
-  rs->requestChannel(Flowables::justN({"initialPayload", "Bob", "Jane"})
-                         ->map([](std::string v) {
-                           std::cout << "Sending: " << v << std::endl;
-                           return Payload(v);
-                         }))
-      ->subscribe([](Payload p) {
-        std::cout << "Received: " << p.moveDataToString() << std::endl;
+  RSocket::createConnectedClient(
+      std::make_unique<TcpConnectionFactory>(std::move(address)))
+      .then([&client](std::unique_ptr<RSocketClient> cl) mutable {
+        client = std::move(cl);
+        client->getRequester()
+            ->requestChannel(Flowables::justN({"initialPayload", "Bob", "Jane"})
+                                 ->map([](std::string v) {
+                                   std::cout << "Sending: " << v << std::endl;
+                                   return Payload(v);
+                                 }))
+            ->subscribe([](Payload p) {
+              std::cout << "Received: " << p.moveDataToString() << std::endl;
+            });
+      })
+      .onError([](folly::exception_wrapper ex) {
+        LOG(INFO) << "Exception received " << ex;
       });
 
   // Wait for a newline on the console to terminate the server.

--- a/examples/channel-hello-world/ChannelHelloWorld_Client.cpp
+++ b/examples/channel-hello-world/ChannelHelloWorld_Client.cpp
@@ -27,24 +27,18 @@ int main(int argc, char* argv[]) {
   folly::SocketAddress address;
   address.setFromHostPort(FLAGS_host, FLAGS_port);
 
-  std::shared_ptr<RSocketClient> client;
+  auto client = RSocket::createConnectedClient(
+                    std::make_unique<TcpConnectionFactory>(std::move(address)))
+                    .get();
 
-  RSocket::createConnectedClient(
-      std::make_unique<TcpConnectionFactory>(std::move(address)))
-      .then([&client](std::shared_ptr<RSocketClient> cl) mutable {
-        client = std::move(cl);
-        client->getRequester()
-            ->requestChannel(Flowables::justN({"initialPayload", "Bob", "Jane"})
-                                 ->map([](std::string v) {
-                                   std::cout << "Sending: " << v << std::endl;
-                                   return Payload(v);
-                                 }))
-            ->subscribe([](Payload p) {
-              std::cout << "Received: " << p.moveDataToString() << std::endl;
-            });
-      })
-      .onError([](folly::exception_wrapper ex) {
-        LOG(INFO) << "Exception received " << ex;
+  client->getRequester()
+      ->requestChannel(Flowables::justN({"initialPayload", "Bob", "Jane"})
+                           ->map([](std::string v) {
+                             std::cout << "Sending: " << v << std::endl;
+                             return Payload(v);
+                           }))
+      ->subscribe([](Payload p) {
+        std::cout << "Received: " << p.moveDataToString() << std::endl;
       });
 
   // Wait for a newline on the console to terminate the server.

--- a/examples/conditional-request-handling/ConditionalRequestHandling_Client.cpp
+++ b/examples/conditional-request-handling/ConditionalRequestHandling_Client.cpp
@@ -40,7 +40,7 @@ int main(int argc, char* argv[]) {
   folly::SocketAddress address;
   address.setFromHostPort(FLAGS_host, FLAGS_port);
 
-  std::unique_ptr<RSocketClient> client;
+  std::shared_ptr<RSocketClient> client;
 
   RSocket::createConnectedClient(
       std::make_unique<TcpConnectionFactory>(std::move(address)),
@@ -49,7 +49,7 @@ int main(int argc, char* argv[]) {
       nullptr,
       RSocketStats::noop(),
       std::make_shared<RSocketNetworkStatsLog>())
-      .then([&client](std::unique_ptr<RSocketClient> cl) mutable {
+      .then([&client](std::shared_ptr<RSocketClient> cl) mutable {
         client = std::move(cl);
         client->getRequester()
             ->requestStream(Payload("Bob"))

--- a/examples/conditional-request-handling/ConditionalRequestHandling_Client.cpp
+++ b/examples/conditional-request-handling/ConditionalRequestHandling_Client.cpp
@@ -40,26 +40,20 @@ int main(int argc, char* argv[]) {
   folly::SocketAddress address;
   address.setFromHostPort(FLAGS_host, FLAGS_port);
 
-  std::shared_ptr<RSocketClient> client;
+  auto client = RSocket::createConnectedClient(
+                    std::make_unique<TcpConnectionFactory>(std::move(address)),
+                    SetupParameters("application/json", "application/json"),
+                    std::make_shared<RSocketResponder>(),
+                    nullptr,
+                    RSocketStats::noop(),
+                    std::make_shared<RSocketNetworkStatsLog>())
+                    .get();
 
-  RSocket::createConnectedClient(
-      std::make_unique<TcpConnectionFactory>(std::move(address)),
-      SetupParameters("application/json", "application/json"),
-      std::make_shared<RSocketResponder>(),
-      nullptr,
-      RSocketStats::noop(),
-      std::make_shared<RSocketNetworkStatsLog>())
-      .then([&client](std::shared_ptr<RSocketClient> cl) mutable {
-        client = std::move(cl);
-        client->getRequester()
-            ->requestStream(Payload("Bob"))
-            ->take(5)
-            ->subscribe([](Payload p) {
-              std::cout << "Received: " << p.moveDataToString() << std::endl;
-            });
-      })
-      .onError([](folly::exception_wrapper ex) {
-        LOG(INFO) << "Exception received " << ex;
+  client->getRequester()
+      ->requestStream(Payload("Bob"))
+      ->take(5)
+      ->subscribe([](Payload p) {
+        std::cout << "Received: " << p.moveDataToString() << std::endl;
       });
 
   // Wait for a newline on the console to terminate the server.

--- a/examples/fire-and-forget-hello-world/FireAndForgetHelloWorld_Client.cpp
+++ b/examples/fire-and-forget-hello-world/FireAndForgetHelloWorld_Client.cpp
@@ -28,11 +28,11 @@ int main(int argc, char* argv[]) {
   folly::SocketAddress address;
   address.setFromHostPort(FLAGS_host, FLAGS_port);
 
-  std::unique_ptr<RSocketClient> client;
+  std::shared_ptr<RSocketClient> client;
 
   RSocket::createConnectedClient(
       std::make_unique<TcpConnectionFactory>(std::move(address)))
-      .then([&client](std::unique_ptr<RSocketClient> cl) mutable {
+      .then([&client](std::shared_ptr<RSocketClient> cl) mutable {
         LOG(INFO) << "Connected";
         client = std::move(cl);
         client->getRequester()

--- a/examples/fire-and-forget-hello-world/FireAndForgetHelloWorld_Client.cpp
+++ b/examples/fire-and-forget-hello-world/FireAndForgetHelloWorld_Client.cpp
@@ -28,20 +28,13 @@ int main(int argc, char* argv[]) {
   folly::SocketAddress address;
   address.setFromHostPort(FLAGS_host, FLAGS_port);
 
-  std::shared_ptr<RSocketClient> client;
+  auto client = RSocket::createConnectedClient(
+                    std::make_unique<TcpConnectionFactory>(std::move(address)))
+                    .get();
 
-  RSocket::createConnectedClient(
-      std::make_unique<TcpConnectionFactory>(std::move(address)))
-      .then([&client](std::shared_ptr<RSocketClient> cl) mutable {
-        LOG(INFO) << "Connected";
-        client = std::move(cl);
-        client->getRequester()
-            ->fireAndForget(Payload("Hello World!"))
-            ->subscribe([] { std::cout << "wrote to network" << std::endl; });
-      })
-      .onError([](folly::exception_wrapper ex) {
-        LOG(INFO) << "Exception received " << ex;
-      });
+  client->getRequester()->fireAndForget(Payload("Hello World!"))->subscribe([] {
+    std::cout << "wrote to network" << std::endl;
+  });
 
   // Wait for a newline on the console to terminate the client.
   std::getchar();

--- a/examples/fire-and-forget-hello-world/FireAndForgetHelloWorld_Client.cpp
+++ b/examples/fire-and-forget-hello-world/FireAndForgetHelloWorld_Client.cpp
@@ -28,17 +28,20 @@ int main(int argc, char* argv[]) {
   folly::SocketAddress address;
   address.setFromHostPort(FLAGS_host, FLAGS_port);
 
-  // create a client which can then make connections below
-  auto rsf = RSocket::createClient(
-      std::make_unique<TcpConnectionFactory>(std::move(address)));
+  std::unique_ptr<RSocketClient> client;
 
-  // connect and wait for connection
-  auto rs = rsf->connect().get();
-
-  // perform request on connected RSocket
-  rs->fireAndForget(Payload("Hello World!"))->subscribe([] {
-    std::cout << "wrote to network" << std::endl;
-  });
+  RSocket::createConnectedClient(
+      std::make_unique<TcpConnectionFactory>(std::move(address)))
+      .then([&client](std::unique_ptr<RSocketClient> cl) mutable {
+        LOG(INFO) << "Connected";
+        client = std::move(cl);
+        client->getRequester()
+            ->fireAndForget(Payload("Hello World!"))
+            ->subscribe([] { std::cout << "wrote to network" << std::endl; });
+      })
+      .onError([](folly::exception_wrapper ex) {
+        LOG(INFO) << "Exception received " << ex;
+      });
 
   // Wait for a newline on the console to terminate the client.
   std::getchar();

--- a/examples/request-response-hello-world/RequestResponseHelloWorld_Client.cpp
+++ b/examples/request-response-hello-world/RequestResponseHelloWorld_Client.cpp
@@ -28,11 +28,11 @@ int main(int argc, char* argv[]) {
   folly::SocketAddress address;
   address.setFromHostPort(FLAGS_host, FLAGS_port);
 
-  std::unique_ptr<RSocketClient> client;
+  std::shared_ptr<RSocketClient> client;
 
   RSocket::createConnectedClient(
       std::make_unique<TcpConnectionFactory>(std::move(address)))
-      .then([&client](std::unique_ptr<RSocketClient> cl) mutable {
+      .then([&client](std::shared_ptr<RSocketClient> cl) mutable {
         LOG(INFO) << "Connected";
         client = std::move(cl);
         client->getRequester()

--- a/examples/request-response-hello-world/RequestResponseHelloWorld_Client.cpp
+++ b/examples/request-response-hello-world/RequestResponseHelloWorld_Client.cpp
@@ -28,17 +28,22 @@ int main(int argc, char* argv[]) {
   folly::SocketAddress address;
   address.setFromHostPort(FLAGS_host, FLAGS_port);
 
-  // create a client which can then make connections below
-  auto rsf = RSocket::createClient(
-      std::make_unique<TcpConnectionFactory>(std::move(address)));
+  std::unique_ptr<RSocketClient> client;
 
-  // connect and wait for connection
-  auto rs = rsf->connect().get();
-
-  // perform request on connected RSocket
-  rs->requestResponse(Payload("Jane"))->subscribe([](Payload p) {
-    std::cout << "Received >> " << p.moveDataToString() << std::endl;
-  });
+  RSocket::createConnectedClient(
+      std::make_unique<TcpConnectionFactory>(std::move(address)))
+      .then([&client](std::unique_ptr<RSocketClient> cl) mutable {
+        LOG(INFO) << "Connected";
+        client = std::move(cl);
+        client->getRequester()
+            ->requestResponse(Payload("Jane"))
+            ->subscribe([](Payload p) {
+              std::cout << "Received >> " << p.moveDataToString() << std::endl;
+            });
+      })
+      .onError([](folly::exception_wrapper ex) {
+        LOG(INFO) << "Exception received " << ex;
+      });
 
   // Wait for a newline on the console to terminate the client.
   std::getchar();

--- a/examples/stream-hello-world/StreamHelloWorld_Client.cpp
+++ b/examples/stream-hello-world/StreamHelloWorld_Client.cpp
@@ -26,21 +26,14 @@ int main(int argc, char* argv[]) {
   folly::SocketAddress address;
   address.setFromHostPort(FLAGS_host, FLAGS_port);
 
-  std::shared_ptr<RSocketClient> client;
+  auto client = RSocket::createConnectedClient(
+                    std::make_unique<TcpConnectionFactory>(std::move(address)))
+                    .get();
 
-  RSocket::createConnectedClient(
-      std::make_unique<TcpConnectionFactory>(std::move(address)))
-      .then([&client](std::shared_ptr<RSocketClient> cl) mutable {
-        LOG(INFO) << "Connected";
-        client = std::move(cl);
-        client->getRequester()
-            ->requestStream(Payload("Jane"))
-            ->subscribe([](Payload p) {
-              std::cout << "Received: " << p.moveDataToString() << std::endl;
-            });
-      })
-      .onError([](folly::exception_wrapper ex) {
-        LOG(INFO) << "Exception received " << ex;
+  client->getRequester()
+      ->requestStream(Payload("Jane"))
+      ->subscribe([](Payload p) {
+        std::cout << "Received: " << p.moveDataToString() << std::endl;
       });
 
   // Wait for a newline on the console to terminate the server.

--- a/examples/stream-hello-world/StreamHelloWorld_Client.cpp
+++ b/examples/stream-hello-world/StreamHelloWorld_Client.cpp
@@ -26,11 +26,11 @@ int main(int argc, char* argv[]) {
   folly::SocketAddress address;
   address.setFromHostPort(FLAGS_host, FLAGS_port);
 
-  std::unique_ptr<RSocketClient> client;
+  std::shared_ptr<RSocketClient> client;
 
   RSocket::createConnectedClient(
       std::make_unique<TcpConnectionFactory>(std::move(address)))
-      .then([&client](std::unique_ptr<RSocketClient> cl) mutable {
+      .then([&client](std::shared_ptr<RSocketClient> cl) mutable {
         LOG(INFO) << "Connected";
         client = std::move(cl);
         client->getRequester()

--- a/examples/stream-observable-to-flowable/StreamObservableToFlowable_Client.cpp
+++ b/examples/stream-observable-to-flowable/StreamObservableToFlowable_Client.cpp
@@ -27,20 +27,27 @@ int main(int argc, char* argv[]) {
   folly::SocketAddress address;
   address.setFromHostPort(FLAGS_host, FLAGS_port);
 
-  // create a client which can then make connections below
-  auto rsf = RSocket::createClient(
-      std::make_unique<TcpConnectionFactory>(std::move(address)));
+  std::unique_ptr<RSocketClient> client;
 
-  auto rs = rsf->connect().get();
-  rs->requestStream(Payload("TopicX"))
-      ->take(10)
-      ->subscribe(
-          [](Payload p) {
-            std::cout << p.cloneDataToString() << std::endl;
-            // simulate slow consumer
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-          },
-          3 /* request batch size */);
+  RSocket::createConnectedClient(
+      std::make_unique<TcpConnectionFactory>(std::move(address)))
+      .then([&client](std::unique_ptr<RSocketClient> cl) mutable {
+        LOG(INFO) << "Connected";
+        client = std::move(cl);
+        client->getRequester()
+            ->requestStream(Payload("TopicX"))
+            ->take(10)
+            ->subscribe(
+                [](Payload p) {
+                  std::cout << p.cloneDataToString() << std::endl;
+                  // simulate slow consumer
+                  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                },
+                3 /* request batch size */);
+      })
+      .onError([](folly::exception_wrapper ex) {
+        LOG(INFO) << "Exception received " << ex;
+      });
 
   // Wait for a newline on the console to terminate the server.
   std::getchar();

--- a/examples/stream-observable-to-flowable/StreamObservableToFlowable_Client.cpp
+++ b/examples/stream-observable-to-flowable/StreamObservableToFlowable_Client.cpp
@@ -27,11 +27,11 @@ int main(int argc, char* argv[]) {
   folly::SocketAddress address;
   address.setFromHostPort(FLAGS_host, FLAGS_port);
 
-  std::unique_ptr<RSocketClient> client;
+  std::shared_ptr<RSocketClient> client;
 
   RSocket::createConnectedClient(
       std::make_unique<TcpConnectionFactory>(std::move(address)))
-      .then([&client](std::unique_ptr<RSocketClient> cl) mutable {
+      .then([&client](std::shared_ptr<RSocketClient> cl) mutable {
         LOG(INFO) << "Connected";
         client = std::move(cl);
         client->getRequester()

--- a/rsocket/ColdResumeHandler.h
+++ b/rsocket/ColdResumeHandler.h
@@ -1,0 +1,8 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+namespace rsocket {
+
+class ColdResumeHandler {};
+}

--- a/rsocket/Exception.h
+++ b/rsocket/Exception.h
@@ -5,15 +5,13 @@
 #include <stdexcept>
 
 // Thrown when an ERROR frame with CONNECTION_ERROR is received during
-// resuming operation.
+// resumption.
 class ResumptionException : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 
-// Thrown when the resume operation was interrupted due to network
-// the application code may try to resume again.
+// Thrown when the resume operation was interrupted due to network.
+// The application may try to resume again.
 class ConnectionException : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };
-
-

--- a/rsocket/Exception.h
+++ b/rsocket/Exception.h
@@ -1,0 +1,21 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <stdexcept>
+
+// Thrown when an ERROR frame with CONNECTION_ERROR is received during
+// resuming operation.
+// TODO: in this case we should get the DuplexConnection back to
+// create a new instance of RS with it
+class ResumptionException : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+// Thrown when the resume operation was interrupted due to network
+// the application code may try to resume again.
+class ConnectionException : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+

--- a/rsocket/Exception.h
+++ b/rsocket/Exception.h
@@ -6,8 +6,6 @@
 
 // Thrown when an ERROR frame with CONNECTION_ERROR is received during
 // resuming operation.
-// TODO: in this case we should get the DuplexConnection back to
-// create a new instance of RS with it
 class ResumptionException : public std::runtime_error {
   using std::runtime_error::runtime_error;
 };

--- a/rsocket/RSocket.cpp
+++ b/rsocket/RSocket.cpp
@@ -6,7 +6,7 @@
 
 namespace rsocket {
 
-folly::Future<std::unique_ptr<RSocketClient>> RSocket::createConnectedClient(
+folly::Future<std::shared_ptr<RSocketClient>> RSocket::createConnectedClient(
     std::unique_ptr<ConnectionFactory> connectionFactory,
     SetupParameters setupParameters,
     std::shared_ptr<RSocketResponder> responder,
@@ -16,7 +16,7 @@ folly::Future<std::unique_ptr<RSocketClient>> RSocket::createConnectedClient(
     std::shared_ptr<ResumeManager> resumeManager,
     std::shared_ptr<ColdResumeHandler> coldResumeHandler,
     OnRSocketResume) {
-  auto c = std::unique_ptr<RSocketClient>(new RSocketClient(
+  auto c = std::shared_ptr<RSocketClient>(new RSocketClient(
       std::move(connectionFactory),
       std::move(setupParameters),
       std::move(responder),
@@ -26,12 +26,10 @@ folly::Future<std::unique_ptr<RSocketClient>> RSocket::createConnectedClient(
       std::move(resumeManager),
       std::move(coldResumeHandler)));
 
-  return c->connect().then([c = std::move(c)]() mutable {
-    return std::move(c);
-  });
+  return c->connect().then([c]() mutable { return c; });
 }
 
-folly::Future<std::unique_ptr<RSocketClient>> RSocket::createResumedClient(
+folly::Future<std::shared_ptr<RSocketClient>> RSocket::createResumedClient(
     std::unique_ptr<ConnectionFactory> connectionFactory,
     SetupParameters setupParameters,
     std::shared_ptr<ResumeManager> resumeManager,
@@ -41,7 +39,7 @@ folly::Future<std::unique_ptr<RSocketClient>> RSocket::createResumedClient(
     std::unique_ptr<KeepaliveTimer> keepaliveTimer,
     std::shared_ptr<RSocketStats> stats,
     std::shared_ptr<RSocketNetworkStats> networkStats) {
-  auto c = std::unique_ptr<RSocketClient>(new RSocketClient(
+  auto c = std::shared_ptr<RSocketClient>(new RSocketClient(
       std::move(connectionFactory),
       std::move(setupParameters),
       std::move(responder),
@@ -51,9 +49,7 @@ folly::Future<std::unique_ptr<RSocketClient>> RSocket::createResumedClient(
       std::move(resumeManager),
       std::move(coldResumeHandler)));
 
-  return c->resume().then([c = std::move(c)]() mutable {
-    return std::move(c);
-  });
+  return c->resume().then([c]() mutable { return c; });
 }
 
 std::unique_ptr<RSocketServer> RSocket::createServer(

--- a/rsocket/RSocket.cpp
+++ b/rsocket/RSocket.cpp
@@ -1,12 +1,59 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
+#include <folly/io/async/EventBaseManager.h>
+
 #include "rsocket/RSocket.h"
 
 namespace rsocket {
 
-std::unique_ptr<RSocketClient> RSocket::createClient(
-    std::unique_ptr<ConnectionFactory> connectionFactory) {
-  return std::make_unique<RSocketClient>(std::move(connectionFactory));
+folly::Future<std::unique_ptr<RSocketClient>> RSocket::createConnectedClient(
+    std::unique_ptr<ConnectionFactory> connectionFactory,
+    SetupParameters setupParameters,
+    std::shared_ptr<RSocketResponder> responder,
+    std::unique_ptr<KeepaliveTimer> keepaliveTimer,
+    std::shared_ptr<RSocketStats> stats,
+    std::shared_ptr<RSocketNetworkStats> networkStats,
+    std::shared_ptr<ResumeManager> resumeManager,
+    std::shared_ptr<ColdResumeHandler> coldResumeHandler,
+    OnRSocketResume) {
+  auto c = std::unique_ptr<RSocketClient>(new RSocketClient(
+      std::move(connectionFactory),
+      std::move(setupParameters),
+      std::move(responder),
+      std::move(keepaliveTimer),
+      std::move(stats),
+      std::move(networkStats),
+      std::move(resumeManager),
+      std::move(coldResumeHandler)));
+
+  return c->connect().then([c = std::move(c)]() mutable {
+    return std::move(c);
+  });
+}
+
+folly::Future<std::unique_ptr<RSocketClient>> RSocket::createResumedClient(
+    std::unique_ptr<ConnectionFactory> connectionFactory,
+    SetupParameters setupParameters,
+    std::shared_ptr<ResumeManager> resumeManager,
+    std::shared_ptr<ColdResumeHandler> coldResumeHandler,
+    OnRSocketResume,
+    std::shared_ptr<RSocketResponder> responder,
+    std::unique_ptr<KeepaliveTimer> keepaliveTimer,
+    std::shared_ptr<RSocketStats> stats,
+    std::shared_ptr<RSocketNetworkStats> networkStats) {
+  auto c = std::unique_ptr<RSocketClient>(new RSocketClient(
+      std::move(connectionFactory),
+      std::move(setupParameters),
+      std::move(responder),
+      std::move(keepaliveTimer),
+      std::move(stats),
+      std::move(networkStats),
+      std::move(resumeManager),
+      std::move(coldResumeHandler)));
+
+  return c->resume().then([c = std::move(c)]() mutable {
+    return std::move(c);
+  });
 }
 
 std::unique_ptr<RSocketServer> RSocket::createServer(

--- a/rsocket/RSocket.h
+++ b/rsocket/RSocket.h
@@ -12,17 +12,38 @@ namespace rsocket {
  */
 class RSocket {
  public:
-  /**
-   * Create an RSocketClient that can be used to open RSocket connections.
-   * Takes a factory of DuplexConnections on the desired transport, such as
-   * TcpClientConnectionFactory.
-   */
-  static std::unique_ptr<RSocketClient> createClient(
-      std::unique_ptr<ConnectionFactory>);
+  // Creates a RSocketClient which is connected to the remoteside.
+  static folly::Future<std::unique_ptr<RSocketClient>> createConnectedClient(
+      std::unique_ptr<ConnectionFactory>,
+      SetupParameters setupParameters = SetupParameters(),
+      std::shared_ptr<RSocketResponder> responder =
+          std::make_shared<RSocketResponder>(),
+      std::unique_ptr<KeepaliveTimer> keepaliveTimer =
+          std::unique_ptr<KeepaliveTimer>(),
+      std::shared_ptr<RSocketStats> stats = RSocketStats::noop(),
+      std::shared_ptr<RSocketNetworkStats> networkStats =
+          std::shared_ptr<RSocketNetworkStats>(),
+      std::shared_ptr<ResumeManager> resumeManager =
+          std::shared_ptr<ResumeManager>(),
+      std::shared_ptr<ColdResumeHandler> coldResumeHandler =
+          std::shared_ptr<ColdResumeHandler>(),
+      OnRSocketResume onRSocketResume =
+          [](std::vector<StreamId>, std::vector<StreamId>) { return false; });
 
-  // TODO duplex client that takes a requestHandler
-  // TODO ConnectionSetupPayload arguments such as MimeTypes, Keepalive, etc
-
+  // Creates a RSocketClient which cold-resumes from the provided state
+  static folly::Future<std::unique_ptr<RSocketClient>> createResumedClient(
+      std::unique_ptr<ConnectionFactory>,
+      SetupParameters setupParameters,
+      std::shared_ptr<ResumeManager> resumeManager,
+      std::shared_ptr<ColdResumeHandler> coldResumeHandler,
+      OnRSocketResume onRSocketResume,
+      std::shared_ptr<RSocketResponder> responder =
+          std::make_shared<RSocketResponder>(),
+      std::unique_ptr<KeepaliveTimer> keepaliveTimer =
+          std::unique_ptr<KeepaliveTimer>(),
+      std::shared_ptr<RSocketStats> stats = RSocketStats::noop(),
+      std::shared_ptr<RSocketNetworkStats> networkStats =
+          std::shared_ptr<RSocketNetworkStats>());
   /**
    * Create an RSocketServer that will accept connections.  Takes an acceptor of
    * DuplexConnections on the desired transport, such as
@@ -31,14 +52,14 @@ class RSocket {
   static std::unique_ptr<RSocketServer> createServer(
       std::unique_ptr<ConnectionAcceptor>);
 
-  // TODO createResumeServer
-
   RSocket() = delete;
 
   RSocket(const RSocket&) = delete;
+
   RSocket(RSocket&&) = delete;
 
   RSocket& operator=(const RSocket&) = delete;
+
   RSocket& operator=(RSocket&&) = delete;
 };
 }

--- a/rsocket/RSocket.h
+++ b/rsocket/RSocket.h
@@ -13,7 +13,7 @@ namespace rsocket {
 class RSocket {
  public:
   // Creates a RSocketClient which is connected to the remoteside.
-  static folly::Future<std::unique_ptr<RSocketClient>> createConnectedClient(
+  static folly::Future<std::shared_ptr<RSocketClient>> createConnectedClient(
       std::unique_ptr<ConnectionFactory>,
       SetupParameters setupParameters = SetupParameters(),
       std::shared_ptr<RSocketResponder> responder =
@@ -31,7 +31,7 @@ class RSocket {
           [](std::vector<StreamId>, std::vector<StreamId>) { return false; });
 
   // Creates a RSocketClient which cold-resumes from the provided state
-  static folly::Future<std::unique_ptr<RSocketClient>> createResumedClient(
+  static folly::Future<std::shared_ptr<RSocketClient>> createResumedClient(
       std::unique_ptr<ConnectionFactory>,
       SetupParameters setupParameters,
       std::shared_ptr<ResumeManager> resumeManager,

--- a/rsocket/RSocketClient.cpp
+++ b/rsocket/RSocketClient.cpp
@@ -6,6 +6,7 @@
 #include "rsocket/RSocketStats.h"
 #include "rsocket/framing/FrameTransport.h"
 #include "rsocket/framing/FramedDuplexConnection.h"
+#include "rsocket/internal/ClientResumeStatusCallback.h"
 #include "rsocket/internal/FollyKeepaliveTimer.h"
 #include "rsocket/internal/RSocketConnectionManager.h"
 
@@ -13,97 +14,139 @@ using namespace folly;
 
 namespace rsocket {
 
-RSocketClient::RSocketClient(
-    std::unique_ptr<ConnectionFactory> connectionFactory)
-    : connectionFactory_(std::move(connectionFactory)),
-      connectionManager_(std::make_unique<RSocketConnectionManager>()) {
-  VLOG(1) << "Constructing RSocketClient";
-}
-
 RSocketClient::~RSocketClient() {
-  VLOG(1) << "Destroying RSocketClient";
+  VLOG(4) << "RSocketClient destroyed ..";
 }
 
-folly::Future<std::unique_ptr<RSocketRequester>> RSocketClient::connect(
+std::shared_ptr<RSocketRequester> RSocketClient::getRequester() const {
+  return requester_;
+}
+
+RSocketClient::RSocketClient(
+    std::unique_ptr<ConnectionFactory> connectionFactory,
     SetupParameters setupParameters,
     std::shared_ptr<RSocketResponder> responder,
     std::unique_ptr<KeepaliveTimer> keepaliveTimer,
     std::shared_ptr<RSocketStats> stats,
-    std::shared_ptr<RSocketNetworkStats> networkStats) {
+    std::shared_ptr<RSocketNetworkStats> networkStats,
+    std::shared_ptr<ResumeManager> resumeManager,
+    std::shared_ptr<ColdResumeHandler> coldResumeHandler,
+    OnRSocketResume)
+    : connectionFactory_(std::move(connectionFactory)),
+      connectionManager_(std::make_unique<RSocketConnectionManager>()),
+      setupParameters_(std::move(setupParameters)),
+      responder_(std::move(responder)),
+      keepaliveTimer_(std::move(keepaliveTimer)),
+      stats_(stats),
+      networkStats_(networkStats),
+      resumeManager_(resumeManager),
+      coldResumeHandler_(coldResumeHandler) {}
+
+folly::Future<folly::Unit> RSocketClient::connect() {
   VLOG(2) << "Starting connection";
 
-  folly::Promise<std::unique_ptr<RSocketRequester>> promise;
+  folly::Promise<folly::Unit> promise;
   auto future = promise.getFuture();
 
-  connectionFactory_->connect([
-    this,
-    setupParameters = std::move(setupParameters),
-    responder = std::move(responder),
-    keepaliveTimer = std::move(keepaliveTimer),
-    stats = std::move(stats),
-    networkStats = std::move(networkStats),
-    promise = std::move(promise)](
+  connectionFactory_->connect([ this, promise = std::move(promise) ](
       std::unique_ptr<DuplexConnection> connection,
-      folly::EventBase& eventBase) mutable {
+      folly::EventBase & eventBase) mutable {
     VLOG(3) << "onConnect received DuplexConnection";
-
-    auto rsocket = fromConnection(
-        std::move(connection),
-        eventBase,
-        std::move(setupParameters),
-        std::move(responder),
-        std::move(keepaliveTimer),
-        std::move(stats),
-        std::move(networkStats));
-    promise.setValue(std::move(rsocket));
+    evb_ = &eventBase;
+    createState(eventBase);
+    std::unique_ptr<DuplexConnection> framedConnection;
+    if (connection->isFramed()) {
+      framedConnection = std::move(connection);
+    } else {
+      framedConnection = std::make_unique<FramedDuplexConnection>(
+          std::move(connection), setupParameters_.protocolVersion);
+    }
+    stateMachine_->connectClientSendSetup(
+        std::move(framedConnection), std::move(setupParameters_));
+    promise.setValue(folly::Unit());
   });
 
   return future;
 }
 
-std::unique_ptr<RSocketRequester> RSocketClient::fromConnection(
-    std::unique_ptr<DuplexConnection> connection,
-    folly::EventBase& eventBase,
-    SetupParameters setupParameters,
-    std::shared_ptr<RSocketResponder> responder,
-    std::unique_ptr<KeepaliveTimer> keepaliveTimer,
-    std::shared_ptr<RSocketStats> stats,
-    std::shared_ptr<RSocketNetworkStats> networkStats) {
+folly::Future<folly::Unit> RSocketClient::resume() {
+  VLOG(2) << "Resuming connection";
+
+  // TODO: CHECK whether the underlying transport is closed before attempting
+  // resumption.
+  //
+  folly::Promise<folly::Unit> promise;
+  auto future = promise.getFuture();
+
+  connectionFactory_->connect([ this, promise = std::move(promise) ](
+      std::unique_ptr<DuplexConnection> connection,
+      folly::EventBase & eventBase) mutable {
+
+    CHECK(
+        !evb_ /* cold-resumption */ ||
+        evb_ == &eventBase /* warm-resumption */);
+
+    class ResumeCallback : public ClientResumeStatusCallback {
+     public:
+      explicit ResumeCallback(folly::Promise<folly::Unit> promise)
+          : promise_(std::move(promise)) {}
+
+      void onResumeOk() noexcept override {
+        promise_.setValue(folly::Unit());
+      }
+
+      void onResumeError(folly::exception_wrapper ex) noexcept override {
+        promise_.setException(ex);
+      }
+
+      folly::Promise<folly::Unit> promise_;
+    };
+
+    auto resumeCallback = std::make_unique<ResumeCallback>(std::move(promise));
+    std::unique_ptr<DuplexConnection> framedConnection;
+    if (connection->isFramed()) {
+      framedConnection = std::move(connection);
+    } else {
+      framedConnection = std::make_unique<FramedDuplexConnection>(
+          std::move(connection), setupParameters_.protocolVersion);
+    }
+    auto frameTransport =
+        yarpl::make_ref<FrameTransport>(std::move(framedConnection));
+
+    if (!stateMachine_) {
+      createState(eventBase);
+    }
+
+    stateMachine_->tryClientResume(
+        setupParameters_.token,
+        std::move(frameTransport),
+        std::move(resumeCallback));
+    promise.setValue(folly::Unit());
+
+  });
+
+  return future;
+}
+
+void RSocketClient::createState(folly::EventBase& eventBase) {
   CHECK(eventBase.isInEventBaseThread());
 
-  if (!responder) {
-    responder = std::make_shared<RSocketResponder>();
-  }
+  // Creation of state is permitted only once for each RSocketClient.
+  // When evb is removed from RSocketStateMachine, the state can be
+  // created in constructor
+  CHECK(!stateMachine_);
 
-  if (!keepaliveTimer) {
-    keepaliveTimer = std::make_unique<FollyKeepaliveTimer>(
-        eventBase, std::chrono::milliseconds(5000));
-  }
-
-  if (!stats) {
-    stats = RSocketStats::noop();
-  }
-
-  auto rs = std::make_shared<RSocketStateMachine>(
+  stateMachine_ = std::make_shared<RSocketStateMachine>(
       eventBase,
-      std::move(responder),
-      std::move(keepaliveTimer),
+      responder_,
+      std::move(keepaliveTimer_),
       ReactiveSocketMode::CLIENT,
-      std::move(stats),
-      std::move(networkStats));
+      stats_,
+      networkStats_);
 
-  connectionManager_->manageConnection(rs, eventBase);
+  requester_ = std::make_shared<RSocketRequester>(stateMachine_, eventBase);
 
-  std::unique_ptr<DuplexConnection> framedConnection;
-  if (connection->isFramed()) {
-    framedConnection = std::move(connection);
-  } else {
-    framedConnection = std::make_unique<FramedDuplexConnection>(
-        std::move(connection), setupParameters.protocolVersion);
-  }
-
-  rs->connectClientSendSetup(std::move(framedConnection), std::move(setupParameters));
-  return std::make_unique<RSocketRequester>(std::move(rs), eventBase);
+  connectionManager_->manageConnection(stateMachine_, eventBase);
 }
 
 } // namespace rsocket

--- a/rsocket/RSocketClient.cpp
+++ b/rsocket/RSocketClient.cpp
@@ -63,7 +63,7 @@ folly::Future<folly::Unit> RSocketClient::connect() {
     }
     stateMachine_->connectClientSendSetup(
         std::move(framedConnection), std::move(setupParameters_));
-    promise.setValue(folly::Unit());
+    promise.setValue();
   });
 
   return future;
@@ -92,13 +92,13 @@ folly::Future<folly::Unit> RSocketClient::resume() {
           : promise_(std::move(promise)) {}
 
       void onResumeOk() noexcept override {
-        promise_.setValue(folly::Unit());
+        promise_.setValue();
       }
 
       void onResumeError(folly::exception_wrapper ex) noexcept override {
         promise_.setException(ex);
       }
-
+     private:
       folly::Promise<folly::Unit> promise_;
     };
 

--- a/rsocket/RSocketClient.h
+++ b/rsocket/RSocketClient.h
@@ -4,66 +4,83 @@
 
 #include <folly/futures/Future.h>
 
-#include "rsocket/RSocketRequester.h"
+#include "rsocket/ColdResumeHandler.h"
 #include "rsocket/ConnectionFactory.h"
 #include "rsocket/RSocketNetworkStats.h"
 #include "rsocket/RSocketParameters.h"
+#include "rsocket/RSocketRequester.h"
 #include "rsocket/RSocketStats.h"
+#include "rsocket/ResumeManager.h"
 
 namespace rsocket {
 
+class RSocket;
 class RSocketConnectionManager;
 
 /**
- * API for connecting to an RSocket server. Returned from RSocket::createClient.
- *
+ * API for connecting to an RSocket server. Created with RSocket class.
  * This connects using a transport from the provided ConnectionFactory.
  */
 class RSocketClient {
  public:
-  explicit RSocketClient(std::unique_ptr<ConnectionFactory>);
-  ~RSocketClient(); // implementing for logging right now
+  ~RSocketClient();
 
   RSocketClient(const RSocketClient&) = delete; // copy
-  RSocketClient(RSocketClient&&) = delete; // move
+  RSocketClient(RSocketClient&&) = default; // move
   RSocketClient& operator=(const RSocketClient&) = delete; // copy
-  RSocketClient& operator=(RSocketClient&&) = delete; // move
+  RSocketClient& operator=(RSocketClient&&) = default; // move
 
-  /*
-   * Connect asynchronously and return a Future which will deliver the RSocket
-   *
-   * Each time this is called:
-   * - a new connection is created using a ConnectionFactory
-   *
-   * The returned RSocketRequester is retained by the RSocketClient instance
-   * so that it lives for the life of RSocketClient, as opposed to the scope
-   * of the Future (such as when used with Future.then(...)).
-   *
-   * To destruct a single RSocketRequester sooner than the RSocketClient
-   * call RSocketRequester.close().
-   */
-  folly::Future<std::unique_ptr<RSocketRequester>> connect(
-      SetupParameters setupParameters = SetupParameters(),
-      std::shared_ptr<RSocketResponder> responder = std::shared_ptr<RSocketResponder>(),
-      std::unique_ptr<KeepaliveTimer> keepaliveTimer = std::unique_ptr<KeepaliveTimer>(),
-      std::shared_ptr<RSocketStats> stats = std::shared_ptr<RSocketStats>(),
-      std::shared_ptr<RSocketNetworkStats> networkStats = std::shared_ptr<RSocketNetworkStats>());
+  friend class RSocket;
 
-  // TODO implement version supporting fast start (send SETUP and requests
-  // without waiting for transport to connect and ack)
-  //  std::shared_ptr<RSocketRequester> fastConnect();
+  // Returns the RSocketRequester associated with the RSocketClient.
+  std::shared_ptr<RSocketRequester> getRequester() const;
 
-  std::unique_ptr<RSocketRequester> fromConnection(
-      std::unique_ptr<DuplexConnection> connection,
-      folly::EventBase& eventBase,
-      SetupParameters setupParameters = SetupParameters(),
-      std::shared_ptr<RSocketResponder> responder = std::shared_ptr<RSocketResponder>(),
-      std::unique_ptr<KeepaliveTimer> keepaliveTimer = std::unique_ptr<KeepaliveTimer>(),
-      std::shared_ptr<RSocketStats> stats = std::shared_ptr<RSocketStats>(),
-      std::shared_ptr<RSocketNetworkStats> networkStats = std::shared_ptr<RSocketNetworkStats>());
+  // Resumes the connection.  If a stateMachine already exists,
+  // it provides a warm-resumption.  If a stateMachine does not exist,
+  // it does a cold-resumption.
+  folly::Future<folly::Unit> resume();
 
  private:
+  // Private constructor.  RSocket class should be used to create instances
+  // of RSocketClient.
+  RSocketClient(
+      std::unique_ptr<ConnectionFactory>,
+      SetupParameters setupParameters = SetupParameters(),
+      std::shared_ptr<RSocketResponder> responder =
+          std::make_shared<RSocketResponder>(),
+      std::unique_ptr<KeepaliveTimer> keepaliveTimer =
+          std::unique_ptr<KeepaliveTimer>(),
+      std::shared_ptr<RSocketStats> stats = RSocketStats::noop(),
+      std::shared_ptr<RSocketNetworkStats> networkStats =
+          std::shared_ptr<RSocketNetworkStats>(),
+      std::shared_ptr<ResumeManager> resumeManager =
+          std::shared_ptr<ResumeManager>(),
+      std::shared_ptr<ColdResumeHandler> coldResumeHandler =
+          std::shared_ptr<ColdResumeHandler>(),
+      OnRSocketResume onRSocketResume =
+          [](std::vector<StreamId>, std::vector<StreamId>) { return false; });
+
+  // Connects to the remote side and creates state.
+  folly::Future<folly::Unit> connect();
+
+  // Creates RSocketStateMachine and RSocketRequester
+  void createState(folly::EventBase& eventBase);
+
   std::unique_ptr<ConnectionFactory> connectionFactory_;
   std::unique_ptr<RSocketConnectionManager> connectionManager_;
+  SetupParameters setupParameters_;
+  std::shared_ptr<RSocketResponder> responder_;
+  std::unique_ptr<KeepaliveTimer> keepaliveTimer_;
+  std::shared_ptr<RSocketStats> stats_;
+  std::shared_ptr<RSocketNetworkStats> networkStats_;
+  std::shared_ptr<ResumeManager> resumeManager_;
+  std::shared_ptr<ColdResumeHandler> coldResumeHandler_;
+
+  std::shared_ptr<RSocketStateMachine> stateMachine_;
+  std::shared_ptr<RSocketRequester> requester_;
+
+  // Remember the evb on which the client was created.  Ensure warme-resume()
+  // operations are done on the same evb.
+  folly::EventBase* evb_;
 };
 }

--- a/rsocket/RSocketClient.h
+++ b/rsocket/RSocketClient.h
@@ -37,7 +37,9 @@ class RSocketClient {
 
   // Resumes the connection.  If a stateMachine already exists,
   // it provides a warm-resumption.  If a stateMachine does not exist,
-  // it does a cold-resumption.
+  // it does a cold-resumption.  The returned future resolves on successful
+  // resumption.  Else either a ConnectionException or a ResumptionException
+  // is raised.
   folly::Future<folly::Unit> resume();
 
  private:

--- a/rsocket/RSocketParameters.h
+++ b/rsocket/RSocketParameters.h
@@ -10,6 +10,9 @@
 
 namespace rsocket {
 
+using OnRSocketResume =
+    std::function<bool(std::vector<StreamId>, std::vector<StreamId>)>;
+
 class RSocketParameters {
  public:
   RSocketParameters(bool _resumable, ProtocolVersion _protocolVersion)

--- a/rsocket/RSocketServer.h
+++ b/rsocket/RSocketServer.h
@@ -18,7 +18,6 @@ namespace rsocket {
 class RSocketConnectionManager;
 
 using OnRSocketSetup = std::function<void(RSocketSetup&)>;
-using OnRSocketResume = std::function<void(ResumeParameters&)>;
 
 /**
  * API for starting an RSocket server. Returned from RSocket::createServer.

--- a/rsocket/ResumeManager.h
+++ b/rsocket/ResumeManager.h
@@ -1,0 +1,8 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+namespace rsocket {
+
+class ResumeManager {};
+}

--- a/rsocket/internal/ClientResumeStatusCallback.h
+++ b/rsocket/internal/ClientResumeStatusCallback.h
@@ -4,22 +4,9 @@
 
 #include <folly/ExceptionWrapper.h>
 
+#include "rsocket/Exception.h"
+
 namespace rsocket {
-
-// Thrown when an ERROR frame with CONNECTION_ERROR is received during
-// resuming operation.
-// TODO: in this case we should get the DuplexConnection back to
-// create a new instance of RS with it
-class ResumptionException : public std::runtime_error {
-  using std::runtime_error::runtime_error;
-};
-
-// Thrown when the resume operation was interrupted due to network
-// the application code may try to resume again.
-class ConnectionException : public std::runtime_error {
-  using std::runtime_error::runtime_error;
-};
-
 class ClientResumeStatusCallback {
  public:
   virtual ~ClientResumeStatusCallback() = default;

--- a/rsocket/internal/ClientResumeStatusCallback.h
+++ b/rsocket/internal/ClientResumeStatusCallback.h
@@ -6,6 +6,20 @@
 
 namespace rsocket {
 
+// Thrown when an ERROR frame with CONNECTION_ERROR is received during
+// resuming operation.
+// TODO: in this case we should get the DuplexConnection back to
+// create a new instance of RS with it
+class ResumptionException : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+// Thrown when the resume operation was interrupted due to network
+// the application code may try to resume again.
+class ConnectionException : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
 class ClientResumeStatusCallback {
  public:
   virtual ~ClientResumeStatusCallback() = default;
@@ -13,15 +27,8 @@ class ClientResumeStatusCallback {
   // Called when a RESUME_OK frame is received during resuming operation
   virtual void onResumeOk() noexcept = 0;
 
-  // Called when an ERROR frame with CONNECTION_ERROR is received during
-  // resuming operation
-  // TODO: in this case we should get the DuplexConnection back to
-  // create a new instance of RS with it
+  // The exception could be one of ResumptionException or ConnectionException
   virtual void onResumeError(folly::exception_wrapper ex) noexcept = 0;
-
-  // Called when the resume operation was interrupted due to network
-  // the application code may try to resume again.
-  virtual void onConnectionError(folly::exception_wrapper ex) noexcept = 0;
 };
 
 } // reactivesocket

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -53,7 +53,7 @@ RSocketStateMachine::~RSocketStateMachine() {
   // automatons destroyed on different threads can be the last ones referencing
   // this.
 
-  VLOG(6) << "RSocketStateMachine";
+  VLOG(6) << "~RSocketStateMachine";
   // We rely on SubscriptionPtr and SubscriberPtr to dispatch appropriate
   // terminal signals.
   DCHECK(!resumeCallback_);
@@ -170,7 +170,7 @@ void RSocketStateMachine::close(
 
   if (resumeCallback_) {
     resumeCallback_->onResumeError(
-        std::runtime_error(ex ? ex.what().c_str() : "RS closing"));
+        ConnectionException(ex ? ex.what().c_str() : "RS closing"));
     resumeCallback_.reset();
   }
 
@@ -197,8 +197,8 @@ void RSocketStateMachine::closeFrameTransport(
   }
 
   if (resumeCallback_) {
-    resumeCallback_->onConnectionError(
-        std::runtime_error(ex ? ex.what().c_str() : "connection closing"));
+    resumeCallback_->onResumeError(
+        ConnectionException(ex ? ex.what().c_str() : "connection closing"));
     resumeCallback_.reset();
   }
 
@@ -491,7 +491,7 @@ void RSocketStateMachine::handleConnectionFrame(
            frame.errorCode_ == ErrorCode::REJECTED_RESUME) &&
           resumeCallback_) {
         resumeCallback_->onResumeError(
-            std::runtime_error(frame.payload_.moveDataToString()));
+            ResumptionException(frame.payload_.moveDataToString()));
         resumeCallback_.reset();
         // fall through
       }

--- a/tck-test/client.cpp
+++ b/tck-test/client.cpp
@@ -40,18 +40,9 @@ int main(int argc, char* argv[]) {
 
   LOG(INFO) << "Creating client to connect to " << address.describe();
 
-  std::shared_ptr<RSocketClient> client;
-
-  RSocket::createConnectedClient(
-      std::make_unique<TcpConnectionFactory>(std::move(address)))
-      .then([&client](std::shared_ptr<RSocketClient> cl) mutable {
-        LOG(INFO) << "Connected";
-        client = std::move(cl);
-      })
-      .onError([](folly::exception_wrapper ex) {
-        LOG(INFO) << "Exception received " << ex;
-      })
-      .get();
+  auto client = RSocket::createConnectedClient(
+                    std::make_unique<TcpConnectionFactory>(std::move(address)))
+                    .get();
 
   std::shared_ptr<RSocketRequester> rs = client->getRequester();
 

--- a/tck-test/client.cpp
+++ b/tck-test/client.cpp
@@ -40,11 +40,11 @@ int main(int argc, char* argv[]) {
 
   LOG(INFO) << "Creating client to connect to " << address.describe();
 
-  std::unique_ptr<RSocketClient> client;
+  std::shared_ptr<RSocketClient> client;
 
   RSocket::createConnectedClient(
       std::make_unique<TcpConnectionFactory>(std::move(address)))
-      .then([&client](std::unique_ptr<RSocketClient> cl) mutable {
+      .then([&client](std::shared_ptr<RSocketClient> cl) mutable {
         LOG(INFO) << "Connected";
         client = std::move(cl);
       })

--- a/test/RSocketClientServerTest.cpp
+++ b/test/RSocketClientServerTest.cpp
@@ -14,7 +14,7 @@ TEST(RSocketClientServer, StartAndShutdown) {
 TEST(RSocketClientServer, ConnectOne) {
   auto server = makeServer(std::make_shared<HelloStreamRequestHandler>());
   auto client = makeClient(*server->listeningPort());
-  auto requester = client->connect().get();
+  auto requester = client->getRequester();
 }
 
 TEST(RSocketClientServer, ConnectManySync) {
@@ -22,23 +22,16 @@ TEST(RSocketClientServer, ConnectManySync) {
 
   for (size_t i = 0; i < 100; ++i) {
     auto client = makeClient(*server->listeningPort());
-    auto requester = client->connect().get();
+    auto requester = client->getRequester();
   }
 }
 
 TEST(RSocketClientServer, ConnectManyAsync) {
   auto server = makeServer(std::make_shared<HelloStreamRequestHandler>());
 
-  std::vector<std::unique_ptr<RSocketClient>> clients;
-  std::vector<folly::Future<folly::Unit>> futures;
-
   for (size_t i = 0; i < 100; ++i) {
     auto client = makeClient(*server->listeningPort());
-    auto requester = client->connect();
-
-    clients.push_back(std::move(client));
-    futures.push_back(requester.unit());
+    auto requester = client->getRequester();
   }
 
-  folly::collectAll(futures).get();
 }

--- a/test/RSocketTests.h
+++ b/test/RSocketTests.h
@@ -33,8 +33,9 @@ inline std::unique_ptr<RSocketServer> makeServer(
 inline std::unique_ptr<RSocketClient> makeClient(uint16_t port) {
   folly::SocketAddress address;
   address.setFromHostPort("localhost", port);
-  return RSocket::createClient(
-      std::make_unique<TcpConnectionFactory>(std::move(address)));
+  return RSocket::createConnectedClient(
+             std::make_unique<TcpConnectionFactory>(std::move(address)))
+      .get();
 }
 }
 }

--- a/test/RSocketTests.h
+++ b/test/RSocketTests.h
@@ -30,7 +30,7 @@ inline std::unique_ptr<RSocketServer> makeServer(
   return rs;
 }
 
-inline std::unique_ptr<RSocketClient> makeClient(uint16_t port) {
+inline std::shared_ptr<RSocketClient> makeClient(uint16_t port) {
   folly::SocketAddress address;
   address.setFromHostPort("localhost", port);
   return RSocket::createConnectedClient(

--- a/test/RequestChannelTest.cpp
+++ b/test/RequestChannelTest.cpp
@@ -38,7 +38,7 @@ class TestHandlerHello : public rsocket::RSocketResponder {
 TEST(RequestChannelTest, Hello) {
   auto server = makeServer(std::make_shared<TestHandlerHello>());
   auto client = makeClient(*server->listeningPort());
-  auto requester = client->connect().get();
+  auto requester = client->getRequester();
 
   auto ts = TestSubscriber<std::string>::create();
   requester

--- a/test/RequestResponseTest.cpp
+++ b/test/RequestResponseTest.cpp
@@ -34,7 +34,7 @@ class TestHandlerHello : public rsocket::RSocketResponder {
 TEST(RequestResponseTest, Hello) {
   auto server = makeServer(std::make_shared<TestHandlerHello>());
   auto client = makeClient(*server->listeningPort());
-  auto requester = client->connect().get();
+  auto requester = client->getRequester();
 
   auto to = SingleTestObserver<std::string>::create();
   requester->requestResponse(Payload("Jane"))
@@ -100,7 +100,7 @@ TEST(RequestResponseTest, Cancel) {
   auto server =
       makeServer(std::make_shared<TestHandlerCancel>(onCancel, onSubscribe));
   auto client = makeClient(*server->listeningPort());
-  auto requester = client->connect().get();
+  auto requester = client->getRequester();
 
   auto to = SingleTestObserver<std::string>::create();
   requester->requestResponse(Payload("Jane"))

--- a/test/RequestStreamTest.cpp
+++ b/test/RequestStreamTest.cpp
@@ -34,7 +34,7 @@ class TestHandlerSync : public rsocket::RSocketResponder {
 TEST(RequestStreamTest, HelloSync) {
   auto server = makeServer(std::make_shared<TestHandlerSync>());
   auto client = makeClient(*server->listeningPort());
-  auto requester = client->connect().get();
+  auto requester = client->getRequester();
   auto ts = TestSubscriber<std::string>::create();
   requester->requestStream(Payload("Bob"))
       ->map([](auto p) { return p.moveDataToString(); })
@@ -78,7 +78,7 @@ class TestHandlerAsync : public rsocket::RSocketResponder {
 TEST(RequestStreamTest, HelloAsync) {
   auto server = makeServer(std::make_shared<TestHandlerAsync>());
   auto client = makeClient(*server->listeningPort());
-  auto requester = client->connect().get();
+  auto requester = client->getRequester();
   auto ts = TestSubscriber<std::string>::create();
   requester->requestStream(Payload("Bob"))
       ->map([](auto p) { return p.moveDataToString(); })


### PR DESCRIPTION
Changing the RSocketClient API to be more intuitive.   

The only way to create clients is using RSocket class.  The clients can be created in two modes - regular-connected-client or cold-resumed-client.  The API forces the users to pass the appropriate parameters for both the constructors.  The only public method which RSocketClient exposes is `resume()`.  `client->resume()` would be a warm-resumption attempt.  All the methods return futures.

```
RSocket::createConnectedClient(...)
      .then([&client](std::unique_ptr<RSocketClient> cl) mutable {
        client = std::move(cl);  // store a reference to the client
        client->getRequester()
            ->requestStream(Payload("BM_Stream"))
            ->subscribe(...);
      });
```

`RSocket::createResumedClient()` has a similar usage.

TODO:
- Add more convenience constructors in RSocket to cover common cases.   All constructors would return `Future<RSocketClient>` and they would create a fresh-connected-client or a cold-resumed-client.
- Resumption part in this PR is only about the API.  It will updated and tested once the server side changes are also made.
- Error propagation from the ConnectionFactory to the user has to be implemented.  This would require probably a change in the ConnectionFactory::connect() method and RSocketClient::connect() method.