### PR TITLE
Make coverage build optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,8 @@ script:
   - mkdir build &&
     cd build &&
     cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DRSOCKET_CC=$COMPILER
-          -DRSOCKET_ASAN=$ASAN -DRSOCKET_INSTALL_DEPS=True .. &&
+          -DRSOCKET_ASAN=$ASAN -DRSOCKET_INSTALL_DEPS=True
+          -DRSOCKET_BUILD_WITH_COVERAGE=ON .. &&
     make -j8 &&
     make test
   - cd ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,9 @@ if (APPLE)
   endif()
 endif()
 
+# disable coverage mode by default
+option(RSOCKET_BUILD_WITH_COVERAGE "Build with --coverage (gcov)" OFF)
+
 # Add compiler-specific options.
 if (CMAKE_COMPILER_IS_GNUCXX)
   if (RSOCKET_ASAN)
@@ -63,19 +66,21 @@ if (CMAKE_COMPILER_IS_GNUCXX)
   endif ()
   set(EXTRA_LINK_FLAGS ${EXTRA_LINK_FLAGS} -fuse-ld=gold)
 
-  # Enable code coverage.
-  add_compile_options(--coverage)
-  set(EXTRA_LINK_FLAGS ${EXTRA_LINK_FLAGS} --coverage)
-  set(COVERAGE_INFO coverage.info)
-  add_custom_command(
-    OUTPUT ${COVERAGE_INFO}
-    # Capture coverage info.
-    COMMAND lcov --directory . --capture --output-file ${COVERAGE_INFO}
-    # Filter out system and test code.
-    COMMAND lcov --remove ${COVERAGE_INFO} 'tests/*' 'test/*' 'tck-test/*' '/usr/*' 'gmock/*' 'folly/*' --output-file
-                 ${COVERAGE_INFO}
-    # Debug before upload.
-    COMMAND lcov --list ${COVERAGE_INFO})
+  if (RSOCKET_BUILD_WITH_COVERAGE)
+    # Enable code coverage.
+    add_compile_options(--coverage)
+    set(EXTRA_LINK_FLAGS ${EXTRA_LINK_FLAGS} --coverage)
+    set(COVERAGE_INFO coverage.info)
+    add_custom_command(
+      OUTPUT ${COVERAGE_INFO}
+      # Capture coverage info.
+      COMMAND lcov --directory . --capture --output-file ${COVERAGE_INFO}
+      # Filter out system and test code.
+      COMMAND lcov --remove ${COVERAGE_INFO} 'tests/*' 'test/*' 'tck-test/*' '/usr/*' 'gmock/*' 'folly/*' --output-file
+                   ${COVERAGE_INFO}
+      # Debug before upload.
+      COMMAND lcov --list ${COVERAGE_INFO})
+  endif()
 elseif (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
   if (RSOCKET_ASAN)
     set(ASAN_FLAGS


### PR DESCRIPTION
* Requiring --coverage on build by default makes it difficult to include the library in external projects - they must pass a coverage flag to the rsocket build to avoid linker errors with gcov and friends

* Makes the coverage build optional (defaults to off in the case of building as an external project)

* Explicitly enables coverage for travis build.

* Tested on MacOS and Ubuntu