### PR TITLE
Fuzzer harness for rsocket server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,25 @@ add_dependencies(tests gmock ReactiveSocket)
 
 add_test(NAME ReactiveSocketTests COMMAND tests)
 
+### Fuzzer harnesses
+add_executable(
+  frame_fuzzer
+  test/fuzzers/frame_fuzzer.cpp)
+
+target_link_libraries(
+  frame_fuzzer
+  ReactiveSocket
+  yarpl
+  ${GFLAGS_LIBRARY}
+  ${GLOG_LIBRARY})
+
+add_dependencies(frame_fuzzer gmock ReactiveSocket)
+
+add_test(
+  NAME FrameFuzzerTests
+  COMMAND ./scripts/frame_fuzzer_test.sh
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
 ########################################
 # TCK Drivers
 ########################################

--- a/scripts/frame_fuzzer_test.sh
+++ b/scripts/frame_fuzzer_test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [ ! -s ./build/frame_fuzzer ]; then
+    echo "./build/frame_fuzzer binary not found!"
+    exit 1
+fi
+
+shopt -s nullglob
+for fuzzcase in ./test/fuzzer_testcases/frame_fuzzer/*; do
+  echo "testing with $fuzzcase..."
+  ./build/frame_fuzzer --v=100 < $fuzzcase
+done

--- a/test/fuzzers/frame_fuzzer.cpp
+++ b/test/fuzzers/frame_fuzzer.cpp
@@ -1,0 +1,120 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+#include <folly/String.h>
+#include <folly/io/async/EventBaseManager.h>
+#include <iostream>
+
+#include <folly/init/Init.h>
+#include <folly/portability/GFlags.h>
+#include <glog/logging.h>
+
+#include "rsocket/ConnectionAcceptor.h"
+#include "rsocket/DuplexConnection.h"
+#include "rsocket/RSocketServer.h"
+
+struct FuzzerConnectionAcceptor : rsocket::ConnectionAcceptor {
+  void start(rsocket::OnDuplexConnectionAccept func_) override {
+    VLOG(1) << "FuzzerConnectionAcceptor::start()" << std::endl;
+    func = func_;
+  }
+
+  void stop() override {
+    VLOG(1) << "FuzzerConnectionAcceptor::stop()" << std::endl;
+  }
+
+  folly::Optional<uint16_t> listeningPort() const override {
+    return 0;
+  }
+
+  rsocket::OnDuplexConnectionAccept func;
+};
+
+struct FuzzerDuplexConnection : rsocket::DuplexConnection {
+  using Subscriber = rsocket::DuplexConnection::Subscriber;
+
+  struct SinkSubscriber : Subscriber {
+    std::vector<std::unique_ptr<folly::IOBuf>> sent_buffers;
+
+    void onNext(std::unique_ptr<folly::IOBuf> buf) {
+      VLOG(1) << "SinkSubscriber::onNext(\""
+              << folly::humanify(buf->cloneAsValue().moveToFbString()) << "\")"
+              << std::endl;
+      sent_buffers.push_back(std::move(buf));
+    }
+  };
+
+  FuzzerDuplexConnection() : output_sub(yarpl::make_ref<SinkSubscriber>()) {}
+
+  virtual void setInput(yarpl::Reference<Subscriber> sub) {
+    VLOG(1) << "FuzzerDuplexConnection::setInput()" << std::endl;
+    input_sub = sub;
+  }
+  virtual yarpl::Reference<Subscriber> getOutput() {
+    VLOG(1) << "FuzzerDuplexConnection::getOutput()" << std::endl;
+    return output_sub;
+  }
+
+  yarpl::Reference<Subscriber> input_sub;
+  yarpl::Reference<Subscriber> output_sub;
+};
+
+struct NoopSubscription : yarpl::flowable::Subscription {
+  void request(int64_t n) override {
+    VLOG(1) << "NoopSubscription::request(" << n << ")";
+  }
+  void cancel() override {
+    VLOG(1) << "NoopSubscription::cancel()";
+  }
+};
+
+struct NoopResponder : rsocket::RSocketResponder {};
+
+std::string get_stdin() {
+  std::cin >> std::noskipws;
+  std::istream_iterator<char> it(std::cin);
+  std::istream_iterator<char> end;
+  std::string input(it, end);
+  return input;
+}
+
+int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv);
+  FLAGS_logtostderr = 1;
+
+  folly::EventBase evb;
+  folly::EventBaseManager::get()->setEventBase(&evb, false);
+
+  auto feed_conn = std::make_unique<FuzzerDuplexConnection>();
+  auto acceptor = std::make_unique<FuzzerConnectionAcceptor>();
+
+  // grab references while we still own the duplex connection
+  auto& input_sub = feed_conn->input_sub;
+  auto& output_sub = feed_conn->output_sub;
+  auto& acceptor_func_ptr = acceptor->func;
+
+  rsocket::RSocketServer server(std::move(acceptor));
+
+  auto responder = std::make_shared<NoopResponder>();
+  server.start(
+      [responder](const rsocket::SetupParameters&) { return responder; });
+
+  CHECK(acceptor_func_ptr);
+  acceptor_func_ptr(std::move(feed_conn), evb);
+  evb.loopOnce();
+
+  CHECK(input_sub);
+  CHECK(output_sub);
+  auto input_subscription = yarpl::make_ref<NoopSubscription>();
+  input_sub->onSubscribe(input_subscription);
+
+  std::string fuzz_input = get_stdin();
+  std::unique_ptr<folly::IOBuf> buf =
+      folly::IOBuf::wrapBuffer(fuzz_input.c_str(), fuzz_input.size());
+
+  VLOG(1) << "fuzz input: " << std::endl;
+  VLOG(1) << folly::humanify(buf->cloneAsValue().moveToFbString()) << std::endl;
+
+  input_sub->onNext(std::move(buf));
+  evb.loopOnce();
+
+  return 0;
+}


### PR DESCRIPTION
A harness for end-to-end testing rsocketserver (aside from any TCP specific stuff); implements a dummy duplex connection fed with input from afl-fuzz (although other fuzzers could be hooked up pretty easily). Reads input fuzzing/test cases from stdin. 

Rsocket/the harness is built like:   
 - `env CC=~/afl-2.49b/afl-gcc CXX=~/afl-2.49b/afl-g++ cmake -DCMAKE_BUILD_TYPE=Debug -DRSOCKET_ASAN=Off ......`
 - `env AFL_HARDEN=1 make -j8 frame_fuzzer`

I highly recommend setting up a Linux virtual machine rather than running this on macOS, AFL runs incredibly slow under macOS.

It's found a few cases so far, mostly segfaults; still triaging to figure out if they're actually interesting or not. 