### PR TITLE
Add warm-resumption unittest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,7 @@ add_executable(
   test/RequestChannelTest.cpp
   test/RequestResponseTest.cpp
   test/RequestStreamTest.cpp
+  test/WarmResumptionTest.cpp
   test/Test.cpp
   test/framing/FrameTest.cpp
   test/framing/FrameTransportTest.cpp

--- a/rsocket/RSocketRequester.cpp
+++ b/rsocket/RSocketRequester.cpp
@@ -20,12 +20,6 @@ RSocketRequester::RSocketRequester(
 
 RSocketRequester::~RSocketRequester() {
   VLOG(1) << "Destroying RSocketRequester";
-
-  if (stateMachine_) {
-    eventBase_.add([stateMachine = std::move(stateMachine_)] {
-      VLOG(2) << "Releasing RSocketStateMachine on EventBase";
-    });
-  }
 }
 
 void RSocketRequester::closeSocket() {

--- a/rsocket/internal/RSocketConnectionManager.cpp
+++ b/rsocket/internal/RSocketConnectionManager.cpp
@@ -98,7 +98,7 @@ void RSocketConnectionManager::removeConnection(
   auto locked = sockets_.lock();
   locked->erase(socket);
 
-  VLOG(2) << "Removed ReactiveSocket";
+  VLOG(2) << "Removed RSocketStateMachine";
 
   if (shutdown_ && locked->empty()) {
     shutdown_->post();

--- a/test/WarmResumptionTest.cpp
+++ b/test/WarmResumptionTest.cpp
@@ -1,0 +1,64 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <thread>
+
+#include "RSocketTests.h"
+
+#include "rsocket/RSocketServiceHandler.h"
+#include "yarpl/flowable/TestSubscriber.h"
+
+using namespace rsocket;
+using namespace rsocket::tests::client_server;
+using namespace yarpl::flowable;
+
+namespace {
+
+class HelloServiceHandler : public RSocketServiceHandler {
+ public:
+  folly::Expected<RSocketConnectionParams, RSocketException> onNewSetup(
+      const SetupParameters&) override {
+    return RSocketConnectionParams(
+        std::make_shared<rsocket::tests::HelloStreamRequestHandler>());
+  }
+
+  void onNewRSocketState(
+      std::shared_ptr<RSocketServerState> state,
+      ResumeIdentificationToken token) override {
+    store_.lock()->insert({token, std::move(state)});
+  }
+
+  folly::Expected<std::shared_ptr<RSocketServerState>, RSocketException>
+  onResume(ResumeIdentificationToken token) override {
+    auto itr = store_->find(token);
+    CHECK(itr != store_->end());
+    return itr->second;
+  };
+
+ private:
+  folly::Synchronized<
+      std::map<ResumeIdentificationToken, std::shared_ptr<RSocketServerState>>,
+      std::mutex>
+      store_;
+};
+
+} // anonymous namespace
+
+TEST(WarmResumptionTest, SimpleStream) {
+  auto server = makeResumableServer(std::make_shared<HelloServiceHandler>());
+  auto client = makeResumableClient(*server->listeningPort());
+  auto requester = client->getRequester();
+  auto ts = TestSubscriber<std::string>::create(7 /* initialRequestN */);
+  requester->requestStream(Payload("Bob"))
+      ->map([](auto p) { return p.moveDataToString(); })
+      ->subscribe(ts);
+  // Wait for a few frames before disconnecting.
+  while (ts->getValueCount() < 3) {
+    std::this_thread::yield();
+  }
+  client->disconnect(std::runtime_error("Test triggered disconnect"));
+  EXPECT_NO_THROW(client->resume().get());
+  ts->request(3);
+  ts->awaitTerminalEvent();
+  ts->assertSuccess();
+  ts->assertValueCount(10);
+}

--- a/yarpl/include/yarpl/flowable/TestSubscriber.h
+++ b/yarpl/include/yarpl/flowable/TestSubscriber.h
@@ -205,6 +205,10 @@ class TestSubscriber : public Subscriber<T> {
     subscription_->cancel();
   }
 
+  void request(int64_t n) {
+    subscription_->request(n);
+  }
+
  private:
   Reference<Subscriber<T>> delegate_;
   std::vector<T> values_;


### PR DESCRIPTION
Added a simple Warm Resumption Unittest.  

It also helped in reproducing a heap-after-use in RSocketRequester.  If the TcpConnectionFactory/TcpConnectionAcceptor go out of scope (and hence their evbs), RSocketRequester will be holding on to invalid evbs and use them during ~RSocketRequester.

Notes:
- This does not prevent the case where RSocketRequester makes a request (which uses evb) after RSocketClient/RSocketServer go out of scope.  In the current state of the code, the application has to hold on to RSocketClient/RSocketServer instances to be able to use RSocketRequester.
- The TestSubscriber used in the tests is not thread-safe - https://github.com/rsocket/rsocket-cpp/issues/606
