### PR TITLE
Test for cold resumption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,6 +406,7 @@ add_executable(
   test/RequestResponseTest.cpp
   test/RequestStreamTest.cpp
   test/WarmResumptionTest.cpp
+  test/ColdResumptionTest.cpp
   test/ConnectionEventsTest.cpp
   test/Test.cpp
   test/framing/FrameTest.cpp

--- a/examples/resumption/ColdResumption_Client.cpp
+++ b/examples/resumption/ColdResumption_Client.cpp
@@ -25,10 +25,10 @@ namespace {
 class HelloSubscriber : public virtual Refcounted, public Subscriber<Payload> {
  public:
   void request(int n) {
-    while (!subscription_) {
+    while (!Subscriber<Payload>::subscription()) {
       std::this_thread::yield();
     }
-    subscription_->request(n);
+    Subscriber<Payload>::subscription()->request(n);
   }
 
   int rcvdCount() const {
@@ -37,7 +37,7 @@ class HelloSubscriber : public virtual Refcounted, public Subscriber<Payload> {
 
  protected:
   void onSubscribe(Reference<Subscription> subscription) noexcept override {
-    subscription_ = subscription;
+    Subscriber<rsocket::Payload>::onSubscribe(subscription);
   }
 
   void onNext(Payload) noexcept override {
@@ -45,7 +45,6 @@ class HelloSubscriber : public virtual Refcounted, public Subscriber<Payload> {
   }
 
  private:
-  Reference<Subscription> subscription_{nullptr};
   std::atomic<int> count_{0};
 };
 

--- a/test/ColdResumptionTest.cpp
+++ b/test/ColdResumptionTest.cpp
@@ -1,0 +1,220 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <gtest/gtest.h>
+
+#include <folly/Conv.h>
+#include <folly/io/async/ScopedEventBaseThread.h>
+
+#include "RSocketTests.h"
+
+#include "rsocket/internal/InMemResumeManager.h"
+#include "test/handlers/HelloServiceHandler.h"
+
+using namespace rsocket;
+using namespace rsocket::tests;
+using namespace rsocket::tests::client_server;
+using namespace yarpl;
+using namespace yarpl::flowable;
+
+typedef std::map<std::string, Reference<Subscriber<Payload>>> HelloSubscribers;
+
+namespace {
+class HelloSubscriber : public virtual Refcounted, public Subscriber<Payload> {
+ public:
+  explicit HelloSubscriber(size_t latestValue) : latestValue_(latestValue) {}
+
+  void request(int n) {
+    subscribedBaton_.wait();
+    Subscriber<Payload>::subscription()->request(n);
+  }
+
+  void awaitLatestValue(size_t value) {
+    auto count = 3;
+    while (value != latestValue_ && count > 0) {
+      VLOG(1) << "Wait for " << count << " seconds for latest value";
+      sleep(1);
+      count--;
+      std::this_thread::yield();
+    }
+    EXPECT_EQ(value, latestValue_);
+  }
+
+  size_t valueCount() const {
+    return count_;
+  }
+
+  size_t getLatestValue() const {
+    return latestValue_;
+  }
+
+ protected:
+  void onSubscribe(Reference<Subscription> subscription) noexcept override {
+    Subscriber<rsocket::Payload>::onSubscribe(subscription);
+    subscribedBaton_.post();
+  }
+
+  void onNext(Payload p) noexcept override {
+    auto currValue = folly::to<size_t>(p.data->moveToFbString().toStdString());
+    EXPECT_EQ(latestValue_, currValue - 1);
+    latestValue_ = currValue;
+    count_++;
+  }
+
+ private:
+  std::atomic<size_t> latestValue_;
+  std::atomic<size_t> count_;
+  folly::Baton<> subscribedBaton_;
+};
+
+class HelloResumeHandler : public ColdResumeHandler {
+ public:
+  explicit HelloResumeHandler(HelloSubscribers subscribers)
+      : subscribers_(std::move(subscribers)) {}
+
+  std::string generateStreamToken(const Payload& payload, StreamId, StreamType)
+      override {
+    auto streamToken =
+        payload.data->cloneAsValue().moveToFbString().toStdString();
+    VLOG(3) << "Generated token: " << streamToken;
+    return streamToken;
+  }
+
+  Reference<Subscriber<Payload>> handleRequesterResumeStream(
+      std::string streamToken,
+      uint32_t consumerAllowance) override {
+    CHECK(subscribers_.find(streamToken) != subscribers_.end());
+    VLOG(1) << "Resuming " << streamToken << " stream with allowance "
+            << consumerAllowance;
+    return subscribers_[streamToken];
+  }
+
+ private:
+  HelloSubscribers subscribers_;
+};
+
+SetupParameters getSetupParams(ResumeIdentificationToken token) {
+  SetupParameters setupParameters;
+  setupParameters.resumable = true;
+  setupParameters.token = token;
+  return setupParameters;
+}
+}
+
+// There are three sessions and three streams.
+// There is cold-resumption between the three sessions.
+//
+// The first stream lasts through all three sessions.
+// The second stream lasts through the second and third session.
+// The third stream lives only in the third session.
+//
+// The first stream requests 10 frames
+// The second stream requests 10 frames
+// The third stream requests 5 frames
+
+TEST(ColdResumptionTest, SuccessfulResumption) {
+  std::string firstPayload = "First";
+  std::string secondPayload = "Second";
+  std::string thirdPayload = "Third";
+  size_t firstLatestValue, secondLatestValue;
+
+  auto server = makeResumableServer(std::make_shared<HelloServiceHandler>());
+
+  folly::ScopedEventBaseThread worker;
+  auto token = ResumeIdentificationToken::generateNew();
+  auto resumeManager =
+      std::make_shared<InMemResumeManager>(RSocketStats::noop());
+  {
+    auto firstSub = make_ref<HelloSubscriber>(0);
+    {
+      auto coldResumeHandler = std::make_shared<HelloResumeHandler>(
+          HelloSubscribers({{firstPayload, firstSub}}));
+      std::shared_ptr<RSocketClient> firstClient;
+      EXPECT_NO_THROW(
+          firstClient = makeColdResumableClient(
+              worker.getEventBase(),
+              *server->listeningPort(),
+              token,
+              resumeManager,
+              coldResumeHandler));
+      firstClient->getRequester()
+          ->requestStream(Payload(firstPayload))
+          ->subscribe(firstSub);
+      firstSub->request(4);
+      // Ensure reception of few frames before resuming.
+      while (firstSub->valueCount() < 1) {
+        std::this_thread::yield();
+      }
+    }
+    firstLatestValue = firstSub->getLatestValue();
+  }
+
+  VLOG(1) << "============== First Cold Resumption ================";
+  sleep(1);
+
+  {
+    auto firstSub = yarpl::make_ref<HelloSubscriber>(firstLatestValue);
+    auto secondSub = yarpl::make_ref<HelloSubscriber>(0);
+    {
+      auto coldResumeHandler = std::make_shared<HelloResumeHandler>(
+          HelloSubscribers({{firstPayload, firstSub}}));
+      std::shared_ptr<RSocketClient> secondClient;
+      EXPECT_NO_THROW(
+          secondClient =
+              RSocket::createResumedClient(
+                  getConnFactory(
+                      worker.getEventBase(), *server->listeningPort()),
+                  getSetupParams(token),
+                  resumeManager,
+                  coldResumeHandler)
+                  .get());
+
+      // Create another stream to verify StreamIds are set properly after
+      // resumption
+      secondClient->getRequester()
+          ->requestStream(Payload(secondPayload))
+          ->subscribe(secondSub);
+      firstSub->request(3);
+      secondSub->request(5);
+      // Ensure reception of few frames before resuming.
+      while (secondSub->valueCount() < 1) {
+        std::this_thread::yield();
+      }
+    }
+    firstLatestValue = firstSub->getLatestValue();
+    secondLatestValue = secondSub->getLatestValue();
+  }
+
+  VLOG(1) << "============= Second Cold Resumption ===============";
+  sleep(1);
+
+  {
+    auto firstSub = yarpl::make_ref<HelloSubscriber>(firstLatestValue);
+    auto secondSub = yarpl::make_ref<HelloSubscriber>(secondLatestValue);
+    auto thirdSub = yarpl::make_ref<HelloSubscriber>(0);
+    auto coldResumeHandler =
+        std::make_shared<HelloResumeHandler>(HelloSubscribers(
+            {{firstPayload, firstSub}, {secondPayload, secondSub}}));
+    std::shared_ptr<RSocketClient> thirdClient;
+    EXPECT_NO_THROW(
+        thirdClient =
+            RSocket::createResumedClient(
+                getConnFactory(worker.getEventBase(), *server->listeningPort()),
+                getSetupParams(token),
+                resumeManager,
+                coldResumeHandler)
+                .get());
+
+    // Create another stream to verify StreamIds are set properly after
+    // resumption
+    thirdClient->getRequester()
+        ->requestStream(Payload(secondPayload))
+        ->subscribe(thirdSub);
+    firstSub->request(3);
+    secondSub->request(5);
+    thirdSub->request(5);
+
+    firstSub->awaitLatestValue(10);
+    secondSub->awaitLatestValue(10);
+    thirdSub->awaitLatestValue(5);
+  }
+}

--- a/test/ConnectionEventsTest.cpp
+++ b/test/ConnectionEventsTest.cpp
@@ -42,7 +42,7 @@ TEST(ConnectionEventsTest, SimpleStream) {
       std::make_shared<HelloServiceHandler>(serverConnEvents));
 
   // create resumable client
-  auto client = makeResumableClient(
+  auto client = makeWarmResumableClient(
       worker.getEventBase(), *server->listeningPort(), clientConnEvents);
 
   // request stream

--- a/test/RSocketTests.h
+++ b/test/RSocketTests.h
@@ -6,9 +6,15 @@
 
 #include "rsocket/RSocket.h"
 
+#include "rsocket/transports/tcp/TcpConnectionFactory.h"
+
 namespace rsocket {
 namespace tests {
 namespace client_server {
+
+std::unique_ptr<TcpConnectionFactory> getConnFactory(
+    folly::EventBase* eventBase,
+    uint16_t port);
 
 std::unique_ptr<RSocketServer> makeServer(
     std::shared_ptr<rsocket::RSocketResponder> responder);
@@ -24,10 +30,17 @@ folly::Future<std::shared_ptr<RSocketClient>> makeClientAsync(
     folly::EventBase* eventBase,
     uint16_t port);
 
-std::shared_ptr<RSocketClient> makeResumableClient(
+std::shared_ptr<RSocketClient> makeWarmResumableClient(
     folly::EventBase* eventBase,
     uint16_t port,
     std::shared_ptr<RSocketConnectionEvents> connectionEvents = nullptr);
+
+std::shared_ptr<RSocketClient> makeColdResumableClient(
+    folly::EventBase* eventBase,
+    uint16_t port,
+    ResumeIdentificationToken token,
+    std::shared_ptr<ResumeManager> resumeManager,
+    std::shared_ptr<ColdResumeHandler> resumeHandler);
 
 } // namespace client_server
 } // namespace tests

--- a/test/handlers/HelloStreamRequestHandler.cpp
+++ b/test/handlers/HelloStreamRequestHandler.cpp
@@ -1,7 +1,11 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "HelloStreamRequestHandler.h"
+
 #include <sstream>
+
+#include <folly/Conv.h>
+
 #include "yarpl/Flowable.h"
 
 using namespace ::rsocket;
@@ -21,12 +25,7 @@ HelloStreamRequestHandler::handleRequestStream(
   auto requestString = request.moveDataToString();
 
   return Flowables::range(1, 10)->map([name = std::move(requestString)](
-      int64_t v) {
-    std::stringstream ss;
-    ss << "Hello " << name << " " << v << "!";
-    std::string s = ss.str();
-    return Payload(s, "metadata");
-  });
+      int64_t v) { return Payload(folly::to<std::string>(v), "metadata"); });
 }
 }
 }


### PR DESCRIPTION
This tests client-originated REQUEST_STREAMs for cold-resumption.

Three streams are created from the client and two cold-resumptions happen in-between.

The test verifies that the client gets all the frames in the right order across these two resumptions.  It remembers the last received frame for each stream before resumption and verifies that the incoming frames after resumption are in expected ones.
