### PR TITLE
Cold resumption for REQUEST_STREAM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,6 +343,7 @@ add_library(
   rsocket/internal/SwappableEventBase.cpp
   rsocket/internal/SwappableEventBase.h
   rsocket/ResumeManager.h
+  rsocket/ColdResumeHandler.cpp
   rsocket/ColdResumeHandler.h
   rsocket/RSocketServiceHandler.cpp
   rsocket/RSocketServiceHandler.h

--- a/examples/resumption/ColdResumption_Client.cpp
+++ b/examples/resumption/ColdResumption_Client.cpp
@@ -1,13 +1,192 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
+#include <iostream>
 
 #include <folly/init/Init.h>
+#include <folly/io/async/ScopedEventBaseThread.h>
+
+#include "rsocket/RSocket.h"
+
+#include "rsocket/internal/InMemResumeManager.h"
+#include "rsocket/transports/tcp/TcpConnectionFactory.h"
+
+using namespace rsocket;
+using namespace yarpl;
+using namespace yarpl::flowable;
+
+DEFINE_string(host, "localhost", "host to connect to");
+DEFINE_int32(port, 9898, "host:port to connect to");
+
+typedef std::map<std::string, Reference<Subscriber<Payload>>> HelloSubscribers;
+
+namespace {
+
+class HelloSubscriber : public virtual Refcounted, public Subscriber<Payload> {
+ public:
+  void request(int n) {
+    while (!subscription_) {
+      std::this_thread::yield();
+    }
+    subscription_->request(n);
+  }
+
+  int rcvdCount() const {
+    return count_;
+  };
+
+ protected:
+  void onSubscribe(Reference<Subscription> subscription) noexcept override {
+    subscription_ = subscription;
+  }
+
+  void onNext(Payload) noexcept override {
+    count_++;
+  }
+
+ private:
+  Reference<Subscription> subscription_{nullptr};
+  std::atomic<int> count_{0};
+};
+
+class HelloResumeHandler : public ColdResumeHandler {
+ public:
+  explicit HelloResumeHandler(HelloSubscribers subscribers)
+      : subscribers_(std::move(subscribers)) {}
+
+  std::string generateStreamToken(const Payload& payload, StreamId, StreamType)
+      override {
+    auto streamToken =
+        payload.data->cloneAsValue().moveToFbString().toStdString();
+    VLOG(3) << "Generated token: " << streamToken;
+    return streamToken;
+  }
+
+  Reference<Subscriber<Payload>> handleRequesterResumeStream(
+      std::string streamToken,
+      uint32_t consumerAllowance) override {
+    CHECK(subscribers_.find(streamToken) != subscribers_.end());
+    LOG(INFO) << "Resuming " << streamToken << " stream with allowance "
+              << consumerAllowance;
+    return subscribers_[streamToken];
+  }
+
+ private:
+  HelloSubscribers subscribers_;
+};
+
+SetupParameters getSetupParams(ResumeIdentificationToken token) {
+  SetupParameters setupParameters;
+  setupParameters.resumable = true;
+  setupParameters.token = token;
+  return setupParameters;
+}
+
+std::unique_ptr<TcpConnectionFactory> getConnFactory() {
+  folly::SocketAddress address;
+  address.setFromHostPort(FLAGS_host, FLAGS_port);
+  return std::make_unique<TcpConnectionFactory>(address);
+}
+}
+
+// There are three sessions and three streams.
+// There is cold-resumption between the three sessions.
+// The first stream lasts through all three sessions.
+// The second stream lasts through the second and third session.
+// the third stream lives only in the third session.
 
 int main(int argc, char* argv[]) {
-
+  FLAGS_logtostderr = true;
+  FLAGS_minloglevel = 0;
   folly::init(&argc, &argv);
 
-  // code to be added
+  auto token = ResumeIdentificationToken::generateNew();
+  auto resumeManager =
+      std::make_shared<InMemResumeManager>(RSocketStats::noop());
+
+  std::string firstPayload = "First";
+  std::string secondPayload = "Second";
+  std::string thirdPayload = "Third";
+
+  {
+    auto firstSub = yarpl::make_ref<HelloSubscriber>();
+    auto coldResumeHandler = std::make_shared<HelloResumeHandler>(
+        HelloSubscribers({{firstPayload, firstSub}}));
+    auto firstClient = RSocket::createConnectedClient(
+                           getConnFactory(),
+                           getSetupParams(token),
+                           nullptr, // responder
+                           nullptr, // keepAliveTimer
+                           nullptr, // stats
+                           nullptr, // connectionEvents
+                           resumeManager,
+                           coldResumeHandler)
+                           .get();
+    firstClient->getRequester()
+        ->requestStream(Payload(firstPayload))
+        ->subscribe(firstSub);
+    firstSub->request(7);
+    while (firstSub->rcvdCount() < 3) {
+      std::this_thread::yield();
+    }
+    firstClient->disconnect(std::runtime_error("disconnect from client"));
+  }
+
+  LOG(INFO) << "============== First Cold Resumption ================";
+
+  {
+    auto firstSub = yarpl::make_ref<HelloSubscriber>();
+    auto coldResumeHandler = std::make_shared<HelloResumeHandler>(
+        HelloSubscribers({{firstPayload, firstSub}}));
+    auto secondClient = RSocket::createResumedClient(
+                            getConnFactory(),
+                            getSetupParams(token),
+                            resumeManager,
+                            coldResumeHandler)
+                            .get();
+
+    firstSub->request(3);
+
+    // Create another stream to verify StreamIds are set properly after
+    // resumption
+    auto secondSub = yarpl::make_ref<HelloSubscriber>();
+    secondClient->getRequester()
+        ->requestStream(Payload(secondPayload))
+        ->subscribe(secondSub);
+    secondSub->request(5);
+    firstSub->request(4);
+    while (secondSub->rcvdCount() < 1) {
+      std::this_thread::yield();
+    }
+  }
+
+  LOG(INFO) << "============== Second Cold Resumption ================";
+
+  {
+    auto firstSub = yarpl::make_ref<HelloSubscriber>();
+    auto secondSub = yarpl::make_ref<HelloSubscriber>();
+    auto coldResumeHandler =
+        std::make_shared<HelloResumeHandler>(HelloSubscribers(
+            {{firstPayload, firstSub}, {secondPayload, secondSub}}));
+    auto thirdClient = RSocket::createResumedClient(
+                           getConnFactory(),
+                           getSetupParams(token),
+                           resumeManager,
+                           coldResumeHandler)
+                           .get();
+
+    firstSub->request(6);
+    secondSub->request(5);
+
+    // Create another stream to verify StreamIds are set properly after
+    // resumption
+    auto thirdSub = yarpl::make_ref<HelloSubscriber>();
+    thirdClient->getRequester()
+        ->requestStream(Payload(thirdPayload))
+        ->subscribe(thirdSub);
+    thirdSub->request(5);
+
+    getchar();
+  }
 
   return 0;
 }

--- a/rsocket/ColdResumeHandler.cpp
+++ b/rsocket/ColdResumeHandler.cpp
@@ -1,0 +1,43 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <folly/Conv.h>
+
+#include "rsocket/ColdResumeHandler.h"
+
+using namespace yarpl;
+using namespace yarpl::flowable;
+
+namespace {
+
+class CancelingSubscriber : public Subscriber<rsocket::Payload> {
+  void onSubscribe(Reference<Subscription> subscription) override {
+    Subscriber<rsocket::Payload>::onSubscribe(subscription);
+    Subscriber<rsocket::Payload>::subscription()->cancel();
+  }
+
+  void onNext(rsocket::Payload) override {}
+};
+}
+
+namespace rsocket {
+
+std::string ColdResumeHandler::generateStreamToken(
+    const Payload&,
+    StreamId streamId,
+    StreamType) {
+  return folly::to<std::string>(streamId);
+}
+
+Reference<Flowable<Payload>> ColdResumeHandler::handleResponderResumeStream(
+    std::string /* streamToken */,
+    uint32_t /* publisherAllowance */) {
+  return Flowables::error<Payload>(
+      std::logic_error("ResumeHandler method not implemented"));
+}
+
+Reference<Subscriber<Payload>> ColdResumeHandler::handleRequesterResumeStream(
+    std::string /* streamToken */,
+    uint32_t /* consumerAllowance */) {
+  return yarpl::make_ref<CancelingSubscriber>();
+}
+}

--- a/rsocket/ColdResumeHandler.h
+++ b/rsocket/ColdResumeHandler.h
@@ -2,7 +2,38 @@
 
 #pragma once
 
+#include "yarpl/Flowable.h"
+
+#include "rsocket/Payload.h"
+#include "rsocket/internal/Common.h"
+
 namespace rsocket {
 
-class ColdResumeHandler {};
+// This class has to be implemented by the client application for cold
+// resumption.  The default implementation will error/close the streams.
+class ColdResumeHandler {
+ public:
+  // Generate an application-aware streamToken for the given stream parameters.
+  virtual std::string generateStreamToken(const Payload&, StreamId, StreamType);
+
+  // This method will be called for each REQUEST_STREAM for which the
+  // application acted as a responder.  The default action would be to return a
+  // Flowable which errors out immediately.
+  // The second parameter is the allowance which the application received
+  // before cold-start and hasn't been fulfilled yet.
+  virtual yarpl::Reference<yarpl::flowable::Flowable<rsocket::Payload>>
+  handleResponderResumeStream(
+      std::string streamToken,
+      uint32_t publisherAllowance);
+
+  // This method will be called for each REQUEST_STREAM for which the
+  // application acted as a requester.  The default action would be to return a
+  // Subscriber which cancels the stream immediately after getting subscribed.
+  // The second parameter is the allowance which the application requested
+  // before cold-start and hasn't been fulfilled yet.
+  virtual yarpl::Reference<yarpl::flowable::Subscriber<rsocket::Payload>>
+  handleRequesterResumeStream(
+      std::string streamToken,
+      uint32_t consumerAllowance);
+};
 }

--- a/rsocket/RSocket.h
+++ b/rsocket/RSocket.h
@@ -35,7 +35,8 @@ class RSocket {
       SetupParameters setupParameters,
       std::shared_ptr<ResumeManager> resumeManager,
       std::shared_ptr<ColdResumeHandler> coldResumeHandler,
-      OnRSocketResume onRSocketResume,
+      OnRSocketResume onRSocketResume =
+          [](std::vector<StreamId>, std::vector<StreamId>) { return false; },
       std::shared_ptr<RSocketResponder> responder =
           std::make_shared<RSocketResponder>(),
       std::unique_ptr<KeepaliveTimer> keepaliveTimer =

--- a/rsocket/RSocketClient.cpp
+++ b/rsocket/RSocketClient.cpp
@@ -114,7 +114,10 @@ folly::Future<folly::Unit> RSocketClient::resume() {
     }
 
     stateMachine_->tryClientResume(
-        token_, std::move(frameTransport), std::move(resumeCallback));
+        token_,
+        std::move(frameTransport),
+        std::move(resumeCallback),
+        protocolVersion_);
   });
 
   return future;
