### PR TITLE
Reintroduce from_connection

### DIFF
--- a/rsocket/RSocket.cpp
+++ b/rsocket/RSocket.cpp
@@ -52,6 +52,30 @@ folly::Future<std::shared_ptr<RSocketClient>> RSocket::createResumedClient(
   return c->resume().then([c]() mutable { return c; });
 }
 
+std::shared_ptr<RSocketClient> RSocket::createClientFromConnection(
+    std::unique_ptr<DuplexConnection> connection,
+    folly::EventBase& eventBase,
+    SetupParameters setupParameters,
+    std::shared_ptr<RSocketResponder> responder,
+    std::unique_ptr<KeepaliveTimer> keepaliveTimer,
+    std::shared_ptr<RSocketStats> stats,
+    std::shared_ptr<RSocketConnectionEvents> connectionEvents,
+    std::shared_ptr<ResumeManager> resumeManager,
+    std::shared_ptr<ColdResumeHandler> coldResumeHandler,
+    OnRSocketResume) {
+  auto c = std::shared_ptr<RSocketClient>(new RSocketClient(
+      nullptr,
+      std::move(setupParameters),
+      std::move(responder),
+      std::move(keepaliveTimer),
+      std::move(stats),
+      std::move(connectionEvents),
+      std::move(resumeManager),
+      std::move(coldResumeHandler)));
+  c->fromConnection(std::move(connection), eventBase);
+  return c;
+}
+
 std::unique_ptr<RSocketServer> RSocket::createServer(
     std::unique_ptr<ConnectionAcceptor> connectionAcceptor) {
   return std::make_unique<RSocketServer>(std::move(connectionAcceptor));

--- a/rsocket/RSocket.h
+++ b/rsocket/RSocket.h
@@ -45,6 +45,25 @@ class RSocket {
       std::shared_ptr<RSocketConnectionEvents> connectionEvents =
           std::shared_ptr<RSocketConnectionEvents>());
 
+  // Creates a RSocketClient from an existing DuplexConnection
+  static std::shared_ptr<RSocketClient> createClientFromConnection(
+      std::unique_ptr<DuplexConnection> connection,
+      folly::EventBase& eventBase,
+      SetupParameters setupParameters = SetupParameters(),
+      std::shared_ptr<RSocketResponder> responder =
+          std::make_shared<RSocketResponder>(),
+      std::unique_ptr<KeepaliveTimer> keepaliveTimer =
+          std::unique_ptr<KeepaliveTimer>(),
+      std::shared_ptr<RSocketStats> stats = RSocketStats::noop(),
+      std::shared_ptr<RSocketConnectionEvents> connectionEvents =
+          std::shared_ptr<RSocketConnectionEvents>(),
+      std::shared_ptr<ResumeManager> resumeManager =
+          std::shared_ptr<ResumeManager>(),
+      std::shared_ptr<ColdResumeHandler> coldResumeHandler =
+          std::shared_ptr<ColdResumeHandler>(),
+      OnRSocketResume onRSocketResume =
+          [](std::vector<StreamId>, std::vector<StreamId>) { return false; });
+
   // A convenience function to create RSocketServer
   static std::unique_ptr<RSocketServer> createServer(
       std::unique_ptr<ConnectionAcceptor>);

--- a/rsocket/RSocketClient.h
+++ b/rsocket/RSocketClient.h
@@ -6,6 +6,7 @@
 
 #include "rsocket/ColdResumeHandler.h"
 #include "rsocket/ConnectionFactory.h"
+#include "rsocket/DuplexConnection.h"
 #include "rsocket/RSocketConnectionEvents.h"
 #include "rsocket/RSocketParameters.h"
 #include "rsocket/RSocketRequester.h"
@@ -67,6 +68,11 @@ class RSocketClient {
 
   // Connects to the remote side and creates state.
   folly::Future<folly::Unit> connect();
+
+  // Create stateMachine with the given DuplexConnection
+  void fromConnection(
+      std::unique_ptr<DuplexConnection> connection,
+      folly::EventBase& eventBase);
 
   // Creates RSocketStateMachine and RSocketRequester
   void createState(folly::EventBase& eventBase);


### PR DESCRIPTION
This method was removed with the latest API changes.  But seems like it is needed.
