### PR TITLE
Drop use of OSS macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,9 +95,6 @@ option(BUILD_BENCHMARKS "Build benchmarks" ON)
 
 enable_testing()
 
-# Add a OSS macro.  This is mainly to get gflags working with travis.
-add_definitions(-DOSS)
-
 include(ExternalProject)
 include(CTest)
 
@@ -366,9 +363,9 @@ add_executable(
   test/test_utils/MockRequestHandler.h
   test/test_utils/MockStats.h
   test/test_utils/Mocks.h
-  test/transport/TcpDuplexConnectionTest.cpp
+  test/transport/DuplexConnectionTest.cpp
   test/transport/DuplexConnectionTest.h
-  test/transport/DuplexConnectionTest.cpp)
+  test/transport/TcpDuplexConnectionTest.cpp)
 
 target_link_libraries(
   tests

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -1,18 +1,12 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-#include <folly/portability/GFlags.h>
-
+#include <folly/init/Init.h>
 #include <glog/logging.h>
-#include "gmock/gmock.h"
+#include <gmock/gmock.h>
 
 int main(int argc, char** argv) {
   FLAGS_logtostderr = true;
-  ::testing::InitGoogleMock(&argc, argv);
-#ifdef OSS
-  google::ParseCommandLineFlags(&argc, &argv, true);
-#else
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
-#endif
-  google::InitGoogleLogging(argv[0]);
+  testing::InitGoogleMock(&argc, argv);
+  folly::init(&argc, &argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
It was added so we could build older and newer versions of gflags (where the
namespaces differed between google:: and gflags::), but we don't need that if we
just stick with folly::init().