### PR TITLE
Fix extraneous semi-colon in ResumeManager

### DIFF
--- a/rsocket/ResumeManager.h
+++ b/rsocket/ResumeManager.h
@@ -27,7 +27,7 @@ namespace rsocket {
 // - lastSentPosition() would return 350
 class ResumeManager {
  public:
-  virtual ~ResumeManager(){};
+  virtual ~ResumeManager() {}
 
   // The following methods will be called for each frame which is being
   // sent/received on the wire.  The application should implement a way to


### PR DESCRIPTION
-Wextra-semi should be supported by gcc and clang, so it's fine to set for all
 builds.