### PR TITLE
Rename RSocketNetworkStats to RSocketConnectionEvents

### DIFF
--- a/rsocket/RSocket.cpp
+++ b/rsocket/RSocket.cpp
@@ -12,7 +12,7 @@ folly::Future<std::shared_ptr<RSocketClient>> RSocket::createConnectedClient(
     std::shared_ptr<RSocketResponder> responder,
     std::unique_ptr<KeepaliveTimer> keepaliveTimer,
     std::shared_ptr<RSocketStats> stats,
-    std::shared_ptr<RSocketNetworkStats> networkStats,
+    std::shared_ptr<RSocketConnectionEvents> connectionEvents,
     std::shared_ptr<ResumeManager> resumeManager,
     std::shared_ptr<ColdResumeHandler> coldResumeHandler,
     OnRSocketResume) {
@@ -22,7 +22,7 @@ folly::Future<std::shared_ptr<RSocketClient>> RSocket::createConnectedClient(
       std::move(responder),
       std::move(keepaliveTimer),
       std::move(stats),
-      std::move(networkStats),
+      std::move(connectionEvents),
       std::move(resumeManager),
       std::move(coldResumeHandler)));
 
@@ -38,14 +38,14 @@ folly::Future<std::shared_ptr<RSocketClient>> RSocket::createResumedClient(
     std::shared_ptr<RSocketResponder> responder,
     std::unique_ptr<KeepaliveTimer> keepaliveTimer,
     std::shared_ptr<RSocketStats> stats,
-    std::shared_ptr<RSocketNetworkStats> networkStats) {
+    std::shared_ptr<RSocketConnectionEvents> connectionEvents) {
   auto c = std::shared_ptr<RSocketClient>(new RSocketClient(
       std::move(connectionFactory),
       std::move(setupParameters),
       std::move(responder),
       std::move(keepaliveTimer),
       std::move(stats),
-      std::move(networkStats),
+      std::move(connectionEvents),
       std::move(resumeManager),
       std::move(coldResumeHandler)));
 

--- a/rsocket/RSocket.h
+++ b/rsocket/RSocket.h
@@ -21,8 +21,8 @@ class RSocket {
       std::unique_ptr<KeepaliveTimer> keepaliveTimer =
           std::unique_ptr<KeepaliveTimer>(),
       std::shared_ptr<RSocketStats> stats = RSocketStats::noop(),
-      std::shared_ptr<RSocketNetworkStats> networkStats =
-          std::shared_ptr<RSocketNetworkStats>(),
+      std::shared_ptr<RSocketConnectionEvents> connectionEvents =
+          std::shared_ptr<RSocketConnectionEvents>(),
       std::shared_ptr<ResumeManager> resumeManager =
           std::shared_ptr<ResumeManager>(),
       std::shared_ptr<ColdResumeHandler> coldResumeHandler =
@@ -42,8 +42,8 @@ class RSocket {
       std::unique_ptr<KeepaliveTimer> keepaliveTimer =
           std::unique_ptr<KeepaliveTimer>(),
       std::shared_ptr<RSocketStats> stats = RSocketStats::noop(),
-      std::shared_ptr<RSocketNetworkStats> networkStats =
-          std::shared_ptr<RSocketNetworkStats>());
+      std::shared_ptr<RSocketConnectionEvents> connectionEvents =
+          std::shared_ptr<RSocketConnectionEvents>());
 
   // A convenience function to create RSocketServer
   static std::unique_ptr<RSocketServer> createServer(

--- a/rsocket/RSocketClient.cpp
+++ b/rsocket/RSocketClient.cpp
@@ -28,7 +28,7 @@ RSocketClient::RSocketClient(
     std::shared_ptr<RSocketResponder> responder,
     std::unique_ptr<KeepaliveTimer> keepaliveTimer,
     std::shared_ptr<RSocketStats> stats,
-    std::shared_ptr<RSocketNetworkStats> networkStats,
+    std::shared_ptr<RSocketConnectionEvents> connectionEvents,
     std::shared_ptr<ResumeManager> resumeManager,
     std::shared_ptr<ColdResumeHandler> coldResumeHandler,
     OnRSocketResume)
@@ -38,7 +38,7 @@ RSocketClient::RSocketClient(
       responder_(std::move(responder)),
       keepaliveTimer_(std::move(keepaliveTimer)),
       stats_(stats),
-      networkStats_(networkStats),
+      connectionEvents_(connectionEvents),
       resumeManager_(resumeManager),
       coldResumeHandler_(coldResumeHandler),
       protocolVersion_(setupParameters_.protocolVersion),
@@ -148,7 +148,7 @@ void RSocketClient::createState(folly::EventBase& eventBase) {
       std::move(keepaliveTimer_),
       ReactiveSocketMode::CLIENT,
       stats_,
-      networkStats_);
+      connectionEvents_);
 
   requester_ = std::make_shared<RSocketRequester>(stateMachine_, eventBase);
 

--- a/rsocket/RSocketClient.h
+++ b/rsocket/RSocketClient.h
@@ -6,7 +6,7 @@
 
 #include "rsocket/ColdResumeHandler.h"
 #include "rsocket/ConnectionFactory.h"
-#include "rsocket/RSocketNetworkStats.h"
+#include "rsocket/RSocketConnectionEvents.h"
 #include "rsocket/RSocketParameters.h"
 #include "rsocket/RSocketRequester.h"
 #include "rsocket/RSocketStats.h"
@@ -56,8 +56,8 @@ class RSocketClient {
       std::unique_ptr<KeepaliveTimer> keepaliveTimer =
           std::unique_ptr<KeepaliveTimer>(),
       std::shared_ptr<RSocketStats> stats = RSocketStats::noop(),
-      std::shared_ptr<RSocketNetworkStats> networkStats =
-          std::shared_ptr<RSocketNetworkStats>(),
+      std::shared_ptr<RSocketConnectionEvents> connectionEvents =
+          std::shared_ptr<RSocketConnectionEvents>(),
       std::shared_ptr<ResumeManager> resumeManager =
           std::shared_ptr<ResumeManager>(),
       std::shared_ptr<ColdResumeHandler> coldResumeHandler =
@@ -77,7 +77,7 @@ class RSocketClient {
   std::shared_ptr<RSocketResponder> responder_;
   std::unique_ptr<KeepaliveTimer> keepaliveTimer_;
   std::shared_ptr<RSocketStats> stats_;
-  std::shared_ptr<RSocketNetworkStats> networkStats_;
+  std::shared_ptr<RSocketConnectionEvents> connectionEvents_;
   std::shared_ptr<ResumeManager> resumeManager_;
   std::shared_ptr<ColdResumeHandler> coldResumeHandler_;
 

--- a/rsocket/RSocketConnectionEvents.h
+++ b/rsocket/RSocketConnectionEvents.h
@@ -8,9 +8,9 @@ class exception_wrapper;
 
 namespace rsocket {
 
-class RSocketNetworkStats {
+class RSocketConnectionEvents {
  public:
-  virtual ~RSocketNetworkStats() = default;
+  virtual ~RSocketConnectionEvents() = default;
 
   virtual void onConnected() {}
   virtual void onDisconnected(const folly::exception_wrapper&) {}

--- a/rsocket/RSocketServer.cpp
+++ b/rsocket/RSocketServer.cpp
@@ -138,7 +138,7 @@ void RSocketServer::onRSocketSetup(
       nullptr,
       ReactiveSocketMode::SERVER,
       std::move(connectionParams.stats),
-      std::move(connectionParams.networkStats));
+      std::move(connectionParams.connectionEvents));
   connectionManager_->manageConnection(rs, *eventBase);
   auto requester = std::make_shared<RSocketRequester>(rs, *eventBase);
   auto serverState = std::shared_ptr<RSocketServerState>(

--- a/rsocket/RSocketServiceHandler.h
+++ b/rsocket/RSocketServiceHandler.h
@@ -4,8 +4,8 @@
 
 #include <folly/Expected.h>
 
+#include "rsocket/RSocketConnectionEvents.h"
 #include "rsocket/RSocketException.h"
-#include "rsocket/RSocketNetworkStats.h"
 #include "rsocket/RSocketParameters.h"
 #include "rsocket/RSocketResponder.h"
 #include "rsocket/RSocketServerState.h"
@@ -25,13 +25,13 @@ struct RSocketConnectionParams {
   RSocketConnectionParams(
       std::shared_ptr<RSocketResponder> _responder,
       std::shared_ptr<RSocketStats> _stats = RSocketStats::noop(),
-      std::shared_ptr<RSocketNetworkStats> _networkStats = nullptr)
+      std::shared_ptr<RSocketConnectionEvents> _connectionEvents = nullptr)
       : responder(std::move(_responder)),
         stats(std::move(_stats)),
-        networkStats(std::move(_networkStats)) {}
+        connectionEvents(std::move(_connectionEvents)) {}
   std::shared_ptr<RSocketResponder> responder;
   std::shared_ptr<RSocketStats> stats;
-  std::shared_ptr<RSocketNetworkStats> networkStats;
+  std::shared_ptr<RSocketConnectionEvents> connectionEvents;
 };
 
 

--- a/rsocket/statemachine/RSocketStateMachine.h
+++ b/rsocket/statemachine/RSocketStateMachine.h
@@ -22,7 +22,7 @@ class FrameSerializer;
 class FrameTransport;
 class KeepaliveTimer;
 class ResumeCache;
-class RSocketNetworkStats;
+class RSocketConnectionEvents;
 class RSocketParameters;
 class RSocketResponder;
 class RSocketStateMachine;
@@ -64,7 +64,8 @@ class RSocketStateMachine final
       std::unique_ptr<KeepaliveTimer> keepaliveTimer_,
       ReactiveSocketMode mode,
       std::shared_ptr<RSocketStats> stats,
-      std::shared_ptr<RSocketNetworkStats> networkStats = std::shared_ptr<RSocketNetworkStats>());
+      std::shared_ptr<RSocketConnectionEvents> connectionEvents =
+          std::shared_ptr<RSocketConnectionEvents>());
 
   void closeWithError(Frame_ERROR&& error);
   void disconnectOrCloseWithError(Frame_ERROR&& error) override;
@@ -205,8 +206,8 @@ class RSocketStateMachine final
     return *stats_;
   }
 
-  std::shared_ptr<RSocketNetworkStats>& networkStats() {
-    return networkStats_;
+  std::shared_ptr<RSocketConnectionEvents>& connectionEvents() {
+    return connectionEvents_;
   }
 
  private:
@@ -296,7 +297,7 @@ class RSocketStateMachine final
   StreamsFactory streamsFactory_;
 
   const std::shared_ptr<RSocketStats> stats_;
-  std::shared_ptr<RSocketNetworkStats> networkStats_;
+  std::shared_ptr<RSocketConnectionEvents> connectionEvents_;
   folly::Executor& executor_;
 };
 }


### PR DESCRIPTION
RSocketNetworkStats was confusing with RSocketStats.  Make it explicit about what each class means.