### PR TITLE
Add sane defaults for StateMachine parameters

### DIFF
--- a/rsocket/RSocketServer.cpp
+++ b/rsocket/RSocketServer.cpp
@@ -128,7 +128,10 @@ void RSocketServer::onRSocketSetup(
     throw result.error();
   }
   auto connectionParams = result.value();
-  CHECK(connectionParams.responder);
+  if (!connectionParams.responder) {
+    LOG(ERROR) << "Received invalid Responder. Dropping connection";
+    throw RSocketException("Received invalid Responder from server");
+  }
   auto responder = std::make_shared<ScheduledRSocketResponder>(
       std::move(connectionParams.responder), *eventBase);
   auto rs = std::make_shared<RSocketStateMachine>(

--- a/rsocket/RSocketServerState.h
+++ b/rsocket/RSocketServerState.h
@@ -7,6 +7,7 @@
 namespace rsocket {
 
 class RSocketServerState {
+ public:
   void close();
 
   std::shared_ptr<RSocketRequester> getRequester() {

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -42,6 +42,11 @@ RSocketStateMachine::RSocketStateMachine(
   // We deliberately do not "open" input or output to avoid having c'tor on the
   // stack when processing any signals from the connection. See ::connect and
   // ::onSubscribe.
+
+  if (!stats_) {
+    stats_ = RSocketStats::noop();
+  }
+
   CHECK(streamState_);
   CHECK(requestResponder_);
 

--- a/rsocket/statemachine/RSocketStateMachine.h
+++ b/rsocket/statemachine/RSocketStateMachine.h
@@ -293,7 +293,7 @@ class RSocketStateMachine final
 
   StreamsFactory streamsFactory_;
 
-  const std::shared_ptr<RSocketStats> stats_;
+  std::shared_ptr<RSocketStats> stats_;
   std::shared_ptr<RSocketConnectionEvents> connectionEvents_;
   folly::Executor& executor_;
 };

--- a/test/handlers/HelloServiceHandler.h
+++ b/test/handlers/HelloServiceHandler.h
@@ -11,7 +11,7 @@ namespace tests {
 
 class HelloServiceHandler : public RSocketServiceHandler {
  public:
-  HelloServiceHandler(
+  explicit HelloServiceHandler(
       std::shared_ptr<RSocketConnectionEvents> connEvents = nullptr)
       : connectionEvents_(connEvents) {}
 

--- a/test/handlers/HelloStreamRequestHandler.cpp
+++ b/test/handlers/HelloStreamRequestHandler.cpp
@@ -15,7 +15,7 @@ Reference<Flowable<rsocket::Payload>>
 HelloStreamRequestHandler::handleRequestStream(
     rsocket::Payload request,
     rsocket::StreamId) {
-  LOG(INFO) << "HelloStreamRequestHandler.handleRequestStream " << request;
+  VLOG(3) << "HelloStreamRequestHandler.handleRequestStream " << request;
 
   // string from payload data
   auto requestString = request.moveDataToString();


### PR DESCRIPTION
Some of these defaults got removed with API changes.
This is also to ensure the dependent code continues working.