### PR TITLE
Remove manual refcounting in FlowableOperator

### DIFF
--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -43,11 +43,6 @@ class FlowableOperator : public Flowable<D> {
         : flowable_(std::move(flowable)), subscriber_(std::move(subscriber)) {
       assert(flowable_);
       assert(subscriber_);
-
-      // We expect to be heap-allocated; until this subscription finishes (is
-      // canceled; completes; error's out), hold a reference so we are not
-      // deallocated (by the subscriber).
-      Refcounted::incRef(*this);
     }
 
     Reference<Operator> getFlowableOperator() {
@@ -151,8 +146,6 @@ class FlowableOperator : public Flowable<D> {
           }
         }
       }
-
-      Refcounted::decRef(*this);
     }
 
     /// The Flowable has the lambda, and other creation parameters.


### PR DESCRIPTION
Changes from #648 remove the need for manual refcounting to be done in FlowableOperator