### PR TITLE
`get_ref` should never be called for an instance of reference count of zero

### DIFF
--- a/yarpl/include/yarpl/Refcounted.h
+++ b/yarpl/include/yarpl/Refcounted.h
@@ -273,13 +273,26 @@ Reference<T> make_ref(Args&&... args) {
   return Reference<T>(new T(std::forward<Args>(args)...));
 }
 
-template <typename T>
+template <
+    typename T,
+    typename =
+    std::enable_if_t<std::is_base_of<Refcounted, std::decay_t<T>>::value>>
 Reference<T> get_ref(T& object) {
+  assert(
+      object.count() > 0 &&
+          "get_ref should not be called from a non referenced object");
+
   return Reference<T>(&object);
 }
 
-template <typename T>
+template <
+    typename T,
+    typename =
+    std::enable_if_t<std::is_base_of<Refcounted, std::decay_t<T>>::value>>
 Reference<T> get_ref(T* object) {
+  assert(
+      object->count() > 0 &&
+          "get_ref should not be called from a non referenced object");
   return Reference<T>(object);
 }
 

--- a/yarpl/include/yarpl/Refcounted.h
+++ b/yarpl/include/yarpl/Refcounted.h
@@ -273,11 +273,10 @@ Reference<T> make_ref(Args&&... args) {
   return Reference<T>(new T(std::forward<Args>(args)...));
 }
 
-template <
-    typename T,
-    typename =
-    std::enable_if_t<std::is_base_of<Refcounted, std::decay_t<T>>::value>>
+template <typename T>
 Reference<T> get_ref(T& object) {
+  static_assert(std::is_base_of<Refcounted, std::decay_t<T>>::value,
+      "This function requires a Refcounted object");
   assert(
       object.count() > 0 &&
           "get_ref should not be called from a non referenced object");
@@ -285,11 +284,10 @@ Reference<T> get_ref(T& object) {
   return Reference<T>(&object);
 }
 
-template <
-    typename T,
-    typename =
-    std::enable_if_t<std::is_base_of<Refcounted, std::decay_t<T>>::value>>
+template <typename T>
 Reference<T> get_ref(T* object) {
+  static_assert(std::is_base_of<Refcounted, std::decay_t<T>>::value,
+      "This function requires a Refcounted object");
   assert(
       object->count() > 0 &&
           "get_ref should not be called from a non referenced object");


### PR DESCRIPTION
https://github.com/rsocket/rsocket-cpp/issues/671

This will prevent buggy code to happen.

Next, we should also properly implement make_ref to let calling get_ref to be possible at the inside of the constructor.