### PR TITLE
`M-x clang-format-buffer` on a few files

### DIFF
--- a/benchmarks/StreamThroughput.cpp
+++ b/benchmarks/StreamThroughput.cpp
@@ -104,7 +104,8 @@ std::unique_ptr<RSocketServer> makeServer(folly::SocketAddress address) {
 std::shared_ptr<RSocketClient> makeClient(
     folly::EventBase* eventBase,
     folly::SocketAddress address) {
-  auto factory = std::make_unique<TcpConnectionFactory>(*eventBase, std::move(address));
+  auto factory =
+      std::make_unique<TcpConnectionFactory>(*eventBase, std::move(address));
   return RSocket::createConnectedClient(std::move(factory)).get();
 }
 
@@ -118,7 +119,8 @@ BENCHMARK(StreamThroughput, n) {
   BENCHMARK_SUSPEND {
     LOG(INFO) << "  Running with " << FLAGS_items << " items";
 
-    folly::SocketAddress address{FLAGS_host, static_cast<uint16_t>(FLAGS_port),
+    folly::SocketAddress address{FLAGS_host,
+                                 static_cast<uint16_t>(FLAGS_port),
                                  true /* allowNameLookup */};
     server = makeServer(std::move(address));
 

--- a/examples/resumption/WarmResumption_Client.cpp
+++ b/examples/resumption/WarmResumption_Client.cpp
@@ -75,9 +75,10 @@ std::shared_ptr<RSocketClient> getClientAndRequestStream(
   SetupParameters setupParameters;
   setupParameters.resumable = true;
   auto client = RSocket::createConnectedClient(
-      std::make_unique<TcpConnectionFactory>(*eventBase, std::move(address)),
-      std::move(setupParameters))
-      .get();
+                    std::make_unique<TcpConnectionFactory>(
+                        *eventBase, std::move(address)),
+                    std::move(setupParameters))
+                    .get();
   client->getRequester()->requestStream(Payload("Jane"))->subscribe(subscriber);
   return client;
 }
@@ -124,7 +125,8 @@ int main(int argc, char* argv[]) {
         }
         // Create a new client
         auto subscriber2 = yarpl::make_ref<HelloSubscriber>();
-        auto client = getClientAndRequestStream(worker1.getEventBase(), subscriber2);
+        auto client =
+            getClientAndRequestStream(worker1.getEventBase(), subscriber2);
         subscriber2->request(7);
         while (subscriber2->rcvdCount() < 7) {
           std::this_thread::yield();

--- a/rsocket/transports/tcp/TcpConnectionFactory.cpp
+++ b/rsocket/transports/tcp/TcpConnectionFactory.cpp
@@ -18,7 +18,8 @@ class ConnectCallback : public folly::AsyncSocket::ConnectCallback {
  public:
   ConnectCallback(
       folly::SocketAddress address,
-      folly::Promise<ConnectionFactory::ConnectedDuplexConnection> connectPromise)
+      folly::Promise<ConnectionFactory::ConnectedDuplexConnection>
+          connectPromise)
       : address_(address), connectPromise_{std::move(connectPromise)} {
     VLOG(2) << "Constructing ConnectCallback";
 
@@ -69,8 +70,7 @@ class ConnectCallback : public folly::AsyncSocket::ConnectCallback {
 TcpConnectionFactory::TcpConnectionFactory(
     folly::EventBase& eventBase,
     folly::SocketAddress address)
-    : address_{std::move(address)},
-      eventBase_{&eventBase}{
+    : address_{std::move(address)}, eventBase_{&eventBase} {
   VLOG(1) << "Constructing TcpConnectionFactory";
 }
 
@@ -95,7 +95,8 @@ std::unique_ptr<DuplexConnection>
 TcpConnectionFactory::createDuplexConnectionFromSocket(
     folly::AsyncSocket::UniquePtr socket,
     std::shared_ptr<RSocketStats> stats) {
-  return std::make_unique<TcpDuplexConnection>(std::move(socket), std::move(stats));
+  return std::make_unique<TcpDuplexConnection>(
+      std::move(socket), std::move(stats));
 }
 
 } // namespace rsocket

--- a/tck-test/TestInterpreter.cpp
+++ b/tck-test/TestInterpreter.cpp
@@ -93,11 +93,11 @@ void TestInterpreter::handleSubscribe(const SubscribeCommand& command) {
     if (test_.resumption()) {
       setupParameters.resumable = true;
     }
-    auto client =
-        RSocket::createConnectedClient(
-            std::make_unique<TcpConnectionFactory>(*worker_.getEventBase(), std::move(address_)),
-            std::move(setupParameters))
-            .get();
+    auto client = RSocket::createConnectedClient(
+                      std::make_unique<TcpConnectionFactory>(
+                          *worker_.getEventBase(), std::move(address_)),
+                      std::move(setupParameters))
+                      .get();
     testClient_[command.clientId()] =
         std::make_shared<TestClient>(move(client));
   }

--- a/test/ConnectionEventsTest.cpp
+++ b/test/ConnectionEventsTest.cpp
@@ -1,8 +1,8 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
+#include <folly/io/async/ScopedEventBaseThread.h>
 #include <gmock/gmock.h>
 #include <thread>
-#include <folly/io/async/ScopedEventBaseThread.h>
 
 #include "RSocketTests.h"
 
@@ -42,7 +42,8 @@ TEST(ConnectionEventsTest, SimpleStream) {
       std::make_shared<HelloServiceHandler>(serverConnEvents));
 
   // create resumable client
-  auto client = makeResumableClient(worker.getEventBase(), *server->listeningPort(), clientConnEvents);
+  auto client = makeResumableClient(
+      worker.getEventBase(), *server->listeningPort(), clientConnEvents);
 
   // request stream
   auto requester = client->getRequester();

--- a/test/WarmResumptionTest.cpp
+++ b/test/WarmResumptionTest.cpp
@@ -1,8 +1,8 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-#include <thread>
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <gtest/gtest.h>
+#include <thread>
 
 #include "RSocketTests.h"
 
@@ -19,7 +19,8 @@ using namespace yarpl::flowable;
 TEST(WarmResumptionTest, SuccessfulResumption) {
   folly::ScopedEventBaseThread worker;
   auto server = makeResumableServer(std::make_shared<HelloServiceHandler>());
-  auto client = makeResumableClient(worker.getEventBase(), *server->listeningPort());
+  auto client =
+      makeResumableClient(worker.getEventBase(), *server->listeningPort());
   auto ts = TestSubscriber<std::string>::create(7 /* initialRequestN */);
   client->getRequester()
       ->requestStream(Payload("Bob"))
@@ -59,7 +60,8 @@ TEST(WarmResumptionTest, FailedResumption1) {
       .then([] { FAIL() << "Resumption succeeded when it should not"; })
       .onError([listeningPort, &worker](folly::exception_wrapper) {
         folly::ScopedEventBaseThread worker2;
-        auto newClient = makeResumableClient(worker2.getEventBase(), listeningPort);
+        auto newClient =
+            makeResumableClient(worker2.getEventBase(), listeningPort);
         auto newTs =
             TestSubscriber<std::string>::create(6 /* initialRequestN */);
         newClient->getRequester()
@@ -101,7 +103,8 @@ TEST(WarmResumptionTest, FailedResumption2) {
   std::shared_ptr<RSocketClient> newClient;
   client->resume()
       .then([] { FAIL() << "Resumption succeeded when it should not"; })
-      .onError([listeningPort, newTs, &newClient, &worker2](folly::exception_wrapper) {
+      .onError([listeningPort, newTs, &newClient, &worker2](
+          folly::exception_wrapper) {
         newClient = makeResumableClient(worker2.getEventBase(), listeningPort);
         newClient->getRequester()
             ->requestStream(Payload("Alice"))

--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -26,7 +26,6 @@ class FlowableOperator : public Flowable<D> {
       : upstream_(std::move(upstream)) {}
 
  protected:
-
   /// An Operator's subscription.
   ///
   /// When a pipeline chain is active, each Flowable has a corresponding
@@ -185,18 +184,16 @@ class MapOperator : public FlowableOperator<U, D, MapOperator<U, D, F>> {
 
  public:
   MapOperator(Reference<Flowable<U>> upstream, F function)
-      : Super(std::move(upstream)),
-        function_(std::move(function)) {}
+      : Super(std::move(upstream)), function_(std::move(function)) {}
 
   void subscribe(Reference<Subscriber<D>> subscriber) override {
-    Super::upstream_->subscribe(make_ref<Subscription>(
-        get_ref(this), std::move(subscriber)));
+    Super::upstream_->subscribe(
+        make_ref<Subscription>(get_ref(this), std::move(subscriber)));
   }
 
  private:
   using SuperSubscription = typename Super::Subscription;
   class Subscription : public SuperSubscription {
-
    public:
     Subscription(
         Reference<ThisOperatorT> flowable,
@@ -224,18 +221,16 @@ class FilterOperator : public FlowableOperator<U, U, FilterOperator<U, F>> {
 
  public:
   FilterOperator(Reference<Flowable<U>> upstream, F function)
-      : Super(std::move(upstream)),
-        function_(std::move(function)) {}
+      : Super(std::move(upstream)), function_(std::move(function)) {}
 
   void subscribe(Reference<Subscriber<U>> subscriber) override {
-    Super::upstream_->subscribe(make_ref<Subscription>(
-        get_ref(this), std::move(subscriber)));
+    Super::upstream_->subscribe(
+        make_ref<Subscription>(get_ref(this), std::move(subscriber)));
   }
 
  private:
   using SuperSubscription = typename Super::Subscription;
   class Subscription : public SuperSubscription {
-
    public:
     Subscription(
         Reference<ThisOperatorT> flowable,
@@ -268,18 +263,16 @@ class ReduceOperator : public FlowableOperator<U, D, ReduceOperator<U, D, F>> {
 
  public:
   ReduceOperator(Reference<Flowable<U>> upstream, F function)
-      : Super(std::move(upstream)),
-        function_(std::move(function)) {}
+      : Super(std::move(upstream)), function_(std::move(function)) {}
 
   void subscribe(Reference<Subscriber<D>> subscriber) override {
-    Super::upstream_->subscribe(make_ref<Subscription>(
-        get_ref(this), std::move(subscriber)));
+    Super::upstream_->subscribe(
+        make_ref<Subscription>(get_ref(this), std::move(subscriber)));
   }
 
  private:
   using SuperSubscription = typename Super::Subscription;
   class Subscription : public SuperSubscription {
-
    public:
     Subscription(
         Reference<ThisOperatorT> flowable,
@@ -327,20 +320,20 @@ class TakeOperator : public FlowableOperator<T, T, TakeOperator<T>> {
       : Super(std::move(upstream)), limit_(limit) {}
 
   void subscribe(Reference<Subscriber<T>> subscriber) override {
-    Super::upstream_->subscribe(make_ref<Subscription>(
-        get_ref(this), limit_, std::move(subscriber)));
+    Super::upstream_->subscribe(
+        make_ref<Subscription>(get_ref(this), limit_, std::move(subscriber)));
   }
 
  private:
   using SuperSubscription = typename Super::Subscription;
   class Subscription : public SuperSubscription {
-
    public:
     Subscription(
         Reference<ThisOperatorT> flowable,
         int64_t limit,
         Reference<Subscriber<T>> subscriber)
-        : SuperSubscription(std::move(flowable), std::move(subscriber)), limit_(limit) {}
+        : SuperSubscription(std::move(flowable), std::move(subscriber)),
+          limit_(limit) {}
 
     void onNext(T value) override {
       if (limit_-- > 0) {
@@ -380,8 +373,8 @@ class SkipOperator : public FlowableOperator<T, T, SkipOperator<T>> {
       : Super(std::move(upstream)), offset_(offset) {}
 
   void subscribe(Reference<Subscriber<T>> subscriber) override {
-    Super::upstream_->subscribe(make_ref<Subscription>(
-        get_ref(this), offset_, std::move(subscriber)));
+    Super::upstream_->subscribe(
+        make_ref<Subscription>(get_ref(this), offset_, std::move(subscriber)));
   }
 
  private:
@@ -392,7 +385,8 @@ class SkipOperator : public FlowableOperator<T, T, SkipOperator<T>> {
         Reference<ThisOperatorT> flowable,
         int64_t offset,
         Reference<Subscriber<T>> subscriber)
-        : SuperSubscription(std::move(flowable), std::move(subscriber)), offset_(offset) {}
+        : SuperSubscription(std::move(flowable), std::move(subscriber)),
+          offset_(offset) {}
 
     void onNext(T value) override {
       if (offset_ > 0) {
@@ -419,7 +413,8 @@ class SkipOperator : public FlowableOperator<T, T, SkipOperator<T>> {
 };
 
 template <typename T>
-class IgnoreElementsOperator : public FlowableOperator<T, T, IgnoreElementsOperator<T>> {
+class IgnoreElementsOperator
+    : public FlowableOperator<T, T, IgnoreElementsOperator<T>> {
   using ThisOperatorT = IgnoreElementsOperator<T>;
   using Super = FlowableOperator<T, T, ThisOperatorT>;
 
@@ -428,8 +423,8 @@ class IgnoreElementsOperator : public FlowableOperator<T, T, IgnoreElementsOpera
       : Super(std::move(upstream)) {}
 
   void subscribe(Reference<Subscriber<T>> subscriber) override {
-    Super::upstream_->subscribe(make_ref<Subscription>(
-        get_ref(this), std::move(subscriber)));
+    Super::upstream_->subscribe(
+        make_ref<Subscription>(get_ref(this), std::move(subscriber)));
   }
 
  private:
@@ -446,20 +441,18 @@ class IgnoreElementsOperator : public FlowableOperator<T, T, IgnoreElementsOpera
 };
 
 template <typename T>
-class SubscribeOnOperator : public FlowableOperator<T, T, SubscribeOnOperator<T>> {
+class SubscribeOnOperator
+    : public FlowableOperator<T, T, SubscribeOnOperator<T>> {
   using ThisOperatorT = SubscribeOnOperator<T>;
   using Super = FlowableOperator<T, T, ThisOperatorT>;
 
  public:
   SubscribeOnOperator(Reference<Flowable<T>> upstream, Scheduler& scheduler)
-      : Super(std::move(upstream)),
-        worker_(scheduler.createWorker()) {}
+      : Super(std::move(upstream)), worker_(scheduler.createWorker()) {}
 
   void subscribe(Reference<Subscriber<T>> subscriber) override {
     Super::upstream_->subscribe(make_ref<Subscription>(
-        get_ref(this),
-        std::move(worker_),
-        std::move(subscriber)));
+        get_ref(this), std::move(worker_), std::move(subscriber)));
   }
 
  private:

--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -48,7 +48,7 @@ class ObservableOperator : public Observable<D> {
       Refcounted::incRef(*this);
     }
 
-    template<typename TOperator>
+    template <typename TOperator>
     TOperator* getObservableAs() {
       return static_cast<TOperator*>(observable_.get());
     }
@@ -96,7 +96,7 @@ class ObservableOperator : public Observable<D> {
       terminateImpl(TerminateState::Down(), std::move(eptr));
     }
 
-  private:
+   private:
     struct TerminateState {
       TerminateState(bool u, bool d) : up{u}, down{d} {}
 
@@ -188,13 +188,12 @@ class MapOperator : public ObservableOperator<U, D> {
  private:
   class Subscription : public ObservableOperator<U, D>::Subscription {
     using Super = typename ObservableOperator<U, D>::Subscription;
+
    public:
     Subscription(
         Reference<Observable<D>> observable,
         Reference<Observer<D>> observer)
-        : Super(
-              std::move(observable),
-              std::move(observer)) {}
+        : Super(std::move(observable), std::move(observer)) {}
 
     void onNext(U value) override {
       auto* map = Super::template getObservableAs<MapOperator>();
@@ -226,13 +225,12 @@ class FilterOperator : public ObservableOperator<U, U> {
  private:
   class Subscription : public ObservableOperator<U, U>::Subscription {
     using Super = typename ObservableOperator<U, U>::Subscription;
+
    public:
     Subscription(
         Reference<Observable<U>> observable,
         Reference<Observer<U>> observer)
-        : Super(
-              std::move(observable),
-              std::move(observer)) {}
+        : Super(std::move(observable), std::move(observer)) {}
 
     void onNext(U value) override {
       auto* filter = Super::template getObservableAs<FilterOperator>();
@@ -245,14 +243,15 @@ class FilterOperator : public ObservableOperator<U, U> {
   F function_;
 };
 
-template<
+template <
     typename U,
     typename D,
     typename F,
     typename = typename std::enable_if<std::is_assignable<D, U>::value>,
-    typename = typename std::enable_if<std::is_callable<F(D, U), D>::value>::type>
+    typename =
+        typename std::enable_if<std::is_callable<F(D, U), D>::value>::type>
 class ReduceOperator : public ObservableOperator<U, D> {
-public:
+ public:
   ReduceOperator(Reference<Observable<U>> upstream, F function)
       : ObservableOperator<U, D>(std::move(upstream)),
         function_(std::move(function)) {}
@@ -264,17 +263,15 @@ public:
             Reference<Observable<D>>(this), std::move(subscriber))));
   }
 
-private:
+ private:
   class Subscription : public ObservableOperator<U, D>::Subscription {
     using Super = typename ObservableOperator<U, D>::Subscription;
 
-  public:
+   public:
     Subscription(
-        Reference <Observable<D>> flowable,
-        Reference <Observer<D>> subscriber)
-        : Super(
-        std::move(flowable),
-        std::move(subscriber)),
+        Reference<Observable<D>> flowable,
+        Reference<Observer<D>> subscriber)
+        : Super(std::move(flowable), std::move(subscriber)),
           accInitialized_(false) {}
 
     void onNext(U value) override {
@@ -294,7 +291,7 @@ private:
       Super::onComplete();
     }
 
-  private:
+   private:
     bool accInitialized_;
     D acc_;
   };
@@ -316,23 +313,20 @@ class TakeOperator : public ObservableOperator<T, T> {
 
  private:
   class Subscription : public ObservableOperator<T, T>::Subscription {
-    using Super = typename ObservableOperator<T,T>::Subscription;
+    using Super = typename ObservableOperator<T, T>::Subscription;
+
    public:
     Subscription(
         Reference<Observable<T>> observable,
         int64_t limit,
         Reference<Observer<T>> observer)
-        : Super(
-              std::move(observable),
-              std::move(observer)),
-          limit_(limit) {}
+        : Super(std::move(observable), std::move(observer)), limit_(limit) {}
 
     void onNext(T value) override {
       if (limit_-- > 0) {
         if (pending_ > 0)
           --pending_;
-        Super::observerOnNext(
-            std::move(value));
+        Super::observerOnNext(std::move(value));
         if (limit_ == 0) {
           Super::terminate();
         }
@@ -354,26 +348,24 @@ class SkipOperator : public ObservableOperator<T, T> {
       : ObservableOperator<T, T>(std::move(upstream)), offset_(offset) {}
 
   void subscribe(Reference<Observer<T>> observer) override {
-    ObservableOperator<T, T>::upstream_->subscribe(
-      make_ref<Subscription>(
-          Reference<Observable<T>>(this), offset_, std::move(observer)));
+    ObservableOperator<T, T>::upstream_->subscribe(make_ref<Subscription>(
+        Reference<Observable<T>>(this), offset_, std::move(observer)));
   }
 
  private:
   class Subscription : public ObservableOperator<T, T>::Subscription {
-    using Super = typename ObservableOperator<T,T>::Subscription;
+    using Super = typename ObservableOperator<T, T>::Subscription;
+
    public:
     Subscription(
-       Reference<Observable<T>> observable,
-       int64_t offset,
-       Reference<Observer<T>> observer)
-       : Super(std::move(observable), std::move(observer)),
-       offset_(offset) {}
+        Reference<Observable<T>> observable,
+        int64_t offset,
+        Reference<Observer<T>> observer)
+        : Super(std::move(observable), std::move(observer)), offset_(offset) {}
 
     void onNext(T value) override {
       if (offset_ <= 0) {
-        Super::observerOnNext(
-            std::move(value));
+        Super::observerOnNext(std::move(value));
       } else {
         --offset_;
       }
@@ -393,14 +385,14 @@ class IgnoreElementsOperator : public ObservableOperator<T, T> {
       : ObservableOperator<T, T>(std::move(upstream)) {}
 
   void subscribe(Reference<Observer<T>> observer) override {
-    ObservableOperator<T, T>::upstream_->subscribe(
-        Reference<Subscription>(new Subscription(
-            Reference<Observable<T>>(this), std::move(observer))));
+    ObservableOperator<T, T>::upstream_->subscribe(Reference<Subscription>(
+        new Subscription(Reference<Observable<T>>(this), std::move(observer))));
   }
 
  private:
   class Subscription : public ObservableOperator<T, T>::Subscription {
-    using Super = typename ObservableOperator<T,T>::Subscription;
+    using Super = typename ObservableOperator<T, T>::Subscription;
+
    public:
     Subscription(
         Reference<Observable<T>> observable,
@@ -445,8 +437,7 @@ class SubscribeOnOperator : public ObservableOperator<T, T> {
     }
 
     void onNext(T value) override {
-      auto* observer =
-          ObservableOperator<T, T>::Subscription::observer_.get();
+      auto* observer = ObservableOperator<T, T>::Subscription::observer_.get();
       observer->onNext(std::move(value));
     }
 

--- a/yarpl/include/yarpl/single/SingleOperator.h
+++ b/yarpl/include/yarpl/single/SingleOperator.h
@@ -100,7 +100,8 @@ template <
 class MapOperator : public SingleOperator<U, D> {
   using ThisOperatorT = MapOperator<U, D, F>;
   using Super = SingleOperator<U, D>;
-  using OperatorSubscription = typename Super::template Subscription<ThisOperatorT>;
+  using OperatorSubscription =
+      typename Super::template Subscription<ThisOperatorT>;
 
  public:
   MapOperator(Reference<Single<U>> upstream, F function)
@@ -109,8 +110,8 @@ class MapOperator : public SingleOperator<U, D> {
   void subscribe(Reference<SingleObserver<D>> observer) override {
     Super::upstream_->subscribe(
         // Note: implicit cast to a reference to a observer.
-        Reference<OperatorSubscription>(
-            new MapSubscription(Reference<ThisOperatorT>(this), std::move(observer))));
+        Reference<OperatorSubscription>(new MapSubscription(
+            Reference<ThisOperatorT>(this), std::move(observer))));
   }
 
  private:
@@ -123,7 +124,8 @@ class MapOperator : public SingleOperator<U, D> {
 
     void onSuccess(U value) override {
       auto map_operator = OperatorSubscription::getOperator();
-      OperatorSubscription::observerOnSuccess(map_operator->function_(std::move(value)));
+      OperatorSubscription::observerOnSuccess(
+          map_operator->function_(std::move(value)));
     }
   };
 
@@ -143,7 +145,6 @@ class FromPublisherOperator : public Single<T> {
  private:
   OnSubscribe function_;
 };
-
 
 template <typename OnSubscribe>
 class SingleVoidFromPublisherOperator : public Single<void> {


### PR DESCRIPTION
Specifically ones that have been changed recently, and are now firing lint
errors on the FB internal linter.