### PR TITLE
Pass function objects by value and move them

### DIFF
--- a/yarpl/include/yarpl/Scheduler.h
+++ b/yarpl/include/yarpl/Scheduler.h
@@ -23,11 +23,11 @@ class Worker : public yarpl::Disposable {
   //          std::is_callable<F(), typename
   //          std::result_of<F()>::type>::value>::
   //          type>
-  //  virtual yarpl::Disposable schedule(F&&) = 0; // TODO can't do this, so how
+  //  virtual yarpl::Disposable schedule(F) = 0; // TODO can't do this, so how
   //  do we allow different impls?
 
   virtual std::unique_ptr<yarpl::Disposable> schedule(
-      std::function<void()>&&) = 0;
+      std::function<void()>) = 0;
 
   virtual void dispose() override = 0;
 

--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -184,9 +184,9 @@ class MapOperator : public FlowableOperator<U, D, MapOperator<U, D, F>> {
   using Super = FlowableOperator<U, D, ThisOperatorT>;
 
  public:
-  MapOperator(Reference<Flowable<U>> upstream, F&& function)
+  MapOperator(Reference<Flowable<U>> upstream, F function)
       : Super(std::move(upstream)),
-        function_(std::forward<F>(function)) {}
+        function_(std::move(function)) {}
 
   void subscribe(Reference<Subscriber<D>> subscriber) override {
     Super::upstream_->subscribe(make_ref<Subscription>(
@@ -223,9 +223,9 @@ class FilterOperator : public FlowableOperator<U, U, FilterOperator<U, F>> {
   using Super = FlowableOperator<U, U, ThisOperatorT>;
 
  public:
-  FilterOperator(Reference<Flowable<U>> upstream, F&& function)
+  FilterOperator(Reference<Flowable<U>> upstream, F function)
       : Super(std::move(upstream)),
-        function_(std::forward<F>(function)) {}
+        function_(std::move(function)) {}
 
   void subscribe(Reference<Subscriber<U>> subscriber) override {
     Super::upstream_->subscribe(make_ref<Subscription>(
@@ -267,9 +267,9 @@ class ReduceOperator : public FlowableOperator<U, D, ReduceOperator<U, D, F>> {
   using Super = FlowableOperator<U, D, ThisOperatorT>;
 
  public:
-  ReduceOperator(Reference<Flowable<U>> upstream, F&& function)
+  ReduceOperator(Reference<Flowable<U>> upstream, F function)
       : Super(std::move(upstream)),
-        function_(std::forward<F>(function)) {}
+        function_(std::move(function)) {}
 
   void subscribe(Reference<Subscriber<D>> subscriber) override {
     Super::upstream_->subscribe(make_ref<Subscription>(
@@ -505,7 +505,7 @@ class SubscribeOnOperator : public FlowableOperator<T, T, SubscribeOnOperator<T>
 template <typename T, typename OnSubscribe>
 class FromPublisherOperator : public Flowable<T> {
  public:
-  explicit FromPublisherOperator(OnSubscribe&& function)
+  explicit FromPublisherOperator(OnSubscribe function)
       : function_(std::move(function)) {}
 
   void subscribe(Reference<Subscriber<T>> subscriber) override {

--- a/yarpl/include/yarpl/flowable/Flowables.h
+++ b/yarpl/include/yarpl/flowable/Flowables.h
@@ -104,9 +104,9 @@ class Flowables {
       typename = typename std::enable_if<std::is_callable<
           OnSubscribe(Reference<Subscriber<T>>),
           void>::value>::type>
-  static Reference<Flowable<T>> fromPublisher(OnSubscribe&& function) {
+  static Reference<Flowable<T>> fromPublisher(OnSubscribe function) {
     return Reference<Flowable<T>>(new FromPublisherOperator<T, OnSubscribe>(
-        std::forward<OnSubscribe>(function)));
+        std::move(function)));
   }
 
   template <typename T>

--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -174,9 +174,9 @@ template <
     typename = typename std::enable_if<std::is_callable<F(U), D>::value>::type>
 class MapOperator : public ObservableOperator<U, D> {
  public:
-  MapOperator(Reference<Observable<U>> upstream, F&& function)
+  MapOperator(Reference<Observable<U>> upstream, F function)
       : ObservableOperator<U, D>(std::move(upstream)),
-        function_(std::forward<F>(function)) {}
+        function_(std::move(function)) {}
 
   void subscribe(Reference<Observer<D>> observer) override {
     ObservableOperator<U, D>::upstream_->subscribe(
@@ -212,9 +212,9 @@ template <
         typename std::enable_if<std::is_callable<F(U), bool>::value>::type>
 class FilterOperator : public ObservableOperator<U, U> {
  public:
-  FilterOperator(Reference<Observable<U>> upstream, F&& function)
+  FilterOperator(Reference<Observable<U>> upstream, F function)
       : ObservableOperator<U, U>(std::move(upstream)),
-        function_(std::forward<F>(function)) {}
+        function_(std::move(function)) {}
 
   void subscribe(Reference<Observer<U>> observer) override {
     ObservableOperator<U, U>::upstream_->subscribe(
@@ -253,9 +253,9 @@ template<
     typename = typename std::enable_if<std::is_callable<F(D, U), D>::value>::type>
 class ReduceOperator : public ObservableOperator<U, D> {
 public:
-  ReduceOperator(Reference<Observable<U>> upstream, F &&function)
+  ReduceOperator(Reference<Observable<U>> upstream, F function)
       : ObservableOperator<U, D>(std::move(upstream)),
-        function_(std::forward<F>(function)) {}
+        function_(std::move(function)) {}
 
   void subscribe(Reference<Observer<D>> subscriber) override {
     ObservableOperator<U, D>::upstream_->subscribe(
@@ -465,7 +465,7 @@ class SubscribeOnOperator : public ObservableOperator<T, T> {
 template <typename T, typename OnSubscribe>
 class FromPublisherOperator : public Observable<T> {
  public:
-  explicit FromPublisherOperator(OnSubscribe&& function)
+  explicit FromPublisherOperator(OnSubscribe function)
       : function_(std::move(function)) {}
 
   void subscribe(Reference<Observer<T>> observer) override {

--- a/yarpl/include/yarpl/observable/Observables.h
+++ b/yarpl/include/yarpl/observable/Observables.h
@@ -72,9 +72,9 @@ class Observables {
       typename = typename std::enable_if<
           std::is_callable<OnSubscribe(Reference<Observer<T>>), void>::value>::
           type>
-  static Reference<Observable<T>> create(OnSubscribe&& function) {
+  static Reference<Observable<T>> create(OnSubscribe function) {
     return Reference<Observable<T>>(new FromPublisherOperator<T, OnSubscribe>(
-        std::forward<OnSubscribe>(function)));
+        std::move(function)));
   }
 
   template <typename T>

--- a/yarpl/include/yarpl/observable/Subscriptions.h
+++ b/yarpl/include/yarpl/observable/Subscriptions.h
@@ -30,7 +30,7 @@ class AtomicBoolSubscription : public Subscription {
 */
 class CallbackSubscription : public Subscription {
  public:
-  explicit CallbackSubscription(std::function<void()>&& onCancel);
+  explicit CallbackSubscription(std::function<void()> onCancel);
   void cancel() override;
   bool isCancelled() const;
 

--- a/yarpl/include/yarpl/single/SingleObservers.h
+++ b/yarpl/include/yarpl/single/SingleObservers.h
@@ -27,9 +27,9 @@ class SingleObservers {
 
  public:
   template <typename T, typename Next, typename = EnableIfCompatible<T, Next>>
-  static auto create(Next&& next) {
+  static auto create(Next next) {
     return Reference<SingleObserver<T>>(
-        new Base<T, Next>(std::forward<Next>(next)));
+        new Base<T, Next>(std::move(next)));
   }
 
   template <
@@ -37,16 +37,16 @@ class SingleObservers {
       typename Success,
       typename Error,
       typename = EnableIfCompatible<T, Success, Error>>
-  static auto create(Success&& next, Error&& error) {
+  static auto create(Success next, Error error) {
     return Reference<SingleObserver<T>>(new WithError<T, Success, Error>(
-        std::forward<Success>(next), std::forward<Error>(error)));
+        std::move(next), std::move(error)));
   }
 
  private:
   template <typename T, typename Next>
   class Base : public SingleObserver<T> {
    public:
-    explicit Base(Next&& next) : next_(std::forward<Next>(next)) {}
+    explicit Base(Next next) : next_(std::move(next)) {}
 
     void onSuccess(T value) override {
       next_(std::move(value));
@@ -61,8 +61,8 @@ class SingleObservers {
   template <typename T, typename Success, typename Error>
   class WithError : public Base<T, Success> {
    public:
-    WithError(Success&& next, Error&& error)
-        : Base<T, Success>(std::forward<Success>(next)), error_(error) {}
+    WithError(Success next, Error error)
+        : Base<T, Success>(std::move(next)), error_(std::move(error)) {}
 
     void onError(std::exception_ptr error) override {
       error_(error);

--- a/yarpl/include/yarpl/single/SingleOperator.h
+++ b/yarpl/include/yarpl/single/SingleOperator.h
@@ -103,8 +103,8 @@ class MapOperator : public SingleOperator<U, D> {
   using OperatorSubscription = typename Super::template Subscription<ThisOperatorT>;
 
  public:
-  MapOperator(Reference<Single<U>> upstream, F&& function)
-      : Super(std::move(upstream)), function_(std::forward<F>(function)) {}
+  MapOperator(Reference<Single<U>> upstream, F function)
+      : Super(std::move(upstream)), function_(std::move(function)) {}
 
   void subscribe(Reference<SingleObserver<D>> observer) override {
     Super::upstream_->subscribe(
@@ -133,7 +133,7 @@ class MapOperator : public SingleOperator<U, D> {
 template <typename T, typename OnSubscribe>
 class FromPublisherOperator : public Single<T> {
  public:
-  explicit FromPublisherOperator(OnSubscribe&& function)
+  explicit FromPublisherOperator(OnSubscribe function)
       : function_(std::move(function)) {}
 
   void subscribe(Reference<SingleObserver<T>> observer) override {

--- a/yarpl/include/yarpl/single/SingleSubscriptions.h
+++ b/yarpl/include/yarpl/single/SingleSubscriptions.h
@@ -33,7 +33,7 @@ class AtomicBoolSingleSubscription : public SingleSubscription {
 */
 class CallbackSingleSubscription : public SingleSubscription {
  public:
-  explicit CallbackSingleSubscription(std::function<void()>&& onCancel)
+  explicit CallbackSingleSubscription(std::function<void()> onCancel)
       : onCancel_(std::move(onCancel)) {}
   void cancel() override {
     bool expected = false;

--- a/yarpl/include/yarpl/single/Singles.h
+++ b/yarpl/include/yarpl/single/Singles.h
@@ -26,9 +26,9 @@ class Singles {
       typename = typename std::enable_if<std::is_callable<
           OnSubscribe(Reference<SingleObserver<T>>),
           void>::value>::type>
-  static Reference<Single<T>> create(OnSubscribe&& function) {
+  static Reference<Single<T>> create(OnSubscribe function) {
     return Reference<Single<T>>(new FromPublisherOperator<T, OnSubscribe>(
-        std::forward<OnSubscribe>(function)));
+        std::move(function)));
   }
 
   template <typename T>

--- a/yarpl/src/yarpl/observable/Subscriptions.cpp
+++ b/yarpl/src/yarpl/observable/Subscriptions.cpp
@@ -21,7 +21,7 @@ bool AtomicBoolSubscription::isCancelled() const {
 /**
  * Implementation that gets a callback when cancellation occurs.
  */
-CallbackSubscription::CallbackSubscription(std::function<void()>&& onCancel)
+CallbackSubscription::CallbackSubscription(std::function<void()> onCancel)
     : onCancel_(std::move(onCancel)) {}
 
 void CallbackSubscription::cancel() {

--- a/yarpl/src/yarpl/schedulers/ThreadScheduler.cpp
+++ b/yarpl/src/yarpl/schedulers/ThreadScheduler.cpp
@@ -31,7 +31,7 @@ class ADisposable : public yarpl::Disposable {
 class ThreadWorker : public Worker {
  public:
   std::unique_ptr<yarpl::Disposable> schedule(
-      std::function<void()>&& task) override {
+      std::function<void()> task) override {
     std::thread([task = std::move(task)]() { task(); }).detach();
     return std::make_unique<ADisposable>();
   }


### PR DESCRIPTION
I have had crashes when I tried to use Single in multithreaded environment. With debugging and testing, I saw that if we don't do perfect forwarding properly we lose objects (the function pointer objects.

So I have replaced this code in Single.h
```
  void subscribe(Success&& next) {
    subscribe(SingleObservers::create<T>(next));
  }
```

with this
```
  void subscribe(Success next) {
    subscribe(SingleObservers::create<T>(std::move(next)));
  }
```
and it fixed the crash!

So I have applied the same to all locations where std::forward should have been used.

