### PR TITLE
Fix hang when destroying RSocketConnectionManager off of the client IO thread

### DIFF
--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -196,13 +196,13 @@ void RSocketStateMachine::close(
     resumeCallback_.reset();
   }
 
+  closeStreams(signal);
+  closeFrameTransport(std::move(ex), signal);
+
   auto connectionEvents = std::move(connectionEvents_);
   if (connectionEvents) {
     connectionEvents->onClosed(ex);
   }
-
-  closeStreams(signal);
-  closeFrameTransport(std::move(ex), signal);
 }
 
 void RSocketStateMachine::closeFrameTransport(

--- a/test/RSocketClientServerTest.cpp
+++ b/test/RSocketClientServerTest.cpp
@@ -62,3 +62,15 @@ TEST(RSocketClientServer, ConnectManyAsync) {
   CHECK_EQ(executed, connectionCount);
   workers.clear();
 }
+
+/// Test destroying a client with an open connection on the same worker thread
+/// as that connection.
+TEST(RSocketClientServer, ClientClosesOnWorker) {
+  folly::ScopedEventBaseThread worker;
+  auto server = makeServer(std::make_shared<HelloStreamRequestHandler>());
+  auto client = makeClient(worker.getEventBase(), *server->listeningPort());
+  auto requester = client->getRequester();
+
+  // Move the client to the worker thread.
+  worker.getEventBase()->runInEventBaseThread([c = std::move(client)] {});
+}


### PR DESCRIPTION
Or really, any IO thread that's managing one of the state machines inside the
connection manager.

To do so, the thread running ~RSocketConnectionManager needs to close the state
machines using it synchronously.  For that, it has to relinquish the
connections map lock.  We'll move out all connections from the map first, then
close them all (either sync or async).  Then we'll use the moral equivalent of a
latch (atomic_int + baton) to determine when all of them have actually closed.