### PR TITLE
Adding keepalive events to RSocketStats

### DIFF
--- a/rsocket/RSocketStats.cpp
+++ b/rsocket/RSocketStats.cpp
@@ -27,6 +27,9 @@ class NoopStats : public RSocketStats {
   void resumeBufferChanged(int, int) override {}
   void streamBufferChanged(int64_t, int64_t) override {}
 
+  void keepaliveSent() override {}
+  void keepaliveReceived() override {}
+
   static std::shared_ptr<NoopStats> instance() {
     static auto singleton = std::make_shared<NoopStats>();
     return singleton;

--- a/rsocket/RSocketStats.h
+++ b/rsocket/RSocketStats.h
@@ -38,5 +38,8 @@ class RSocketStats {
   virtual void streamBufferChanged(
       int64_t framesCountDelta,
       int64_t dataSizeDelta) = 0;
+
+  virtual void keepaliveSent() = 0;
+  virtual void keepaliveReceived() = 0;
 };
 }

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -452,6 +452,7 @@ void RSocketStateMachine::handleConnectionFrame(
         } else if (keepaliveTimer_) {
           keepaliveTimer_->keepaliveReceived();
         }
+        stats_->keepaliveReceived();
       }
       return;
     }
@@ -727,6 +728,7 @@ void RSocketStateMachine::sendKeepalive(
   VLOG(3) << "Out: " << pingFrame;
   outputFrameOrEnqueue(
       frameSerializer_->serializeOut(std::move(pingFrame), remoteResumeable_));
+  stats_->keepaliveSent();
 }
 
 void RSocketStateMachine::tryClientResume(

--- a/test/test_utils/StatsPrinter.cpp
+++ b/test/test_utils/StatsPrinter.cpp
@@ -57,4 +57,12 @@ void StatsPrinter::streamBufferChanged(
   LOG(INFO) << "streamBufferChanged framesCountDelta=" << framesCountDelta
             << " dataSizeDelta=" << dataSizeDelta;
 }
+
+void StatsPrinter::keepaliveSent() {
+  LOG(INFO) << "keepalive sent";
+}
+
+void StatsPrinter::keepaliveReceived() {
+  LOG(INFO) << "keepalive response received";
+}
 }

--- a/test/test_utils/StatsPrinter.h
+++ b/test/test_utils/StatsPrinter.h
@@ -26,5 +26,8 @@ class StatsPrinter : public RSocketStats {
   void resumeBufferChanged(int framesCountDelta, int dataSizeDelta) override;
   void streamBufferChanged(int64_t framesCountDelta, int64_t dataSizeDelta)
       override;
+
+  void keepaliveSent() override;
+  void keepaliveReceived() override;
 };
 }


### PR DESCRIPTION
We would like to get notified about keepalive events to measure the latency for a keepalive roundtrip (and compare it to other protocols). This change adds a callback to the existing stats interface and calls it from the state machine upon sending and receiving such a frame.