### PR TITLE
Updating folly to v2017.07.10.00

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ if (NOT FOLLY_INSTALL_DIR)
 endif ()
 
 # Check if the correct version of folly is already installed.
-set(FOLLY_VERSION v2017.06.19.00)
+set(FOLLY_VERSION v2017.07.10.00)
 set(FOLLY_VERSION_FILE ${FOLLY_INSTALL_DIR}/${FOLLY_VERSION})
 if (RSOCKET_INSTALL_DEPS)
   if (NOT EXISTS ${FOLLY_VERSION_FILE})


### PR DESCRIPTION
There's v2017.07.17.00 and v2017.07.17.01 already available, but I figured we'd
go to the one without a point release.