@@ -168,7 +171,8 @@ void RSocketClient::createState(folly::EventBase& eventBase) {
       ReactiveSocketMode::CLIENT,
       std::move(stats_),
       std::move(connectionEvents_),
-      std::move(resumeManager_));
+      std::move(resumeManager_),
+      std::move(coldResumeHandler_));
 
   requester_ = std::make_shared<RSocketRequester>(stateMachine_, eventBase);
 

--- a/rsocket/RSocketClient.h
+++ b/rsocket/RSocketClient.h
@@ -60,10 +60,8 @@ class RSocketClient {
       std::shared_ptr<RSocketStats> stats = RSocketStats::noop(),
       std::shared_ptr<RSocketConnectionEvents> connectionEvents =
           std::shared_ptr<RSocketConnectionEvents>(),
-      std::shared_ptr<ResumeManager> resumeManager =
-          std::shared_ptr<ResumeManager>(),
-      std::shared_ptr<ColdResumeHandler> coldResumeHandler =
-          std::shared_ptr<ColdResumeHandler>(),
+      std::shared_ptr<ResumeManager> resumeManager = nullptr,
+      std::shared_ptr<ColdResumeHandler> coldResumeHandler = nullptr,
       OnRSocketResume onRSocketResume =
           [](std::vector<StreamId>, std::vector<StreamId>) { return false; });
 
