### PR TITLE
Improve most error frame messages

### DIFF
--- a/rsocket/framing/Frame.cpp
+++ b/rsocket/framing/Frame.cpp
@@ -141,92 +141,112 @@ std::ostream& operator<<(std::ostream& os, const Frame_PAYLOAD& frame) {
   return os << frame.header_ << ", " << frame.payload_;
 }
 
-Frame_ERROR Frame_ERROR::unexpectedFrame() {
-  return Frame_ERROR(
-      0, ErrorCode::CONNECTION_ERROR, Payload("unexpected frame"));
+Frame_ERROR Frame_ERROR::invalidSetup(std::string message) {
+  return connectionErr(ErrorCode::INVALID_SETUP, std::move(message));
 }
 
-Frame_ERROR Frame_ERROR::invalidFrame() {
-  return Frame_ERROR(0, ErrorCode::CONNECTION_ERROR, Payload("invalid frame"));
+Frame_ERROR Frame_ERROR::unsupportedSetup(std::string message) {
+  return connectionErr(ErrorCode::UNSUPPORTED_SETUP, std::move(message));
 }
 
-Frame_ERROR Frame_ERROR::badSetupFrame(const std::string& message) {
-  return Frame_ERROR(0, ErrorCode::INVALID_SETUP, Payload(message));
+Frame_ERROR Frame_ERROR::rejectedSetup(std::string message) {
+  return connectionErr(ErrorCode::REJECTED_SETUP, std::move(message));
 }
 
-Frame_ERROR Frame_ERROR::rejectedSetup(const std::string& message) {
-  return Frame_ERROR(0, ErrorCode::REJECTED_SETUP, Payload(message));
+Frame_ERROR Frame_ERROR::rejectedResume(std::string message) {
+  return connectionErr(ErrorCode::REJECTED_RESUME, std::move(message));
 }
 
-Frame_ERROR Frame_ERROR::connectionError(const std::string& message) {
-  return Frame_ERROR(0, ErrorCode::CONNECTION_ERROR, Payload(message));
-}
-
-Frame_ERROR Frame_ERROR::rejectedResume(const std::string& message) {
-  return Frame_ERROR(0, ErrorCode::REJECTED_RESUME, Payload(message));
-}
-
-Frame_ERROR Frame_ERROR::error(StreamId streamId, Payload&& payload) {
-  DCHECK(streamId) << "streamId MUST be non-0";
-  return Frame_ERROR(streamId, ErrorCode::INVALID, std::move(payload));
+Frame_ERROR Frame_ERROR::connectionError(std::string message) {
+  return connectionErr(ErrorCode::CONNECTION_ERROR, std::move(message));
 }
 
 Frame_ERROR Frame_ERROR::applicationError(
-    StreamId streamId,
-    Payload&& payload) {
-  DCHECK(streamId) << "streamId MUST be non-0";
-  return Frame_ERROR(
-      streamId, ErrorCode::APPLICATION_ERROR, std::move(payload));
+    StreamId stream,
+    std::string message) {
+  return streamErr(ErrorCode::APPLICATION_ERROR, std::move(message), stream);
+}
+
+Frame_ERROR Frame_ERROR::rejected(StreamId stream, std::string message) {
+  return streamErr(ErrorCode::REJECTED, std::move(message), stream);
+}
+
+Frame_ERROR Frame_ERROR::canceled(StreamId stream, std::string message) {
+  return streamErr(ErrorCode::CANCELED, std::move(message), stream);
+}
+
+Frame_ERROR Frame_ERROR::invalid(StreamId stream, std::string message) {
+  return streamErr(ErrorCode::INVALID, std::move(message), stream);
+}
+
+Frame_ERROR Frame_ERROR::connectionErr(
+    ErrorCode err,
+    std::string message) {
+  return Frame_ERROR{0, err, Payload{std::move(message)}};
+}
+
+Frame_ERROR Frame_ERROR::streamErr(
+    ErrorCode err,
+    std::string message,
+    StreamId stream) {
+  if (stream == 0) {
+    throw std::invalid_argument{"Can't make stream error for stream zero"};
+  }
+  return Frame_ERROR{stream, err, Payload{std::move(message)}};
 }
 
 std::ostream& operator<<(std::ostream& os, const Frame_ERROR& frame) {
   return os << frame.header_ << ", " << frame.errorCode_ << ", "
             << frame.payload_;
-}
+  }
 
-std::ostream& operator<<(std::ostream& os, const Frame_KEEPALIVE& frame) {
-  return os << frame.header_ << "(<"
-            << (frame.data_ ? frame.data_->computeChainDataLength() : 0)
-            << ">)";
-}
+  std::ostream& operator<<(std::ostream& os, const Frame_KEEPALIVE& frame) {
+    return os << frame.header_ << "(<"
+              << (frame.data_ ? frame.data_->computeChainDataLength() : 0)
+              << ">)";
+  }
 
-std::ostream& operator<<(std::ostream& os, const Frame_SETUP& frame) {
-  return os << frame.header_ << ", Version: " << frame.versionMajor_ << "."
-            << frame.versionMinor_ << ", " << frame.payload_;
-}
+  std::ostream& operator<<(std::ostream& os, const Frame_SETUP& frame) {
+    return os << frame.header_ << ", Version: " << frame.versionMajor_ << "."
+              << frame.versionMinor_ << ", " << frame.payload_;
+  }
 
-void Frame_SETUP::moveToSetupPayload(SetupParameters& setupPayload) {
-  setupPayload.metadataMimeType = std::move(metadataMimeType_);
-  setupPayload.dataMimeType = std::move(dataMimeType_);
-  setupPayload.payload = std::move(payload_);
-  setupPayload.token = std::move(token_);
-  setupPayload.resumable = !!(header_.flags_ & FrameFlags::RESUME_ENABLE);
-  setupPayload.protocolVersion = ProtocolVersion(versionMajor_, versionMinor_);
-}
+  void Frame_SETUP::moveToSetupPayload(SetupParameters & setupPayload) {
+    setupPayload.metadataMimeType = std::move(metadataMimeType_);
+    setupPayload.dataMimeType = std::move(dataMimeType_);
+    setupPayload.payload = std::move(payload_);
+    setupPayload.token = std::move(token_);
+    setupPayload.resumable = !!(header_.flags_ & FrameFlags::RESUME_ENABLE);
+    setupPayload.protocolVersion =
+        ProtocolVersion(versionMajor_, versionMinor_);
+  }
 
-std::ostream& operator<<(std::ostream& os, const Frame_LEASE& frame) {
-  return os << frame.header_ << ", ("
-            << (frame.metadata_ ? frame.metadata_->computeChainDataLength() : 0)
-            << ")";
-}
+  std::ostream& operator<<(std::ostream& os, const Frame_LEASE& frame) {
+    return os << frame.header_ << ", ("
+              << (frame.metadata_ ? frame.metadata_->computeChainDataLength()
+                                  : 0)
+              << ")";
+  }
 
-std::ostream& operator<<(std::ostream& os, const Frame_RESUME& frame) {
-  return os << frame.header_ << ", ("
-            << "token"
-            << ", @server " << frame.lastReceivedServerPosition_ << ", @client "
-            << frame.clientPosition_ << ")";
-}
+  std::ostream& operator<<(std::ostream& os, const Frame_RESUME& frame) {
+    return os << frame.header_ << ", ("
+              << "token"
+              << ", @server " << frame.lastReceivedServerPosition_
+              << ", @client " << frame.clientPosition_ << ")";
+  }
 
-std::ostream& operator<<(std::ostream& os, const Frame_RESUME_OK& frame) {
-  return os << frame.header_ << ", (@" << frame.position_ << ")";
-}
+  std::ostream& operator<<(std::ostream& os, const Frame_RESUME_OK& frame) {
+    return os << frame.header_ << ", (@" << frame.position_ << ")";
+  }
 
-std::ostream& operator<<(std::ostream& os, const Frame_REQUEST_CHANNEL& frame) {
-  return os << frame.header_ << ", " << frame.payload_;
-}
+  std::ostream& operator<<(
+      std::ostream& os, const Frame_REQUEST_CHANNEL& frame) {
+    return os << frame.header_ << ", " << frame.payload_;
+  }
 
-std::ostream& operator<<(std::ostream& os, const Frame_REQUEST_STREAM& frame) {
-  return os << frame.header_ << ", " << frame.payload_;
-}
+  std::ostream& operator<<(
+      std::ostream& os, const Frame_REQUEST_STREAM& frame) {
+    return os << frame.header_ << ", " << frame.payload_;
+  }
 
 } // namespace rsocket

--- a/rsocket/framing/Frame.h
+++ b/rsocket/framing/Frame.h
@@ -280,15 +280,24 @@ class Frame_ERROR {
         errorCode_(errorCode),
         payload_(std::move(payload)) {}
 
-  static Frame_ERROR unexpectedFrame();
-  static Frame_ERROR invalidFrame();
-  static Frame_ERROR badSetupFrame(const std::string& message);
-  static Frame_ERROR rejectedSetup(const std::string& message);
-  static Frame_ERROR connectionError(const std::string& message);
-  static Frame_ERROR rejectedResume(const std::string& message);
-  static Frame_ERROR error(StreamId streamId, Payload&& payload);
-  static Frame_ERROR applicationError(StreamId streamId, Payload&& payload);
+  // Connection errors.
+  static Frame_ERROR invalidSetup(std::string);
+  static Frame_ERROR unsupportedSetup(std::string);
+  static Frame_ERROR rejectedSetup(std::string);
+  static Frame_ERROR rejectedResume(std::string);
+  static Frame_ERROR connectionError(std::string);
 
+  // Stream errors.
+  static Frame_ERROR applicationError(StreamId, std::string);
+  static Frame_ERROR rejected(StreamId, std::string);
+  static Frame_ERROR canceled(StreamId, std::string);
+  static Frame_ERROR invalid(StreamId, std::string);
+
+ private:
+  static Frame_ERROR connectionErr(ErrorCode, std::string);
+  static Frame_ERROR streamErr(ErrorCode, std::string, StreamId);
+
+ public:
   FrameHeader header_;
   ErrorCode errorCode_{};
   Payload payload_;

--- a/rsocket/statemachine/RSocketStateMachine.h
+++ b/rsocket/statemachine/RSocketStateMachine.h
@@ -154,27 +154,24 @@ class RSocketStateMachine final
   template <typename TFrame>
   bool deserializeFrameOrError(
       TFrame& frame,
-      std::unique_ptr<folly::IOBuf> payload) {
-    if (frameSerializer_->deserializeFrom(frame, std::move(payload))) {
+      std::unique_ptr<folly::IOBuf> buf) {
+    if (frameSerializer_->deserializeFrom(frame, std::move(buf))) {
       return true;
-    } else {
-      closeWithError(Frame_ERROR::invalidFrame());
-      return false;
     }
+    closeWithError(Frame_ERROR::connectionError("Invalid frame"));
+    return false;
   }
 
   template <typename TFrame>
   bool deserializeFrameOrError(
       bool resumable,
       TFrame& frame,
-      std::unique_ptr<folly::IOBuf> payload) {
-    if (frameSerializer_->deserializeFrom(
-            frame, std::move(payload), resumable)) {
+      std::unique_ptr<folly::IOBuf> buf) {
+    if (frameSerializer_->deserializeFrom(frame, std::move(buf), resumable)) {
       return true;
-    } else {
-      closeWithError(Frame_ERROR::invalidFrame());
-      return false;
     }
+    closeWithError(Frame_ERROR::connectionError("Invalid frame"));
+    return false;
   }
 
   bool resumeFromPositionOrClose(
@@ -270,7 +267,7 @@ class RSocketStateMachine final
   void writeCloseStream(
       StreamId streamId,
       StreamCompletionSignal signal,
-      Payload payload) override;
+      std::string message) override;
   void onStreamClosed(StreamId streamId, StreamCompletionSignal signal)
       override;
 

--- a/rsocket/statemachine/StreamStateMachineBase.cpp
+++ b/rsocket/statemachine/StreamStateMachineBase.cpp
@@ -52,25 +52,23 @@ void StreamStateMachineBase::applicationError(std::string errorPayload) {
   writer_->writeCloseStream(
       streamId_,
       StreamCompletionSignal::APPLICATION_ERROR,
-      Payload(std::move(errorPayload)));
+      std::move(errorPayload));
 }
 
 void StreamStateMachineBase::errorStream(std::string errorPayload) {
   writer_->writeCloseStream(
       streamId_,
       StreamCompletionSignal::ERROR,
-      Payload(std::move(errorPayload)));
+      std::move(errorPayload));
   closeStream(StreamCompletionSignal::ERROR);
 }
 
 void StreamStateMachineBase::cancelStream() {
-  writer_->writeCloseStream(
-      streamId_, StreamCompletionSignal::CANCEL, Payload());
+  writer_->writeCloseStream(streamId_, StreamCompletionSignal::CANCEL, "");
 }
 
 void StreamStateMachineBase::completeStream() {
-  writer_->writeCloseStream(
-      streamId_, StreamCompletionSignal::COMPLETE, Payload());
+  writer_->writeCloseStream(streamId_, StreamCompletionSignal::COMPLETE, "");
 }
 
 void StreamStateMachineBase::closeStream(StreamCompletionSignal signal) {

--- a/rsocket/statemachine/StreamsWriter.h
+++ b/rsocket/statemachine/StreamsWriter.h
@@ -32,7 +32,7 @@ class StreamsWriter {
   virtual void writeCloseStream(
       StreamId streamId,
       StreamCompletionSignal signal,
-      Payload payload) = 0;
+      std::string message) = 0;
 
   virtual void onStreamClosed(
       StreamId streamId,


### PR DESCRIPTION
Mostly getting rid of the `Frame_ERROR::invalidFrame()` helper, forcing callsites
to use `Frame_ERROR::connectionError()` with a useful error message.