### PR TITLE
Support destroying a SetupResumeAcceptor after its EventBase is destr…

### DIFF
--- a/rsocket/RSocketServer.cpp
+++ b/rsocket/RSocketServer.cpp
@@ -15,9 +15,10 @@ RSocketServer::RSocketServer(
     std::unique_ptr<ConnectionAcceptor> connectionAcceptor)
     : duplexConnectionAcceptor_(std::move(connectionAcceptor)),
       setupResumeAcceptors_([] {
-        return new rsocket::SetupResumeAcceptor(
+        return new rsocket::SetupResumeAcceptor{
             ProtocolVersion::Unknown,
-            folly::EventBaseManager::get()->getExistingEventBase());
+            folly::EventBaseManager::get()->getExistingEventBase(),
+            std::this_thread::get_id()};
       }),
       connectionManager_(std::make_unique<RSocketConnectionManager>()) {}
 

--- a/test/internal/SetupResumeAcceptorTest.cpp
+++ b/test/internal/SetupResumeAcceptorTest.cpp
@@ -280,5 +280,13 @@ TEST(SetupResumeAcceptor, RejectedResume) {
   EXPECT_TRUE(resumeCalled);
 }
 
+TEST(SetupResumeAcceptor, EventBaseDisappear) {
+  auto evb = std::make_unique<folly::EventBase>();
+
+  SetupResumeAcceptor acceptor{
+      ProtocolVersion::Latest, evb.get(), std::this_thread::get_id()};
+  evb.reset();
+}
+
 // TODO: Test for whether changing FrameProcessor in on{Resume,Setup} breaks
 // things.


### PR DESCRIPTION
…oyed

We hit this issue when manually passing DuplexConnection objects to
RSocketServer::acceptConnection().  We generally end up with the worker threads
getting killed first, which starts destroying their EventBases and then their
folly::ThreadLocal<SetupResumeAcceptor> objects.  When we're destroying the
SetupResumeAcceptor the EventBase is gone, and accessing it will cause us to
crash.