### PR TITLE
Remove lock and buffering of input in FrameTransport

### DIFF
--- a/rsocket/framing/FrameTransport.h
+++ b/rsocket/framing/FrameTransport.h
@@ -2,15 +2,8 @@
 
 #pragma once
 
-#include <deque>
-#include <memory>
-#include <mutex>
-
 #include <folly/ExceptionWrapper.h>
-#include <folly/Optional.h>
-
 #include "rsocket/DuplexConnection.h"
-#include "rsocket/internal/AllowanceSemaphore.h"
 #include "rsocket/internal/Common.h"
 #include "yarpl/flowable/Subscription.h"
 
@@ -46,15 +39,6 @@ class FrameTransport final :
   }
 
  private:
-  // TODO(t15924567): Recursive locks are evil! This should instead use a
-  // synchronization abstraction which preserves FIFO ordering. However, this is
-  // incrementally better than the race conditions which existed here before.
-  //
-  // Further reading:
-  // https://groups.google.com/forum/?hl=en#!topic/comp.programming.threads/tcrTKnfP8HI%5B1-25%5D
-  using Mutex = std::recursive_mutex;
-  using Lock = std::lock_guard<Mutex>;
-
   void connect();
 
   // Subscriber.
@@ -69,30 +53,16 @@ class FrameTransport final :
   void request(int64_t) override;
   void cancel() override;
 
-  /// Drain all pending reads and any pending terminal signal into the
-  /// FrameProcessor.
-  ///
-  /// TODO: This always sends the payloads first and then follows with the
-  /// terminal signal, regardless if terminal signal was sent before the
-  /// payloads.  Not clear if that is desirable.
-  void drainReads(const Lock&);
-
   /// Terminates the FrameProcessor.  Will queue up the exception if no
   /// processor is set, overwriting any previously queued exception.
   void terminateProcessor(folly::exception_wrapper);
 
   void closeImpl(folly::exception_wrapper);
 
-  mutable Mutex mutex_;
-
   std::shared_ptr<FrameProcessor> frameProcessor_;
-
   std::shared_ptr<DuplexConnection> connection_;
 
   yarpl::Reference<DuplexConnection::Subscriber> connectionOutput_;
   yarpl::Reference<yarpl::flowable::Subscription> connectionInputSub_;
-
-  std::deque<std::unique_ptr<folly::IOBuf>> pendingReads_;
-  folly::Optional<folly::exception_wrapper> pendingTerminal_;
 };
 }


### PR DESCRIPTION
removing the last bits of extra logic from FrameTransport before I remove the class all together.

* removed mutex from the class. Locking is not necessary, we support single threaded access to/from duplex connection. The RSocketStateMachine and DuplexConnection are running on the same thread.
* removed input buffering. Since everything is synchronous, there is no need to provide buffering for situations when FrameTransport is connected and the FrameProcessor is not attached. This used to happen because we were potentially resuming on another thread and there could a race there. There is no race anymore.

I tested the change with all unit tests and I also ran all of our examples + resumption.