### PR TITLE
Make the ConnectManyAsync function to async connect to the server

### DIFF
--- a/test/RSocketClientServerTest.cpp
+++ b/test/RSocketClientServerTest.cpp
@@ -34,12 +34,29 @@ TEST(RSocketClientServer, ConnectManySync) {
 }
 
 TEST(RSocketClientServer, ConnectManyAsync) {
-  folly::ScopedEventBaseThread worker;
   auto server = makeServer(std::make_shared<HelloStreamRequestHandler>());
 
-  for (size_t i = 0; i < 100; ++i) {
-    auto client = makeClient(worker.getEventBase(), *server->listeningPort());
-    auto requester = client->getRequester();
+  size_t count = 1000;
+  std::vector<std::unique_ptr<folly::ScopedEventBaseThread>> workers(count);
+  std::vector<folly::Future<std::shared_ptr<RSocketClient>>> clients;
+
+  std::atomic<int> executed{0};
+  for (size_t i = 0; i < count; ++i) {
+    workers[i] = std::make_unique<folly::ScopedEventBaseThread>();
+    auto clientFuture =
+        makeClientAsync(workers[i]->getEventBase(), *server->listeningPort())
+            .then([&executed](std::shared_ptr<rsocket::RSocketClient> client) {
+              auto requester = client->getRequester();
+              client->disconnect(folly::exception_wrapper());
+              ++executed;
+              return client;
+            });
+    clients.emplace_back(std::move(clientFuture));
   }
 
+  auto results = folly::collectAll(clients).get(folly::Duration(1000));
+  results.clear();
+  clients.clear();
+  CHECK_EQ(executed, count);
+  workers.clear();
 }

--- a/test/RSocketTests.cpp
+++ b/test/RSocketTests.cpp
@@ -34,7 +34,7 @@ std::unique_ptr<RSocketServer> makeResumableServer(
   return rs;
 }
 
-std::shared_ptr<RSocketClient> makeClient(
+folly::Future<std::shared_ptr<RSocketClient>> makeClientAsync(
     folly::EventBase* eventBase,
     uint16_t port) {
   CHECK(eventBase);
@@ -42,8 +42,13 @@ std::shared_ptr<RSocketClient> makeClient(
   folly::SocketAddress address;
   address.setFromHostPort("localhost", port);
   return RSocket::createConnectedClient(
-      std::make_unique<TcpConnectionFactory>(*eventBase, std::move(address)))
-      .get();
+      std::make_unique<TcpConnectionFactory>(*eventBase, std::move(address)));
+}
+
+std::shared_ptr<RSocketClient> makeClient(
+    folly::EventBase* eventBase,
+    uint16_t port) {
+  return makeClientAsync(eventBase, port).get();
 }
 
 std::shared_ptr<RSocketClient> makeResumableClient(

--- a/test/RSocketTests.h
+++ b/test/RSocketTests.h
@@ -20,6 +20,10 @@ std::shared_ptr<RSocketClient> makeClient(
     folly::EventBase* eventBase,
     uint16_t port);
 
+folly::Future<std::shared_ptr<RSocketClient>> makeClientAsync(
+    folly::EventBase* eventBase,
+    uint16_t port);
+
 std::shared_ptr<RSocketClient> makeResumableClient(
     folly::EventBase* eventBase,
     uint16_t port,


### PR DESCRIPTION
The ConnectManySync and ConnectManyAsync function's content was the same. 
So I have updated the ConnectManyAsync function to connect to the server from different threads,  asynchronously connecting to the server.