### PR TITLE
Fail resumption if it happens in different thread

### DIFF
--- a/rsocket/RSocketServer.cpp
+++ b/rsocket/RSocketServer.cpp
@@ -160,6 +160,9 @@ void RSocketServer::onRSocketResume(
   }
   auto serverState = std::move(result.value());
   CHECK(serverState);
+  if (!serverState->rSocketStateMachine_->isInEventBaseThread()) {
+    throw RSocketException("Trying to RESUME in a different worker thread");
+  }
   serverState->rSocketStateMachine_->resumeServer(
       std::move(frameTransport), resumeParams);
 }

--- a/rsocket/internal/SetupResumeAcceptor.cpp
+++ b/rsocket/internal/SetupResumeAcceptor.cpp
@@ -170,6 +170,7 @@ void SetupResumeAcceptor::processFrame(
       } catch (const std::exception& exn) {
         folly::exception_wrapper ew{std::current_exception(), exn};
         auto errFrame = Frame_ERROR::rejectedResume(ew.what().toStdString());
+        VLOG(3) << "Out: " << errFrame;
         transport->outputFrameOrEnqueue(
             serializer->serializeOut(std::move(errFrame)));
         close(std::move(transport), std::move(ew));

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -888,6 +888,10 @@ void RSocketStateMachine::connectClientSendSetup(
   connect(std::move(frameTransport), true, ProtocolVersion::Unknown);
 }
 
+bool RSocketStateMachine::isInEventBaseThread() {
+  return dynamic_cast<folly::EventBase*>(&executor_)->isInEventBaseThread();
+}
+
 void RSocketStateMachine::writeNewStream(
     StreamId streamId,
     StreamType streamType,

--- a/rsocket/statemachine/RSocketStateMachine.h
+++ b/rsocket/statemachine/RSocketStateMachine.h
@@ -207,6 +207,8 @@ class RSocketStateMachine final
     return connectionEvents_;
   }
 
+  bool isInEventBaseThread();
+
  private:
 
   bool connect(


### PR DESCRIPTION
In the short term, we need to fail resumption if the client tries to resume in a different thread.  Adding the code changes to support it.  mid/longer term we need to figure out way to allow resumption of clients from different threads.