### PR TITLE
add coverage support for clang, fix coverage remove globs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,22 +100,23 @@ cache:
 before_script:
   # Install lcov to coveralls conversion + upload tool.
   - gem install coveralls-lcov
-  - lcov --directory build --zerocounters
+  - lcov --version
 
 script:
-  - mkdir build &&
-    cd build &&
-    cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DRSOCKET_CC=$COMPILER
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DRSOCKET_CC=$COMPILER
           -DRSOCKET_ASAN=$ASAN -DRSOCKET_INSTALL_DEPS=True
-          -DRSOCKET_BUILD_WITH_COVERAGE=ON .. &&
-    make -j8 &&
-    make test
+          -DRSOCKET_BUILD_WITH_COVERAGE=ON ..
+  - make -j8
+  - lcov --directory . --zerocounters
+  - make test
+  - make coverage
   - cd ..
   - ./scripts/tck_test.sh -c cpp -s cpp
   - ./scripts/tck_test.sh -c java -s java
   - ./scripts/tck_test.sh -c java -s cpp
   - ./scripts/tck_test.sh -c cpp -s java
-  - cd build && make coverage
 
 after_success:
     # Upload to coveralls.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,13 @@ string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWER)
 if (APPLE)
   set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
   if ("${BUILD_TYPE_LOWER}" MATCHES "debug")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,integer -fno-sanitize=unsigned-integer-overflow")
+    if (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,integer -fno-sanitize=unsigned-integer-overflow")
+    elseif (${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+    else ()
+        message(FATAL_ERROR "Unsupported compiler on macOS")
+    endif()
   endif()
 endif()
 
@@ -66,21 +72,6 @@ if (CMAKE_COMPILER_IS_GNUCXX)
   endif ()
   set(EXTRA_LINK_FLAGS ${EXTRA_LINK_FLAGS} -fuse-ld=gold)
 
-  if (RSOCKET_BUILD_WITH_COVERAGE)
-    # Enable code coverage.
-    add_compile_options(--coverage)
-    set(EXTRA_LINK_FLAGS ${EXTRA_LINK_FLAGS} --coverage)
-    set(COVERAGE_INFO coverage.info)
-    add_custom_command(
-      OUTPUT ${COVERAGE_INFO}
-      # Capture coverage info.
-      COMMAND lcov --directory . --capture --output-file ${COVERAGE_INFO}
-      # Filter out system and test code.
-      COMMAND lcov --remove ${COVERAGE_INFO} 'tests/*' 'test/*' 'tck-test/*' '/usr/*' 'gmock/*' 'folly/*' --output-file
-                   ${COVERAGE_INFO}
-      # Debug before upload.
-      COMMAND lcov --list ${COVERAGE_INFO})
-  endif()
 elseif (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
   if (RSOCKET_ASAN)
     set(ASAN_FLAGS
@@ -89,12 +80,48 @@ elseif (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
   endif ()
 endif ()
 
+# Enable code coverage, if the compiler is supported
+if (RSOCKET_BUILD_WITH_COVERAGE)
+  set(COVERAGE_INFO coverage.info)
+
+  if (${CMAKE_SYSTEM_NAME} MATCHES Linux AND ${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
+    # clang and linux's lcov don't play nice together; don't attempt with linux/clang
+    add_custom_command(
+      OUTPUT ${COVERAGE_INFO}
+      COMMAND echo "Coverage info omitted for clang/linux builds")
+
+  else ()
+    add_custom_command(
+      OUTPUT ${COVERAGE_INFO}
+      # Capture coverage info.
+      COMMAND lcov --directory . --capture --output-file ${COVERAGE_INFO}
+      # Filter out system and test code.
+      COMMAND lcov --remove ${COVERAGE_INFO} '*/tests/*' '*/test/*' '*/tck-test/*' '*/usr/include/*' '/usr/*' '*/gmock/*' '*/folly/*' --output-file
+                   ${COVERAGE_INFO}
+      # Debug before upload.
+      COMMAND lcov --list ${COVERAGE_INFO})
+  endif ()
+
+  if (CMAKE_COMPILER_IS_GNUCXX)
+    add_compile_options(--coverage -g)
+    set(EXTRA_LINK_FLAGS ${EXTRA_LINK_FLAGS} --coverage)
+
+  elseif (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
+    add_compile_options(-g -O0 -fprofile-arcs -ftest-coverage)
+    set(EXTRA_LINK_FLAGS ${EXTRA_LINK_FLAGS} -fprofile-arcs -ftest-coverage)
+
+  else ()
+    message(FATAL_ERROR "Code coverage not supported with this compiler/host combination")
+  endif ()
+
+  message(STATUS "Building with coverage")
+  add_custom_target(coverage DEPENDS ${COVERAGE_INFO})
+endif ()
+
 if (DEFINED ASAN_FLAGS)
   add_compile_options(${ASAN_FLAGS})
   set(EXTRA_LINK_FLAGS ${EXTRA_LINK_FLAGS} ${ASAN_FLAGS})
 endif ()
-
-add_custom_target(coverage DEPENDS ${COVERAGE_INFO})
 
 option(BUILD_BENCHMARKS "Build benchmarks" ON)
 
@@ -290,8 +317,6 @@ add_library(
   rsocket/framing/FrameTransport.cpp
   rsocket/framing/FrameTransport.h
   rsocket/framing/FrameType.cpp
-  rsocket/framing/FrameType.cpp
-  rsocket/framing/FrameType.h
   rsocket/framing/FrameType.h
   rsocket/framing/FramedDuplexConnection.cpp
   rsocket/framing/FramedDuplexConnection.h

--- a/scripts/tck_test.sh
+++ b/scripts/tck_test.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [ "$#" -ne 4 ]; then
     echo "Illegal number of parameters - $#"
     exit 1
@@ -41,6 +43,11 @@ if [ ! -s ./build/tckclient ] && [ "$client_lang" = cpp ]; then
     exit 1
 fi
 
+timeout='timeout'
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  timeout='gtimeout'
+fi
+
 java_server="java -cp rsocket-tck-drivers-0.9-SNAPSHOT.jar io/rsocket/tckdrivers/main/Main --server --host localhost --port 9898 --file tck-test/servertest.txt"
 java_client="java -cp rsocket-tck-drivers-0.9-SNAPSHOT.jar io/rsocket/tckdrivers/main/Main --client --host localhost --port 9898 --file tck-test/clienttest.txt"
 
@@ -51,13 +58,13 @@ server="${server_lang}_server"
 client="${client_lang}_client"
 
 # run server in the background
-timeout 60 ${!server} &
+$timeout 60 ${!server} &
 
 # wait for the server to listen
 sleep 2
 
 # run client
-timeout 60 ${!client}
+$timeout 60 ${!client}
 ret=$?
 
 # terminate server

--- a/yarpl/CMakeLists.txt
+++ b/yarpl/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -momit-leaf-frame-pointer")
 
 # The yarpl-tests binary constantly fails with an ASAN error in gtest internal
 # code on macOS.
-if(APPLE)
+if(APPLE AND ${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
   message("== macOS detected, disabling ASAN for yarpl")
   add_compile_options("-fno-sanitize=address,undefined")
 endif()


### PR DESCRIPTION
`lcov` wasn't stripping coverage information for gmock (on osx, at least), as the file paths for gmock were under a prefix; same for folly and various includes from XCode. New globs are more forgiving. 

adds support for code coverage when compiling with clang on macOS
adds support for TCK tests in macOS

also removes an errant duplicated FrameType.{h,cpp}