### PR TITLE
Allowance persistence for cold resumption

### DIFF
--- a/examples/resumption/ColdResumption_Client.cpp
+++ b/examples/resumption/ColdResumption_Client.cpp
@@ -63,7 +63,7 @@ class HelloResumeHandler : public ColdResumeHandler {
 
   Reference<Subscriber<Payload>> handleRequesterResumeStream(
       std::string streamToken,
-      uint32_t consumerAllowance) override {
+      size_t consumerAllowance) override {
     CHECK(subscribers_.find(streamToken) != subscribers_.end());
     LOG(INFO) << "Resuming " << streamToken << " stream with allowance "
               << consumerAllowance;

--- a/rsocket/ColdResumeHandler.cpp
+++ b/rsocket/ColdResumeHandler.cpp
@@ -20,14 +20,14 @@ std::string ColdResumeHandler::generateStreamToken(
 
 Reference<Flowable<Payload>> ColdResumeHandler::handleResponderResumeStream(
     std::string /* streamToken */,
-    uint32_t /* publisherAllowance */) {
+    size_t /* publisherAllowance */) {
   return Flowables::error<Payload>(
       std::logic_error("ResumeHandler method not implemented"));
 }
 
 Reference<Subscriber<Payload>> ColdResumeHandler::handleRequesterResumeStream(
     std::string /* streamToken */,
-    uint32_t /* consumerAllowance */) {
+    size_t /* consumerAllowance */) {
   return yarpl::make_ref<CancelingSubscriber<Payload>>();
 }
 }

--- a/rsocket/ColdResumeHandler.h
+++ b/rsocket/ColdResumeHandler.h
@@ -26,7 +26,7 @@ class ColdResumeHandler {
   virtual yarpl::Reference<yarpl::flowable::Flowable<rsocket::Payload>>
   handleResponderResumeStream(
       std::string streamToken,
-      uint32_t publisherAllowance);
+      size_t publisherAllowance);
 
   // This method will be called for each REQUEST_STREAM for which the
   // application acted as a requester.  The default action would be to return a
@@ -36,6 +36,6 @@ class ColdResumeHandler {
   virtual yarpl::Reference<yarpl::flowable::Subscriber<rsocket::Payload>>
   handleRequesterResumeStream(
       std::string streamToken,
-      uint32_t consumerAllowance);
+      size_t consumerAllowance);
 };
 }

--- a/rsocket/ResumeManager.h
+++ b/rsocket/ResumeManager.h
@@ -33,14 +33,16 @@ class ResumeManager {
   // sent/received on the wire.  The application should implement a way to
   // store the sent and received frames in persistent storage.
   virtual void trackReceivedFrame(
-      const folly::IOBuf& serializedFrame,
+      size_t frameLength,
       FrameType frameType,
-      StreamId streamId) = 0;
+      StreamId streamId,
+      size_t consumerAllowance) = 0;
 
   virtual void trackSentFrame(
       const folly::IOBuf& serializedFrame,
       FrameType frameType,
-      folly::Optional<StreamId> streamIdPtr) = 0;
+      folly::Optional<StreamId> streamIdPtr,
+      size_t consumerAllowance) = 0;
 
   // We have received acknowledgement from the remote-side that it has frames
   // up to "position".  We can discard all frames before that.  This
