### PR TITLE
integration tests for request/response

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ if (RSOCKET_BUILD_WITH_COVERAGE)
   endif ()
 
   if (CMAKE_COMPILER_IS_GNUCXX)
-    add_compile_options(--coverage -g)
+    add_compile_options(-g -O0 --coverage)
     set(EXTRA_LINK_FLAGS ${EXTRA_LINK_FLAGS} --coverage)
 
   elseif (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
@@ -415,6 +415,7 @@ add_executable(
   test/internal/FollyKeepaliveTimerTest.cpp
   test/internal/SwappableEventBaseTest.cpp
   test/internal/SetupResumeAcceptorTest.cpp
+  test/test_utils/GenericRequestResponseHandler.h
   test/test_utils/MockDuplexConnection.h
   test/test_utils/MockKeepaliveTimer.h
   test/test_utils/MockRequestHandler.h

--- a/rsocket/Payload.cpp
+++ b/rsocket/Payload.cpp
@@ -47,18 +47,35 @@ std::ostream& operator<<(std::ostream& os, const Payload& payload) {
                     : "): <null>");
 }
 
-std::string Payload::moveDataToString() {
-  if (!data) {
+static std::string moveIOBufToString(std::unique_ptr<folly::IOBuf> iobuf) {
+  if (!iobuf) {
     return "";
   }
-  return data->moveToFbString().toStdString();
+  return iobuf->moveToFbString().toStdString();
+}
+
+static std::string cloneIOBufToString(
+    std::unique_ptr<folly::IOBuf> const& iobuf) {
+  if (!iobuf) {
+    return "";
+  }
+  return iobuf->cloneAsValue().moveToFbString().toStdString();
+}
+
+std::string Payload::moveDataToString() {
+  return moveIOBufToString(std::move(data));
 }
 
 std::string Payload::cloneDataToString() const {
-  if (!data) {
-    return "";
-  }
-  return data->cloneAsValue().moveToFbString().toStdString();
+  return cloneIOBufToString(data);
+}
+
+std::string Payload::moveMetadataToString() {
+  return moveIOBufToString(std::move(metadata));
+}
+
+std::string Payload::cloneMetadataToString() const {
+  return cloneIOBufToString(metadata);
 }
 
 void Payload::clear() {

--- a/rsocket/Payload.h
+++ b/rsocket/Payload.h
@@ -32,6 +32,10 @@ struct Payload {
 
   std::string moveDataToString();
   std::string cloneDataToString() const;
+
+  std::string moveMetadataToString();
+  std::string cloneMetadataToString() const;
+
   void clear();
 
   Payload clone() const;

--- a/test/test_utils/GenericRequestResponseHandler.h
+++ b/test/test_utils/GenericRequestResponseHandler.h
@@ -1,0 +1,94 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+// #include "RSocketTests.h"
+#include "yarpl/Single.h"
+
+#include "folly/ExceptionWrapper.h"
+
+using namespace yarpl;
+using namespace yarpl::single;
+using namespace rsocket;
+using namespace rsocket::tests;
+using namespace rsocket::tests::client_server;
+
+namespace rsocket {
+namespace tests {
+
+using StringPair = std::pair<std::string, std::string>;
+
+inline std::ostream& operator<<(std::ostream& os, StringPair const& payload) {
+  return os << "('" << payload.first << "', '" << payload.second << "')";
+}
+
+struct ResponseImpl {
+  enum class Type { PAYLOAD, EXCEPTION };
+
+  StringPair p;
+  std::exception_ptr e;
+  Type type;
+
+  explicit ResponseImpl(StringPair const& p) : p(p), type(Type::PAYLOAD) {}
+  explicit ResponseImpl(std::exception_ptr const& e)
+      : e(e), type(Type::EXCEPTION) {}
+
+  ~ResponseImpl() {}
+};
+
+using Response = std::unique_ptr<ResponseImpl>;
+
+// Type that maps a request (data/metadata) to a response
+// (data/metadata or exception)
+using HandlerFunc = folly::Function<Response(StringPair const&)>;
+
+struct GenericRequestResponseHandler : public rsocket::RSocketResponder {
+  GenericRequestResponseHandler(HandlerFunc&& func)
+      : handler_(std::make_unique<HandlerFunc>(std::move(func))) {}
+
+  Reference<Single<Payload>> handleRequestResponse(Payload request, StreamId)
+      override {
+    auto data = request.moveDataToString();
+    auto meta = request.moveMetadataToString();
+
+    StringPair req(data, meta);
+    Response resp = (*handler_)(req);
+
+    return Single<Payload>::create(
+        [ resp = std::move(resp), this ](auto subscriber) {
+          subscriber->onSubscribe(SingleSubscriptions::empty());
+
+          if (resp->type == ResponseImpl::Type::PAYLOAD) {
+            subscriber->onSuccess(Payload(resp->p.first, resp->p.second));
+          } else if (resp->type == ResponseImpl::Type::EXCEPTION) {
+            subscriber->onError(resp->e);
+          } else {
+            throw std::runtime_error("unknown response type");
+          }
+        });
+  }
+
+  ~GenericRequestResponseHandler() {}
+
+ private:
+  std::unique_ptr<HandlerFunc> handler_;
+};
+
+Response payload_response(StringPair const& sp) {
+  return std::make_unique<ResponseImpl>(sp);
+}
+
+Response payload_response(std::string const& a, std::string const& b) {
+  return payload_response({a, b});
+}
+
+template <typename T>
+Response error_response(T const& err) {
+  return std::make_unique<ResponseImpl>(std::make_exception_ptr(err));
+}
+
+StringPair payload_to_stringpair(Payload p) {
+  return StringPair(p.moveDataToString(), p.moveMetadataToString());
+}
+}
+} /* namespace rsocket::tests */

--- a/yarpl/include/yarpl/single/SingleOperator.h
+++ b/yarpl/include/yarpl/single/SingleOperator.h
@@ -65,6 +65,7 @@ class SingleOperator : public Single<D> {
     void onError(std::exception_ptr error) override {
       observer_->onError(error);
       upstreamSubscription_.reset(); // should break the cycle to this
+      observer_.reset();
     }
 
     void cancel() override {


### PR DESCRIPTION
Immediate failure on the requester side (eg the server has shut down) is broken, so the test is disabled. 

Also implements a "generic" request/response handler, so one-off classes don't need to be defined for each integration test. 