### PR TITLE
Use glog's DCHECK in Flowable.h, fix release build

### DIFF
--- a/yarpl/CMakeLists.txt
+++ b/yarpl/CMakeLists.txt
@@ -29,7 +29,6 @@ endif()
 # Using NDEBUG in Release builds.
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG")
 
-# Find glog and libraries specifically.
 find_path(GLOG_INCLUDE_DIR glog/logging.h)
 find_library(GLOG_LIBRARY glog)
 

--- a/yarpl/CMakeLists.txt
+++ b/yarpl/CMakeLists.txt
@@ -26,22 +26,17 @@ if(APPLE)
   add_compile_options("-fno-sanitize=address,undefined")
 endif()
 
-# Configuration for Debug build mode.
-#set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-
+# Using NDEBUG in Release builds.
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG")
 
-# Find glog and gflags libraries specifically
+# Find glog and libraries specifically.
 find_path(GLOG_INCLUDE_DIR glog/logging.h)
-
 find_library(GLOG_LIBRARY glog)
 
 message("glog include_dir <${GLOG_INCLUDE_DIR}> lib <${GLOG_LIBRARY}>")
 
 include_directories(SYSTEM ${GLOG_INCLUDE_DIR})
 include_directories(${CMAKE_SOURCE_DIR})
-
 
 # library source
 add_library(
@@ -97,7 +92,10 @@ target_include_directories(
         PUBLIC "${PROJECT_SOURCE_DIR}/src" # allow include paths such as "yarpl/flowable/FlowableRange.h"
         )
 
-target_link_libraries(yarpl folly)
+target_link_libraries(
+  yarpl
+  folly
+  ${GLOG_LIBRARY})
 
 # Executable for Experimenting
 add_executable(

--- a/yarpl/include/yarpl/flowable/Flowable.h
+++ b/yarpl/include/yarpl/flowable/Flowable.h
@@ -2,13 +2,14 @@
 
 #pragma once
 
-#include <cassert>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <utility>
+
+#include <glog/logging.h>
 
 #include "yarpl/Refcounted.h"
 #include "yarpl/Scheduler.h"
@@ -192,8 +193,7 @@ class Flowable : public virtual Refcounted {
 
     // Subscriber methods.
     void onSubscribe(Reference<Subscription>) override {
-      // Not actually expected to be called.
-      assert(false && "do not call this method!");
+      LOG(FATAL) << "Do not call this method";
     }
 
     void onNext(T value) override {
@@ -204,8 +204,8 @@ class Flowable : public virtual Refcounted {
       // we will set the flag first to save a potential call to lock.try_lock()
       // in the process method via cancel or request methods
       auto old = requested_.exchange(kCanceled, std::memory_order_relaxed);
-      assert(old != kCanceled && "calling onComplete or onError twice or on "
-          "canceled subscription");
+      DCHECK_NE(old, kCanceled) << "Calling onComplete or onError twice or on "
+                                << "canceled subscription";
 
       subscriber_->onComplete();
       // We should already be in process(); nothing more to do.
@@ -218,8 +218,8 @@ class Flowable : public virtual Refcounted {
       // we will set the flag first to save a potential call to lock.try_lock()
       // in the process method via cancel or request methods
       auto old = requested_.exchange(kCanceled, std::memory_order_relaxed);
-      assert(old != kCanceled && "calling onComplete or onError twice or on "
-          "canceled subscription");
+      DCHECK_NE(old, kCanceled) << "Calling onComplete or onError twice or on "
+                                << "canceled subscription";
 
       subscriber_->onError(error);
       // We should already be in process(); nothing more to do.


### PR DESCRIPTION
assert() generally causes "unused variable" errors because it gets completely
erased in optimized builds.  Switch to using DCHECK which won't cause a compiler
error (presumably because it does the equivalent of `(void)variable;`
internally).