@@ -85,25 +87,13 @@ class ResumeManager {
   // the local side is a publisher (REQUEST_STREAM Responder and
   // REQUEST_CHANNEL).  This should return the allowance which the local side
   // has received and hasn't fulfilled yet.
-  virtual uint32_t getPublisherAllowance(StreamId) = 0;
+  virtual size_t getPublisherAllowance(StreamId) = 0;
 
   // Get allowance for the given StreamId.  This is called for situations where
   // the local side is a consumer (REQUEST_STREAM Requester and
   // REQUEST_CHANNEL).  This should return the allowance which has been sent to
   // the remote side and hasn't been fulfilled yet.
-  virtual uint32_t getConsumerAllowance(StreamId) = 0;
-
-  // Increment the publisher allowance to be preserved for the StreamId
-  virtual void incrPublisherAllowance(StreamId, uint32_t) = 0;
-
-  // Decrement the publisher allowance to be preserved for the StreamId
-  virtual void decrPublisherAllowance(StreamId, uint32_t) = 0;
-
-  // Increment the consumer allowance to be preserved for the StreamId
-  virtual void incrConsumerAllowance(StreamId, uint32_t) = 0;
-
-  // Decrement the consumer allowance to be preserved for the StreamId
-  virtual void decrConsumerAllowance(StreamId, uint32_t) = 0;
+  virtual size_t getConsumerAllowance(StreamId) = 0;
 
   // Return the application-aware streamToken for the given StreamId
   virtual std::string getStreamToken(StreamId) = 0;

--- a/rsocket/internal/AllowanceSemaphore.h
+++ b/rsocket/internal/AllowanceSemaphore.h
@@ -53,6 +53,10 @@ class AllowanceSemaphore {
     return value_;
   }
 
+  ValueType getValue() const {
+    return value_;
+  }
+
   static ValueType max() {
     return std::numeric_limits<ValueType>::max();
   }

--- a/rsocket/statemachine/ConsumerBase.cpp
+++ b/rsocket/statemachine/ConsumerBase.cpp
@@ -55,17 +55,9 @@ void ConsumerBase::endStream(StreamCompletionSignal signal) {
   Base::endStream(signal);
 }
 
-//void ConsumerBase::pauseStream(RequestHandler& requestHandler) {
-//  if (consumingSubscriber_) {
-//    requestHandler.onSubscriberPaused(consumingSubscriber_);
-//  }
-//}
-//
-//void ConsumerBase::resumeStream(RequestHandler& requestHandler) {
-//  if (consumingSubscriber_) {
-//    requestHandler.onSubscriberResumed(consumingSubscriber_);
-//  }
-//}
+size_t ConsumerBase::getConsumerAllowance() const {
+  return allowance_.getValue();
+}
 
 void ConsumerBase::processPayload(Payload&& payload, bool onNext) {
   if (payload || onNext) {

--- a/rsocket/statemachine/ConsumerBase.h
+++ b/rsocket/statemachine/ConsumerBase.h
@@ -40,6 +40,8 @@ class ConsumerBase : public StreamStateMachineBase,
   void generateRequest(size_t n);
   /// @}
 
+  size_t getConsumerAllowance() const override;
+
  protected:
   void checkConsumerRequest();
   void cancelConsumer();

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -388,26 +388,25 @@ void RSocketStateMachine::processFrameImpl(
     return;
   }
 
+  auto frameLength = frame->computeChainDataLength();
   auto streamId = *streamIdPtr;
-  resumeManager_->trackReceivedFrame(*frame, frameType, streamId);
   if (streamId == 0) {
     handleConnectionFrame(frameType, std::move(frame));
-    return;
-  }
-
-  // during the time when we are resuming we are can't receive any other
-  // than connection level frames which drives the resumption
-  // TODO(lehecka): this assertion should be handled more elegantly using
-  // different state machine
-  if (resumeCallback_) {
+  } else if (resumeCallback_) {
+    // during the time when we are resuming we are can't receive any other
+    // than connection level frames which drives the resumption
+    // TODO(lehecka): this assertion should be handled more elegantly using
+    // different state machine
     constexpr folly::StringPiece message{
         "Received stream frame while resuming"};
     LOG(ERROR) << message;
     closeWithError(Frame_ERROR::connectionError(message.str()));
     return;
+  } else {
+    handleStreamFrame(streamId, frameType, std::move(frame));
   }
-
-  handleStreamFrame(streamId, frameType, std::move(frame));
+  resumeManager_->trackReceivedFrame(
+      frameLength, frameType, streamId, getConsumerAllowance(streamId));
 }
 
 void RSocketStateMachine::onTerminal(folly::exception_wrapper ex) {
@@ -596,7 +595,6 @@ void RSocketStateMachine::handleStreamFrame(
           std::move(framePayload.payload_),
           framePayload.header_.flagsComplete(),
           framePayload.header_.flagsNext());
-      resumeManager_->decrConsumerAllowance(streamId, 1);
       break;
     }
     case FrameType::ERROR: {
@@ -853,7 +851,10 @@ void RSocketStateMachine::outputFrame(std::unique_ptr<folly::IOBuf> frame) {
 
   if (isResumable_) {
     auto streamIdPtr = frameSerializer_->peekStreamId(*frame);
-    resumeManager_->trackSentFrame(*frame, frameType, streamIdPtr);
+    size_t consumerAllowance =
+        (streamIdPtr) ? getConsumerAllowance(*streamIdPtr) : 0;
+    resumeManager_->trackSentFrame(
+        *frame, frameType, streamIdPtr, consumerAllowance);
   }
   frameTransport_->outputFrameOrDrop(std::move(frame));
 }
@@ -949,7 +950,6 @@ void RSocketStateMachine::writeNewStream(
     case StreamType::STREAM:
       outputFrameOrEnqueue(Frame_REQUEST_STREAM(
           streamId, FrameFlags::EMPTY, initialRequestN, std::move(payload)));
-      resumeManager_->incrConsumerAllowance(streamId, initialRequestN);
       break;
 
     case StreamType::REQUEST_RESPONSE:
@@ -968,7 +968,6 @@ void RSocketStateMachine::writeNewStream(
 }
 
 void RSocketStateMachine::writeRequestN(StreamId streamId, uint32_t n) {
-  resumeManager_->incrConsumerAllowance(streamId, n);
   outputFrameOrEnqueue(Frame_REQUEST_N(streamId, n));
 }
 
@@ -1046,4 +1045,14 @@ bool RSocketStateMachine::ensureOrAutodetectFrameSerializer(
   frameSerializer_ = std::move(serializer);
   return true;
 }
+
+size_t RSocketStateMachine::getConsumerAllowance(StreamId streamId) const {
+  size_t consumerAllowance = 0;
+  auto it = streamState_.streams_.find(streamId);
+  if (it != streamState_.streams_.end()) {
+    consumerAllowance = it->second->getConsumerAllowance();
+  }
+  return consumerAllowance;
+}
+
 } // namespace rsocket

--- a/rsocket/statemachine/RSocketStateMachine.h
+++ b/rsocket/statemachine/RSocketStateMachine.h
@@ -285,6 +285,8 @@ class RSocketStateMachine final
 
   bool ensureOrAutodetectFrameSerializer(const folly::IOBuf& firstFrame);
 
+  size_t getConsumerAllowance(StreamId streamId) const;
+
   ReactiveSocketMode mode_;
   bool isResumable_{false};
   bool remoteResumeable_{false};

--- a/rsocket/statemachine/RequestResponseRequester.cpp
+++ b/rsocket/statemachine/RequestResponseRequester.cpp
@@ -116,15 +116,7 @@ void RequestResponseRequester::handlePayload(
   closeStream(StreamCompletionSignal::COMPLETE);
 }
 
-// void RequestResponseRequester::pauseStream(RequestHandler& requestHandler) {
-//  if (consumingSubscriber_) {
-//    requestHandler.onSubscriberPaused(consumingSubscriber_);
-//  }
-//}
-//
-// void RequestResponseRequester::resumeStream(RequestHandler& requestHandler) {
-//  if (consumingSubscriber_) {
-//    requestHandler.onSubscriberResumed(consumingSubscriber_);
-//  }
-//}
+size_t RequestResponseRequester::getConsumerAllowance() const {
+  return (state_ == State::REQUESTED) ? 1 : 0;
+}
 }

--- a/rsocket/statemachine/RequestResponseRequester.h
+++ b/rsocket/statemachine/RequestResponseRequester.h
@@ -31,8 +31,7 @@ class RequestResponseRequester : public StreamStateMachineBase,
 
   void endStream(StreamCompletionSignal signal) override;
 
-//  void pauseStream(RequestHandler& requestHandler) override;
-//  void resumeStream(RequestHandler& requestHandler) override;
+  size_t getConsumerAllowance() const override;
 
   /// State of the Subscription requester.
   enum class State : uint8_t {

--- a/rsocket/statemachine/StreamStateMachineBase.cpp
+++ b/rsocket/statemachine/StreamStateMachineBase.cpp
@@ -25,6 +25,10 @@ void StreamStateMachineBase::handleCancel() {
   VLOG(4) << "Unexpected handleCancel";
 }
 
+size_t StreamStateMachineBase::getConsumerAllowance() const {
+  return 0;
+}
+
 void StreamStateMachineBase::endStream(StreamCompletionSignal) {
   isTerminated_ = true;
 }

--- a/rsocket/statemachine/StreamStateMachineBase.h
+++ b/rsocket/statemachine/StreamStateMachineBase.h
@@ -48,6 +48,8 @@ class StreamStateMachineBase : public virtual yarpl::Refcounted {
   virtual void handleError(folly::exception_wrapper errorPayload);
   virtual void handleCancel();
 
+  virtual size_t getConsumerAllowance() const;
+
   /// Indicates a terminal signal from the connection.
   ///
   /// This signal corresponds to Subscriber::{onComplete,onError} and

--- a/test/ColdResumptionTest.cpp
+++ b/test/ColdResumptionTest.cpp
@@ -81,7 +81,7 @@ class HelloResumeHandler : public ColdResumeHandler {
 
   Reference<Subscriber<Payload>> handleRequesterResumeStream(
       std::string streamToken,
-      uint32_t consumerAllowance) override {
+      size_t consumerAllowance) override {
     CHECK(subscribers_.find(streamToken) != subscribers_.end());
     VLOG(1) << "Resuming " << streamToken << " stream with allowance "
             << consumerAllowance;


### PR DESCRIPTION
This PR changes how allowance is persisted for cold-resumption.  It currently changes only the consumer side allowance.  If folks are okay with the approach, I will make similar changes to the publisher side allowance.

- The allowance information for cold-resumption is now explicitly obtained from `StreamStateMachineBase` (instead of inferring it based on in/out frames).   For REQUEST_RESPONSE, the Requester will have a consumerAllowance of 1 if it is in a requested state, else 0.  For REQUEST_STREAM and REQUEST_CHANNEL, the consumerAllowance will the requestN sent minus the requestN fulfilled the from remote side.

- The allowance information and the in/out frames are now persisted with a single call to `ResumeManager`.  The persistence implementation could save both atomically.

- Earlier, the frames were persisted (event 1) before the application consumed the frame (event 2).  This could lead to application permanently losing the frame if there is a crash between the two events.  I have changed the design to persist frames after the application has consumed them.  This could potentially lead to application consuming some frames twice (but I felt this is better than application missing the frame).  Ideally the events should be in a single transaction.

Notes:
- There is a publisherAllowance and consumerAllowance for each stream since REQUEST_CHANNEL would need both and there should be a distinction.
- We could enforce all sent frames to have a valid StreamId (I don't know of a case where a frame can be without a StreamId).  Then we could get rid of the folly::Optional in trackSentFrame signature.