### PR TITLE
Documenting and testing SetupResumeAcceptor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,6 +361,7 @@ add_executable(
   test/handlers/HelloStreamRequestHandler.h
   test/internal/AllowanceSemaphoreTest.cpp
   test/internal/FollyKeepaliveTimerTest.cpp
+  test/internal/SetupResumeAcceptorTest.cpp
   test/test_utils/MockDuplexConnection.h
   test/test_utils/MockKeepaliveTimer.h
   test/test_utils/MockRequestHandler.h

--- a/rsocket/internal/SetupResumeAcceptor.h
+++ b/rsocket/internal/SetupResumeAcceptor.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <unordered_set>
 
+#include <folly/Function.h>
 #include <folly/futures/Future.h>
 
 #include "rsocket/RSocketParameters.h"
@@ -24,52 +25,56 @@ class DuplexConnection;
 class FrameSerializer;
 class FrameTransport;
 
-// This class allows to store duplex connection and wait until the first frame
-// is received. Then either onSetup or onResume is invoked.
+/// Acceptor of DuplexConnections that lets us decide whether the connection is
+/// trying to setup a new connection or resume an existing one.
+///
+/// An instance of this class must be tied to a specific thread, as the
+/// SetupResumeAcceptor::accept() entry point is not thread-safe.
 class SetupResumeAcceptor final {
  public:
   using OnSetup =
-      std::function<void(yarpl::Reference<FrameTransport>, SetupParameters)>;
+      folly::Function<void(yarpl::Reference<FrameTransport>, SetupParameters)>;
   using OnResume =
-      std::function<bool(yarpl::Reference<FrameTransport>, ResumeParameters)>;
+      folly::Function<bool(yarpl::Reference<FrameTransport>, ResumeParameters)>;
 
-  explicit SetupResumeAcceptor(
-      ProtocolVersion defaultProtocolVersion,
-      folly::EventBase* eventBase);
-
+  SetupResumeAcceptor(ProtocolVersion, folly::EventBase*);
   ~SetupResumeAcceptor();
 
-  void accept(
-      std::unique_ptr<DuplexConnection> connection,
-      OnSetup onSetup,
-      OnResume onResume);
+  /// Wait for and process the first frame on a DuplexConnection, calling the
+  /// appropriate callback when the frame is received.  Not thread-safe.
+  void accept(std::unique_ptr<DuplexConnection>, OnSetup, OnResume);
 
+  /// Close all open connections, and prevent new ones from being accepted.  Can
+  /// be called from any thread.
   folly::Future<folly::Unit> close();
 
-private:
+ private:
   friend class OneFrameProcessor;
 
   void processFrame(
-      yarpl::Reference<FrameTransport> transport,
-      std::unique_ptr<folly::IOBuf> frame,
-      OnSetup onSetup,
-      OnResume onResume);
+      yarpl::Reference<FrameTransport>,
+      std::unique_ptr<folly::IOBuf>,
+      OnSetup,
+      OnResume);
 
-  void closeAndRemoveConnection(
-      const yarpl::Reference<FrameTransport>& transport,
-      folly::exception_wrapper ex);
-  void removeConnection(const yarpl::Reference<FrameTransport>& transport);
+  /// Close and remove a FrameTransport from the set.
+  void close(yarpl::Reference<FrameTransport>, folly::exception_wrapper);
 
-  void closeAllConnections();
+  /// Remove a FrameTransport from the set.  Drop the attached OneFrameProcessor
+  /// if it has one.
+  void remove(const yarpl::Reference<FrameTransport>&);
 
-  std::shared_ptr<FrameSerializer> getOrAutodetectFrameSerializer(
-      const folly::IOBuf& firstFrame);
+  /// Close all open connections.
+  void closeAll();
+
+  /// Get the default FrameSerializer if one exists, otherwise try to autodetect
+  /// the correct FrameSerializer from the given frame.
+  std::shared_ptr<FrameSerializer> createSerializer(const folly::IOBuf&);
 
   std::unordered_set<yarpl::Reference<FrameTransport>> connections_;
   bool closed_{false};
 
-  std::shared_ptr<FrameSerializer> defaultFrameSerializer_;
+  std::shared_ptr<FrameSerializer> defaultSerializer_;
   folly::EventBase* eventBase_;
 };
-
-} // reactivesocket
+}