@@ -93,7 +91,7 @@ class RSocketClient {
 
   // Remember the evb on which the client was created.  Ensure warme-resume()
   // operations are done on the same evb.
-  folly::EventBase* evb_;
+  folly::EventBase* evb_{nullptr};
 
   ProtocolVersion protocolVersion_;
   ResumeIdentificationToken token_;

--- a/rsocket/RSocketServer.cpp
+++ b/rsocket/RSocketServer.cpp
@@ -141,7 +141,8 @@ void RSocketServer::onRSocketSetup(
       ReactiveSocketMode::SERVER,
       std::move(connectionParams.stats),
       std::move(connectionParams.connectionEvents),
-      nullptr /* resumeManager */);
+      nullptr, /* resumeManager */
+      nullptr /* coldResumeHandler */);
   connectionManager_->manageConnection(rs, *eventBase);
   auto requester = std::make_shared<RSocketRequester>(rs, *eventBase);
   auto serverState = std::shared_ptr<RSocketServerState>(

--- a/rsocket/ResumeManager.h
+++ b/rsocket/ResumeManager.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <unordered_set>
+
 #include <folly/Optional.h>
 
 #include "rsocket/framing/Frame.h"
@@ -73,10 +75,43 @@ class ResumeManager {
   // remote side.
   virtual ResumePosition impliedPosition() const = 0;
 
-  // This gets called when a new stream is opened.
-  virtual void onStreamOpen(StreamId streamId, FrameType frameType) = 0;
-
   // This gets called when a stream is closed.
   virtual void onStreamClosed(StreamId streamId) = 0;
+
+  // Return the StreamIds of locally originating REQUEST_STREAMs
+  virtual std::unordered_set<StreamId> getRequesterRequestStreamIds() = 0;
+
+  // Get allowance for the given StreamId.  This is called for situations where
+  // the local side is a publisher (REQUEST_STREAM Responder and
+  // REQUEST_CHANNEL).  This should return the allowance which the local side
+  // has received and hasn't fulfilled yet.
+  virtual uint32_t getPublisherAllowance(StreamId) = 0;
+
+  // Get allowance for the given StreamId.  This is called for situations where
+  // the local side is a consumer (REQUEST_STREAM Requester and
+  // REQUEST_CHANNEL).  This should return the allowance which has been sent to
+  // the remote side and hasn't been fulfilled yet.
+  virtual uint32_t getConsumerAllowance(StreamId) = 0;
+
+  // Increment the publisher allowance to be preserved for the StreamId
+  virtual void incrPublisherAllowance(StreamId, uint32_t) = 0;
+
+  // Decrement the publisher allowance to be preserved for the StreamId
+  virtual void decrPublisherAllowance(StreamId, uint32_t) = 0;
+
+  // Increment the consumer allowance to be preserved for the StreamId
+  virtual void incrConsumerAllowance(StreamId, uint32_t) = 0;
+
+  // Decrement the consumer allowance to be preserved for the StreamId
+  virtual void decrConsumerAllowance(StreamId, uint32_t) = 0;
+
+  // Return the application-aware streamToken for the given StreamId
+  virtual std::string getStreamToken(StreamId) = 0;
+
+  // Save the application-aware streamToken for the given StreamId
+  virtual void saveStreamToken(StreamId, std::string streamToken) = 0;
+
+  // Returns the largest used StreamId so far.
+  virtual StreamId getLargestUsedStreamId() = 0;
 };
 }

