### PR TITLE
Fixing flint errors

### DIFF
--- a/rsocket/ColdResumeHandler.cpp
+++ b/rsocket/ColdResumeHandler.cpp
@@ -1,25 +1,25 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-#include <folly/Conv.h>
-
 #include "rsocket/ColdResumeHandler.h"
+
+#include <folly/Conv.h>
 
 using namespace yarpl;
 using namespace yarpl::flowable;
 
+namespace rsocket {
+
 namespace {
 
-class CancelingSubscriber : public Subscriber<rsocket::Payload> {
+class CancelingSubscriber : public Subscriber<Payload> {
   void onSubscribe(Reference<Subscription> subscription) override {
-    Subscriber<rsocket::Payload>::onSubscribe(subscription);
-    Subscriber<rsocket::Payload>::subscription()->cancel();
+    Subscriber<Payload>::onSubscribe(subscription);
+    Subscriber<Payload>::subscription()->cancel();
   }
 
-  void onNext(rsocket::Payload) override {}
+  void onNext(Payload) override {}
 };
 }
-
-namespace rsocket {
 
 std::string ColdResumeHandler::generateStreamToken(
     const Payload&,

--- a/rsocket/ColdResumeHandler.h
+++ b/rsocket/ColdResumeHandler.h
@@ -13,6 +13,8 @@ namespace rsocket {
 // resumption.  The default implementation will error/close the streams.
 class ColdResumeHandler {
  public:
+  virtual ~ColdResumeHandler() = default;
+
   // Generate an application-aware streamToken for the given stream parameters.
   virtual std::string generateStreamToken(const Payload&, StreamId, StreamType);
 


### PR DESCRIPTION
* ColdResumeHandler missing virtual dtor and .cpp file not including .h as first
  file.

* GenericRequestResponseHandler missing `explicit` on single-arg ctor, and doing
  `using namespace foo` in a header.  Had to move the operator<< out of
  `rsocket::tests` as clang was having trouble finding it.