--- a/rsocket/transports/tcp/TcpDuplexConnection.cpp
+++ b/rsocket/transports/tcp/TcpDuplexConnection.cpp
@@ -192,10 +192,16 @@ class TcpOutputSubscriber
     tcpReaderWriter_->setOutputSubscription(nullptr);
   }
 
-  void onError(std::exception_ptr ex) noexcept override {
+  void onError(std::exception_ptr eptr) noexcept override {
     CHECK(tcpReaderWriter_);
     auto tcpReaderWriter = std::move(tcpReaderWriter_);
-    tcpReaderWriter->closeErr(folly::exception_wrapper(std::move(ex)));
+
+    try {
+      std::rethrow_exception(eptr);
+    } catch (const std::exception& exn) {
+      folly::exception_wrapper ew{eptr, exn};
+      tcpReaderWriter->closeErr(std::move(ew));
+    }
   }
 
  private:

--- a/test/framing/FrameTransportTest.cpp
+++ b/test/framing/FrameTransportTest.cpp
@@ -18,32 +18,15 @@ MATCHER_P(IOBufStringEq, s, "") {
   return folly::IOBufEqual()(*arg, *folly::IOBuf::copyBuffer(s));
 }
 
-/*
- * Make a MockDuplexConnection, and run an arbitrary lambda on the subscriber it
- * returns from getOutput().
- */
-template <class SubscriberFn>
-std::unique_ptr<StrictMock<MockDuplexConnection>> makeConnection(
-    SubscriberFn fn) {
-  auto connection = std::make_unique<StrictMock<MockDuplexConnection>>();
-
-  EXPECT_CALL(*connection, setInput_(_));
-  EXPECT_CALL(*connection, getOutput_()).WillOnce(Invoke([&] {
-    auto subscriber = yarpl::make_ref<
-        StrictMock<MockSubscriber<std::unique_ptr<folly::IOBuf>>>>();
-    fn(subscriber);
-    return subscriber;
-  }));
-
-  return connection;
-}
 }
 
 TEST(FrameTransport, Close) {
-  auto connection = makeConnection([](auto& subscriber) {
-    EXPECT_CALL(*subscriber, onSubscribe_(_));
-    EXPECT_CALL(*subscriber, onComplete_());
-  });
+  auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
+      [](auto) {},
+      [](auto output) {
+        EXPECT_CALL(*output, onSubscribe_(_));
+        EXPECT_CALL(*output, onComplete_());
+      });
 
   auto transport = yarpl::make_ref<FrameTransport>(std::move(connection));
   transport->setFrameProcessor(
@@ -52,10 +35,12 @@ TEST(FrameTransport, Close) {
 }
 
 TEST(FrameTransport, CloseWithError) {
-  auto connection = makeConnection([](auto& subscriber) {
-    EXPECT_CALL(*subscriber, onSubscribe_(_));
-    EXPECT_CALL(*subscriber, onError_(_));
-  });
+  auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
+      [](auto) {},
+      [](auto output) {
+        EXPECT_CALL(*output, onSubscribe_(_));
+        EXPECT_CALL(*output, onError_(_));
+      });
 
   auto transport = yarpl::make_ref<FrameTransport>(std::move(connection));
   transport->setFrameProcessor(
@@ -64,14 +49,16 @@ TEST(FrameTransport, CloseWithError) {
 }
 
 TEST(FrameTransport, SimpleEnqueue) {
-  auto connection = makeConnection([](auto& subscriber) {
-    EXPECT_CALL(*subscriber, onSubscribe_(_));
+  auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
+      [](auto) {},
+      [](auto output) {
+        EXPECT_CALL(*output, onSubscribe_(_));
 
-    EXPECT_CALL(*subscriber, onNext_(IOBufStringEq("Hello")));
-    EXPECT_CALL(*subscriber, onNext_(IOBufStringEq("World")));
+        EXPECT_CALL(*output, onNext_(IOBufStringEq("Hello")));
+        EXPECT_CALL(*output, onNext_(IOBufStringEq("World")));
 
-    EXPECT_CALL(*subscriber, onComplete_());
-  });
+        EXPECT_CALL(*output, onComplete_());
+      });
 
   auto transport = yarpl::make_ref<FrameTransport>(std::move(connection));
 
@@ -84,14 +71,16 @@ TEST(FrameTransport, SimpleEnqueue) {
 }
 
 TEST(FrameTransport, SimpleNoQueue) {
-  auto connection = makeConnection([](auto& subscriber) {
-    EXPECT_CALL(*subscriber, onSubscribe_(_));
+  auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
+      [](auto) {},
+      [](auto output) {
+        EXPECT_CALL(*output, onSubscribe_(_));
 
-    EXPECT_CALL(*subscriber, onNext_(IOBufStringEq("Hello")));
-    EXPECT_CALL(*subscriber, onNext_(IOBufStringEq("World")));
+        EXPECT_CALL(*output, onNext_(IOBufStringEq("Hello")));
+        EXPECT_CALL(*output, onNext_(IOBufStringEq("World")));
 
-    EXPECT_CALL(*subscriber, onComplete_());
-  });
+        EXPECT_CALL(*output, onComplete_());
+      });
 
   auto transport = yarpl::make_ref<FrameTransport>(std::move(connection));
 
@@ -105,19 +94,19 @@ TEST(FrameTransport, SimpleNoQueue) {
 }
 
 TEST(FrameTransport, InputSendsError) {
-  auto connection = makeConnection([](auto& subscriber) {
-    EXPECT_CALL(*subscriber, onSubscribe_(_));
-    EXPECT_CALL(*subscriber, onComplete_());
-  });
+  auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
+      [](auto input) {
+        auto subscription = yarpl::make_ref<StrictMock<MockSubscription>>();
+        EXPECT_CALL(*subscription, request_(_));
+        EXPECT_CALL(*subscription, cancel_());
 
-  ON_CALL(*connection, setInput_(_)).WillByDefault(Invoke([](auto subscriber) {
-    auto subscription = yarpl::make_ref<StrictMock<MockSubscription>>();
-    EXPECT_CALL(*subscription, request_(_));
-    EXPECT_CALL(*subscription, cancel_());
-
-    subscriber->onSubscribe(std::move(subscription));
-    subscriber->onError(std::make_exception_ptr(std::runtime_error("Oops")));
-  }));
+        input->onSubscribe(std::move(subscription));
+        input->onError(std::make_exception_ptr(std::runtime_error("Oops")));
+      },
+      [](auto output) {
+        EXPECT_CALL(*output, onSubscribe_(_));
+        EXPECT_CALL(*output, onComplete_());
+      });
 
   auto transport = yarpl::make_ref<FrameTransport>(std::move(connection));
 

--- a/test/internal/SetupResumeAcceptorTest.cpp
+++ b/test/internal/SetupResumeAcceptorTest.cpp
@@ -1,0 +1,284 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <gtest/gtest.h>
+
+#include <folly/io/async/EventBase.h>
+
+#include "rsocket/framing/FrameTransport.h"
+#include "rsocket/internal/SetupResumeAcceptor.h"
+#include "test/test_utils/MockDuplexConnection.h"
+#include "test/test_utils/MockFrameProcessor.h"
+#include "test/test_utils/Mocks.h"
+
+using namespace rsocket;
+using namespace testing;
+
+namespace {
+
+/*
+ * Make a legitimate-looking SETUP frame.
+ */
+Frame_SETUP makeSetup() {
+  Frame_SETUP frame;
+  frame.header_ = FrameHeader{FrameType::SETUP, FrameFlags::EMPTY, 0};
+  frame.versionMajor_ = 1;
+  frame.versionMinor_ = 0;
+  frame.keepaliveTime_ = Frame_SETUP::kMaxKeepaliveTime;
+  frame.maxLifetime_ = Frame_SETUP::kMaxLifetime;
+  frame.token_ = ResumeIdentificationToken::generateNew();
+  frame.metadataMimeType_ = "application/olive+oil";
+  frame.dataMimeType_ = "json/vorhees";
+  frame.payload_ = Payload("Test SETUP data", "Test SETUP metadata");
+  return frame;
+}
+
+/*
+ * Make a legitimate-looking RESUME frame.
+ */
+Frame_RESUME makeResume() {
+  Frame_RESUME frame;
+  frame.header_ = FrameHeader{FrameType::RESUME, FrameFlags::EMPTY, 0};
+  frame.versionMajor_ = 1;
+  frame.versionMinor_ = 0;
+  frame.token_ = ResumeIdentificationToken::generateNew();
+  frame.lastReceivedServerPosition_ = 500;
+  frame.clientPosition_ = 300;
+  return frame;
+}
+
+void setupFail(yarpl::Reference<FrameTransport> transport, SetupParameters) {
+  transport->close();
+  FAIL() << "setupFail() was called";
+}
+
+bool resumeFail(yarpl::Reference<FrameTransport> transport, ResumeParameters) {
+  transport->close();
+  ADD_FAILURE() << "resumeFail() was called";
+  return false;
+}
+}
+
+TEST(SetupResumeAcceptor, ImmediateDtor) {
+  folly::EventBase evb;
+  SetupResumeAcceptor acceptor1{ProtocolVersion::Latest, &evb};
+  SetupResumeAcceptor acceptor2{ProtocolVersion::Unknown, &evb};
+}
+
+TEST(SetupResumeAcceptor, ImmediateClose) {
+  folly::EventBase evb;
+  SetupResumeAcceptor acceptor1{ProtocolVersion::Latest, &evb};
+  SetupResumeAcceptor acceptor2{ProtocolVersion::Unknown, &evb};
+  acceptor1.close().get();
+  acceptor2.close().get();
+}
+
+
+TEST(SetupResumeAcceptor, EarlyComplete) {
+  folly::EventBase evb;
+  SetupResumeAcceptor acceptor{ProtocolVersion::Latest, &evb};
+
+  auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
+      [](auto input) {
+        input->onComplete();
+      },
+      [](auto output) {
+        EXPECT_CALL(*output, onSubscribe_(_));
+        EXPECT_CALL(*output, onComplete_());
+      });
+
+  acceptor.accept(std::move(connection), setupFail, resumeFail);
+
+  evb.loop();
+}
+
+TEST(SetupResumeAcceptor, EarlyError) {
+  folly::EventBase evb;
+  SetupResumeAcceptor acceptor{ProtocolVersion::Latest, &evb};
+
+  auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
+      [](auto input) {
+        input->onError(std::make_exception_ptr(std::runtime_error("Whoops")));
+      },
+      [](auto output) {
+        EXPECT_CALL(*output, onSubscribe_(_));
+        EXPECT_CALL(*output, onError_(_));
+      });
+
+  acceptor.accept(std::move(connection), setupFail, resumeFail);
+
+  evb.loop();
+}
+
+TEST(SetupResumeAcceptor, SingleSetup) {
+  folly::EventBase evb;
+  SetupResumeAcceptor acceptor{ProtocolVersion::Latest, &evb};
+
+  auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
+      [](auto input) {
+        auto serializer = FrameSerializer::createCurrentVersion();
+        input->onNext(serializer->serializeOut(makeSetup()));
+      },
+      [](auto output) {
+        EXPECT_CALL(*output, onSubscribe_(_));
+        EXPECT_CALL(*output, onComplete_());
+      });
+
+  bool setupCalled = false;
+
+  acceptor.accept(
+      std::move(connection),
+      [&](auto transport, auto) {
+        transport->close();
+        setupCalled = true;
+      },
+      resumeFail);
+
+  evb.loop();
+
+  EXPECT_TRUE(setupCalled);
+}
+
+TEST(SetupResumeAcceptor, SetupAndFnf) {
+  folly::EventBase evb;
+  SetupResumeAcceptor acceptor{ProtocolVersion::Latest, &evb};
+
+  auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
+      [](auto input) {
+        auto serializer = FrameSerializer::createCurrentVersion();
+
+        auto setup = makeSetup();
+        Frame_REQUEST_FNF fnf{100, FrameFlags::EMPTY, Payload("Hi")};
+
+        input->onNext(serializer->serializeOut(std::move(setup)));
+        input->onNext(serializer->serializeOut(std::move(fnf)));
+      },
+      [](auto output) {
+        EXPECT_CALL(*output, onSubscribe_(_));
+        EXPECT_CALL(*output, onComplete_());
+      });
+
+  yarpl::Reference<FrameTransport> transport;
+
+  acceptor.accept(
+      std::move(connection),
+      [&](auto tport, auto) { transport = std::move(tport); },
+      resumeFail);
+
+  evb.loop();
+
+  EXPECT_TRUE(transport.get());
+
+  auto processor = std::make_shared<StrictMock<MockFrameProcessor>>();
+  EXPECT_CALL(*processor, processFrame_(_))
+    .WillOnce(Invoke([](auto const& buf) {
+          auto serializer = FrameSerializer::createCurrentVersion();
+
+          Frame_REQUEST_FNF fnf;
+          EXPECT_TRUE(serializer->deserializeFrom(fnf, buf->clone()));
+          EXPECT_EQ(fnf.header_.streamId_, 100u);
+          EXPECT_EQ(fnf.header_.flags_, FrameFlags::EMPTY);
+          EXPECT_EQ(fnf.payload_.cloneDataToString(), "Hi");
+        }));
+  transport->setFrameProcessor(processor);
+  transport->close();
+}
+
+TEST(SetupResumeAcceptor, InvalidSetup) {
+  folly::EventBase evb;
+  SetupResumeAcceptor acceptor{ProtocolVersion::Latest, &evb};
+
+  auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
+      [](auto input) {
+        auto serializer = FrameSerializer::createCurrentVersion();
+
+        // Bogus keepalive time that can't be deserialized.
+        auto setup = makeSetup();
+        setup.keepaliveTime_ = -5;
+
+        input->onNext(serializer->serializeOut(std::move(setup)));
+      },
+      [](auto output) {
+        EXPECT_CALL(*output, onSubscribe_(_));
+        EXPECT_CALL(*output, onNext_(_)).WillOnce(Invoke([](auto const& buf) {
+          auto serializer = FrameSerializer::createCurrentVersion();
+          Frame_ERROR frame;
+          EXPECT_TRUE(serializer->deserializeFrom(frame, buf->clone()));
+          EXPECT_EQ(frame.errorCode_, ErrorCode::CONNECTION_ERROR);
+        }));
+        EXPECT_CALL(*output, onError_(_));
+      });
+
+  acceptor.accept(std::move(connection), setupFail, resumeFail);
+
+  evb.loop();
+}
+
+TEST(SetupResumeAcceptor, RejectedSetup) {
+  folly::EventBase evb;
+  SetupResumeAcceptor acceptor{ProtocolVersion::Latest, &evb};
+
+  auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
+      [](auto input) {
+        auto serializer = FrameSerializer::createCurrentVersion();
+        input->onNext(serializer->serializeOut(makeSetup()));
+      },
+      [](auto output) {
+        EXPECT_CALL(*output, onSubscribe_(_));
+        EXPECT_CALL(*output, onNext_(_)).WillOnce(Invoke([](auto const& buf) {
+          auto serializer = FrameSerializer::createCurrentVersion();
+          Frame_ERROR frame;
+          EXPECT_TRUE(serializer->deserializeFrom(frame, buf->clone()));
+          EXPECT_EQ(frame.errorCode_, ErrorCode::INVALID_SETUP);
+        }));
+        EXPECT_CALL(*output, onError_(_));
+      });
+
+  bool setupCalled = false;
+
+  acceptor.accept(
+      std::move(connection),
+      [&](auto, auto) {
+        setupCalled = true;
+        throw std::runtime_error("Oops");
+      },
+      resumeFail);
+
+  evb.loop();
+
+  EXPECT_TRUE(setupCalled);
+}
+
+TEST(SetupResumeAcceptor, RejectedResume) {
+  folly::EventBase evb;
+  SetupResumeAcceptor acceptor{ProtocolVersion::Latest, &evb};
+
+  auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
+      [](auto input) {
+        auto serializer = FrameSerializer::createCurrentVersion();
+        input->onNext(serializer->serializeOut(makeResume()));
+      },
+      [](auto output) {
+        EXPECT_CALL(*output, onSubscribe_(_));
+        EXPECT_CALL(*output, onNext_(_)).WillOnce(Invoke([](auto const& buf) {
+          auto serializer = FrameSerializer::createCurrentVersion();
+          Frame_ERROR frame;
+          EXPECT_TRUE(serializer->deserializeFrom(frame, buf->clone()));
+          EXPECT_EQ(frame.errorCode_, ErrorCode::REJECTED_RESUME);
+        }));
+        EXPECT_CALL(*output, onError_(_));
+      });
+
+  bool resumeCalled = false;
+
+  acceptor.accept(std::move(connection), setupFail, [&](auto, auto) {
+    resumeCalled = true;
+    return false;
+  });
+
+  evb.loop();
+
+  EXPECT_TRUE(resumeCalled);
+}
+
+// TODO: Test for whether changing FrameProcessor in on{Resume,Setup} breaks
+// things.


### PR DESCRIPTION
Documenting and testing SetupResumeAcceptor

* Tweaked OnSetup and OnResume functions to be folly::Function to keep us
  honest about moving them instead of copying.

* Forced use of folly::EventBase::runInEventBaseThread() on all calls to close() in 
  SetupResumeAcceptor::processFrame().

* Fixed any places where we were constructing a folly::exception_wrapper without
  a std::exception_ptr.

* Added MockDuplexConnection ctor that runs lambdas on input and output
  subscribers.