--- a/rsocket/framing/Frame.cpp
+++ b/rsocket/framing/Frame.cpp
@@ -245,7 +245,8 @@ std::ostream& operator<<(std::ostream& os, const Frame_ERROR& frame) {
 
   std::ostream& operator<<(
       std::ostream& os, const Frame_REQUEST_STREAM& frame) {
-    return os << frame.header_ << ", " << frame.payload_;
+    return os << frame.header_ << ", initialRequestN=" << frame.requestN_
+              << ", " << frame.payload_;
   }
 
 } // namespace rsocket

--- a/rsocket/framing/FrameTransport.cpp
+++ b/rsocket/framing/FrameTransport.cpp
@@ -19,7 +19,7 @@ FrameTransport::FrameTransport(std::unique_ptr<DuplexConnection> connection)
 }
 
 FrameTransport::~FrameTransport() {
-  VLOG(6) << "~FrameTransport";
+  VLOG(1) << "~FrameTransport";
 }
 
 void FrameTransport::connect() {

--- a/rsocket/statemachine/StreamRequester.cpp
+++ b/rsocket/statemachine/StreamRequester.cpp
@@ -4,6 +4,12 @@
 
 namespace rsocket {
 
+void StreamRequester::setRequested(uint32_t n) {
+  VLOG(3) << "Setting allowance to " << n;
+  requested_ = true;
+  addImplicitAllowance(n);
+}
+
 void StreamRequester::request(int64_t n) noexcept {
   if (n == 0) {
     return;

--- a/rsocket/statemachine/StreamRequester.h
+++ b/rsocket/statemachine/StreamRequester.h
@@ -24,6 +24,8 @@ class StreamRequester : public ConsumerBase {
   explicit StreamRequester(const Base::Parameters& params, Payload payload)
       : Base(params), initialPayload_(std::move(payload)) {}
 
+  void setRequested(uint32_t n);
+
  private:
   // implementation from ConsumerBase::SubscriptionBase
   void request(int64_t) noexcept override;

--- a/rsocket/statemachine/StreamsFactory.cpp
+++ b/rsocket/statemachine/StreamsFactory.cpp
@@ -47,6 +47,18 @@ void StreamsFactory::createStreamRequester(
   stateMachine->subscribe(std::move(responseSink));
 }
 
+void StreamsFactory::createStreamRequester(
+    Reference<yarpl::flowable::Subscriber<Payload>> responseSink,
+    StreamId streamId,
+    uint32_t n) {
+  StreamRequester::Parameters params(connection_.shared_from_this(), streamId);
+  auto stateMachine = yarpl::make_ref<StreamRequester>(params, Payload());
+  // Set requested to true (since cold resumption)
+  stateMachine->setRequested(n);
+  connection_.addStream(params.streamId, stateMachine);
+  stateMachine->subscribe(std::move(responseSink));
+}
+
 void StreamsFactory::createRequestResponseRequester(
     Payload payload,
     Reference<yarpl::single::SingleObserver<Payload>> responseSink) {
@@ -63,6 +75,10 @@ StreamId StreamsFactory::getNextStreamId() {
   CHECK(streamId <= std::numeric_limits<int32_t>::max() - 2);
   nextStreamId_ += 2;
   return streamId;
+}
+
+void StreamsFactory::setNextStreamId(StreamId streamId) {
+  nextStreamId_ = streamId + 2;
 }
 
 bool StreamsFactory::registerNewPeerStreamId(StreamId streamId) {

--- a/rsocket/statemachine/StreamsFactory.h
+++ b/rsocket/statemachine/StreamsFactory.h
@@ -28,6 +28,11 @@ class StreamsFactory {
       Payload request,
       yarpl::Reference<yarpl::flowable::Subscriber<Payload>> responseSink);
 
+  void createStreamRequester(
+      yarpl::Reference<yarpl::flowable::Subscriber<Payload>> responseSink,
+      StreamId streamId,
+      uint32_t n);
+
   void createRequestResponseRequester(
       Payload payload,
       yarpl::Reference<yarpl::single::SingleObserver<Payload>> responseSink);
@@ -47,6 +52,8 @@ class StreamsFactory {
 
   bool registerNewPeerStreamId(StreamId streamId);
   StreamId getNextStreamId();
+
+  void setNextStreamId(StreamId streamId);
 
  private:
   RSocketStateMachine& connection_;


### PR DESCRIPTION
This PR has cold-resumption using the new RSocket API.

It currently implements resumption only for one use case - `REQUEST_STREAM` initiated by the client.  All the other use-cases should be easy to extend to and I will do them in subsequent PRs.

All the changes are on client side. The implementation is inline with the protocol spec and the resumption design doc.

Notes:
- Allowances are being persisted and they get communicated to the application on resumption.  The allowances are bidirectional, so it should work with `REQUEST_CHANNEL` as well.  It is up to the application to use the unfulfilled allowance information after resumption.
- The default `ColdResumeHandler` behavior would be to error-out/close the streams on resumption.
- Previously, `RSocketStateMachine` used to close streams in `ResumeManager` on destruction.  Now this happens only when a stream is explicitly closed.
- The resumption code in `RSocketStateMachine::handleConnectionFrame` will be moved to a separate method once we start adding resumption code for other stream types.
- The protocol implementation calling `onRSocketResume` will be added in subsequent PRs.
- This modifies the `InMemResumeManager`, which adds a slight overhead for regular use-case.   I will pull the new methods into a subclass of InMemResumeManager.  Then InMemResumeManager can be used as it is now.  The new subclass will serve as a prototype for in-memory ResumeManager for cold-resumption.  I will do this in a separate PR.


Testing:
- This PR has a sample cold-resumption client.  The client cold resumes twice and has three streams which are active across the three sessions in different ways.  I will add integration tests in a separate PR.
- It involves creating streams after resumption, to verify StreamId gets persisted properly.
- The example uses initialPayload as streamToken for resumption.
- It has a simple `ColdResumeHandler` which has a stored map of `Subscribers`


```
 RSocketStateMachine.cpp:56] Creating RSocketStateMachine
 RSocketStateMachine.cpp:916] Out: SETUP[RESUME_ENABLE, 0], Version: 1.0, Metadata(0): <null>, Data(0): <null>
 RSocketStateMachine.h:156] Out: REQUEST_STREAM[0x00, 1], initialRequestN=7, Metadata(0): <null>, Data(5): 'First'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(14): 'Hello First 1!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(14): 'Hello First 2!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(14): 'Hello First 3!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(14): 'Hello First 4!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(14): 'Hello First 5!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(14): 'Hello First 6!'
 ColdResumption_Client.cpp:134] ============== First Cold Resumption ================
 RSocketStateMachine.cpp:56] Creating RSocketStateMachine
 RSocketStateMachine.cpp:757] Out: RESUME[0x00, 0], (token, @server 186, @client 0)
 RSocketStateMachine.cpp:472] In: RESUME_OK[0x00, 0], (@15)
 ColdResumption_Client.cpp:68] Resuming First stream with allowance 1
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(14): 'Hello First 7!'
 RSocketStateMachine.h:156] Out: REQUEST_N[0x00, 1](3)
 RSocketStateMachine.h:156] Out: REQUEST_STREAM[0x00, 3], initialRequestN=5, Metadata(0): <null>, Data(6): 'Second'
 RSocketStateMachine.h:156] Out: REQUEST_N[0x00, 1](4)
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(14): 'Hello First 8!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(14): 'Hello First 9!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(15): 'Hello First 10!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 3], Metadata(8): 'metadata', Data(15): 'Hello Second 1!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 3], Metadata(8): 'metadata', Data(15): 'Hello Second 2!'
ColdResumption_Client.cpp:162] ============== Second Cold Resumption ================
 RSocketStateMachine.cpp:56] Creating RSocketStateMachine
 RSocketStateMachine.cpp:757] Out: RESUME[0x00, 0], (token, @server 375, @client 0)
 RSocketStateMachine.cpp:472] In: RESUME_OK[0x00, 0], (@51)
 ColdResumption_Client.cpp:68] Resuming First stream with allowance 4
 ColdResumption_Client.cpp:68] Resuming Second stream with allowance 3
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 3], Metadata(8): 'metadata', Data(15): 'Hello Second 3!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 3], Metadata(8): 'metadata', Data(15): 'Hello Second 4!'
 RSocketStateMachine.h:156] Out: REQUEST_N[0x00, 1](6)
 RSocketStateMachine.h:156] Out: REQUEST_N[0x00, 3](5)
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 3], Metadata(8): 'metadata', Data(15): 'Hello Second 5!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(15): 'Hello First 11!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(15): 'Hello First 12!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(15): 'Hello First 13!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(15): 'Hello First 14!'
 RSocketStateMachine.h:156] Out: REQUEST_STREAM[0x00, 5], initialRequestN=5, Metadata(0): <null>, Data(5): 'Third'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(15): 'Hello First 15!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(15): 'Hello First 16!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(15): 'Hello First 17!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(15): 'Hello First 18!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(15): 'Hello First 19!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 1], Metadata(8): 'metadata', Data(15): 'Hello First 20!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 3], Metadata(8): 'metadata', Data(15): 'Hello Second 6!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 3], Metadata(8): 'metadata', Data(15): 'Hello Second 7!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 3], Metadata(8): 'metadata', Data(15): 'Hello Second 8!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 3], Metadata(8): 'metadata', Data(15): 'Hello Second 9!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 3], Metadata(8): 'metadata', Data(16): 'Hello Second 10!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 5], Metadata(8): 'metadata', Data(14): 'Hello Third 1!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 5], Metadata(8): 'metadata', Data(14): 'Hello Third 2!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 5], Metadata(8): 'metadata', Data(14): 'Hello Third 3!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 5], Metadata(8): 'metadata', Data(14): 'Hello Third 4!'
 RSocketStateMachine.cpp:593] In: PAYLOAD[METADATA|NEXT, 5], Metadata(8): 'metadata', Data(14): 'Hello Third 5!'
 RSocketStateMachine.cpp:728] Out: KEEPALIVE[KEEPALIVE_RESPOND, 0](<0>)
 RSocketStateMachine.cpp:440] In: KEEPALIVE[0x00, 0](<0>)
 RSocketStateMachine.cpp:728] Out: KEEPALIVE[KEEPALIVE_RESPOND, 0](<0>)
 RSocketStateMachine.cpp:440] In: KEEPALIVE[0x00, 0](<0>)
```
