### PR TITLE
Lint fixes and `M-x clang-format-buffer`

### DIFF
--- a/benchmarks/Latch.h
+++ b/benchmarks/Latch.h
@@ -7,7 +7,7 @@
 /// Simple implementation of a latch synchronization primitive, for testing.
 class Latch {
  public:
-  Latch(size_t limit): limit_{limit} {}
+  explicit Latch(size_t limit) : limit_{limit} {}
 
   void wait() {
     baton_.wait();

--- a/benchmarks/Throughput.h
+++ b/benchmarks/Throughput.h
@@ -9,7 +9,7 @@ namespace rsocket {
 /// Responder that always sends back a fixed message.
 class FixedResponder : public RSocketResponder {
  public:
-  FixedResponder(const std::string& message)
+  explicit FixedResponder(const std::string& message)
       : message_{folly::IOBuf::copyBuffer(message)} {}
 
   /// Infinitely streams back the message.

--- a/rsocket/statemachine/RequestResponseRequester.cpp
+++ b/rsocket/statemachine/RequestResponseRequester.cpp
@@ -24,7 +24,8 @@ void RequestResponseRequester::subscribe(
     newStream(StreamType::REQUEST_RESPONSE, 1, std::move(initialPayload_));
   } else {
     if (auto subscriber = std::move(consumingSubscriber_)) {
-      subscriber->onError(std::runtime_error("cannot request more than 1 item"));
+      subscriber->onError(
+          std::runtime_error("cannot request more than 1 item"));
     }
     closeStream(StreamCompletionSignal::ERROR);
   }
@@ -115,13 +116,13 @@ void RequestResponseRequester::handlePayload(
   closeStream(StreamCompletionSignal::COMPLETE);
 }
 
-//void RequestResponseRequester::pauseStream(RequestHandler& requestHandler) {
+// void RequestResponseRequester::pauseStream(RequestHandler& requestHandler) {
 //  if (consumingSubscriber_) {
 //    requestHandler.onSubscriberPaused(consumingSubscriber_);
 //  }
 //}
 //
-//void RequestResponseRequester::resumeStream(RequestHandler& requestHandler) {
+// void RequestResponseRequester::resumeStream(RequestHandler& requestHandler) {
 //  if (consumingSubscriber_) {
 //    requestHandler.onSubscriberResumed(consumingSubscriber_);
 //  }

--- a/test/RSocketClientServerTest.cpp
+++ b/test/RSocketClientServerTest.cpp
@@ -2,8 +2,8 @@
 
 #include "RSocketTests.h"
 
-#include <folly/io/async/ScopedEventBaseThread.h>
 #include <folly/Random.h>
+#include <folly/io/async/ScopedEventBaseThread.h>
 #include <gtest/gtest.h>
 #include "test/handlers/HelloStreamRequestHandler.h"
 
@@ -46,7 +46,8 @@ TEST(RSocketClientServer, ConnectManyAsync) {
   for (size_t i = 0; i < connectionCount; ++i) {
     int workerId = folly::Random::rand32(workerCount);
     auto clientFuture =
-        makeClientAsync(workers[workerId].getEventBase(), *server->listeningPort())
+        makeClientAsync(
+            workers[workerId].getEventBase(), *server->listeningPort())
             .then([&executed](std::shared_ptr<rsocket::RSocketClient> client) {
               auto requester = client->getRequester();
               client->disconnect(folly::exception_wrapper());

--- a/yarpl/include/yarpl/flowable/Flowable.h
+++ b/yarpl/include/yarpl/flowable/Flowable.h
@@ -45,12 +45,9 @@ class Flowable : public virtual Refcounted {
       typename = typename std::enable_if<
           std::is_callable<Next(T), void>::value &&
           std::is_callable<Error(folly::exception_wrapper), void>::value>::type>
-  void subscribe(
-      Next next,
-      Error error,
-      int64_t batch = credits::kNoFlowControl) {
-    subscribe(Subscribers::create<T>(
-        std::move(next), std::move(error), batch));
+  void
+  subscribe(Next next, Error error, int64_t batch = credits::kNoFlowControl) {
+    subscribe(Subscribers::create<T>(std::move(next), std::move(error), batch));
   }
 
   /**
@@ -72,19 +69,20 @@ class Flowable : public virtual Refcounted {
       Complete complete,
       int64_t batch = credits::kNoFlowControl) {
     subscribe(Subscribers::create<T>(
-        std::move(next),
-        std::move(error),
-        std::move(complete),
-        batch));
+        std::move(next), std::move(error), std::move(complete), batch));
   }
 
-  template <typename Function, typename R = typename std::result_of<Function(T)>::type>
+  template <
+      typename Function,
+      typename R = typename std::result_of<Function(T)>::type>
   Reference<Flowable<R>> map(Function function);
 
   template <typename Function>
   Reference<Flowable<T>> filter(Function function);
 
-  template <typename Function, typename R = typename std::result_of<Function(T, T)>::type>
+  template <
+      typename Function,
+      typename R = typename std::result_of<Function(T, T)>::type>
   Reference<Flowable<R>> reduce(Function function);
 
   Reference<Flowable<T>> take(int64_t);

--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -39,7 +39,8 @@ class FlowableOperator : public Flowable<D> {
     Subscription(
         Reference<Operator> flowable,
         Reference<Subscriber<D>> subscriber)
-        : flowableOperator_(std::move(flowable)), subscriber_(std::move(subscriber)) {
+        : flowableOperator_(std::move(flowable)),
+          subscriber_(std::move(subscriber)) {
       assert(flowableOperator_);
       assert(subscriber_);
     }

--- a/yarpl/include/yarpl/flowable/Flowables.h
+++ b/yarpl/include/yarpl/flowable/Flowables.h
@@ -106,8 +106,8 @@ class Flowables {
           OnSubscribe(Reference<Subscriber<T>>),
           void>::value>::type>
   static Reference<Flowable<T>> fromPublisher(OnSubscribe function) {
-    return Reference<Flowable<T>>(new FromPublisherOperator<T, OnSubscribe>(
-        std::move(function)));
+    return Reference<Flowable<T>>(
+        new FromPublisherOperator<T, OnSubscribe>(std::move(function)));
   }
 
   template <typename T>
@@ -121,7 +121,8 @@ class Flowables {
 
   template <typename T>
   static Reference<Flowable<T>> error(folly::exception_wrapper ex) {
-    auto lambda = [ex = std::move(ex)](Reference<Subscriber<T>> subscriber, int64_t) {
+    auto lambda = [ex = std::move(ex)](
+        Reference<Subscriber<T>> subscriber, int64_t) {
       subscriber->onError(std::move(ex));
       return std::make_tuple(static_cast<int64_t>(0), true);
     };
@@ -130,7 +131,8 @@ class Flowables {
 
   template <typename T, typename ExceptionType>
   static Reference<Flowable<T>> error(const ExceptionType& ex) {
-    auto lambda = [ex = std::move(ex)](Reference<Subscriber<T>> subscriber, int64_t) {
+    auto lambda = [ex = std::move(ex)](
+        Reference<Subscriber<T>> subscriber, int64_t) {
       subscriber->onError(std::move(ex));
       return std::make_tuple(static_cast<int64_t>(0), true);
     };
@@ -148,10 +150,11 @@ class Flowables {
           ++generated;
         }
         return std::make_tuple(generated, false);
-      } catch(const std::exception& ex) {
-        subscriber->onError(folly::exception_wrapper(std::current_exception(), ex));
+      } catch (const std::exception& ex) {
+        subscriber->onError(
+            folly::exception_wrapper(std::current_exception(), ex));
         return std::make_tuple(generated, true);
-      } catch(...) {
+      } catch (...) {
         subscriber->onError(std::runtime_error("unknown error"));
         return std::make_tuple(generated, true);
       }

--- a/yarpl/include/yarpl/observable/Observables.h
+++ b/yarpl/include/yarpl/observable/Observables.h
@@ -50,9 +50,11 @@ class Observables {
   // this will generate an observable which can be subscribed to only once
   template <typename T>
   static Reference<Observable<T>> justOnce(T value) {
-    auto lambda = [value = std::move(value), used = false](Reference<Observer<T>> observer) mutable {
+    auto lambda = [ value = std::move(value), used = false ](
+        Reference<Observer<T>> observer) mutable {
       if (used) {
-        observer->onError(std::runtime_error("justOnce value was already used"));
+        observer->onError(
+            std::runtime_error("justOnce value was already used"));
         return;
       }
 
@@ -72,8 +74,8 @@ class Observables {
           std::is_callable<OnSubscribe(Reference<Observer<T>>), void>::value>::
           type>
   static Reference<Observable<T>> create(OnSubscribe function) {
-    return Reference<Observable<T>>(new FromPublisherOperator<T, OnSubscribe>(
-        std::move(function)));
+    return Reference<Observable<T>>(
+        new FromPublisherOperator<T, OnSubscribe>(std::move(function)));
   }
 
   template <typename T>


### PR DESCRIPTION
Mostly 80 column violations, a few single-arg ctors without `explicit`.