### PR TITLE
Improvements on the stream benchmark

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -18,3 +18,5 @@ function(make_folly_benchmark NAME FILE)
 endfunction()
 
 make_folly_benchmark(streamthroughput StreamThroughput.cpp)
+
+add_test(NAME StreamThroughputTest COMMAND streamthroughput --items 100000)


### PR DESCRIPTION
* Use a gflag to control the number of items to send.  Much easier to profile,
  and configurable so we can run it as a test as part of Travis.

* Get rid of the yield logic.  Have the subscriber cancel the subscription once
  it hits the number of requested items.

* Replace mutex+condvar+bool with folly::Baton.

* Delete BM_Subscription, it was unused.