### PR TITLE
No more `new`

### DIFF
--- a/rsocket/statemachine/ConsumerBase.cpp
+++ b/rsocket/statemachine/ConsumerBase.cpp
@@ -23,7 +23,7 @@ void ConsumerBase::subscribe(
 
   DCHECK(!consumingSubscriber_);
   consumingSubscriber_ = std::move(subscriber);
-  consumingSubscriber_->onSubscribe(Reference<Subscription>(this));
+  consumingSubscriber_->onSubscribe(get_ref(this));
 }
 
 void ConsumerBase::checkConsumerRequest() {

--- a/rsocket/statemachine/RequestResponseRequester.cpp
+++ b/rsocket/statemachine/RequestResponseRequester.cpp
@@ -17,7 +17,7 @@ void RequestResponseRequester::subscribe(
   DCHECK(!isTerminated());
   DCHECK(!consumingSubscriber_);
   consumingSubscriber_ = std::move(subscriber);
-  consumingSubscriber_->onSubscribe(Reference<SingleSubscription>(this));
+  consumingSubscriber_->onSubscribe(get_ref(this));
 
   if (state_ == State::NEW) {
     state_ = State::REQUESTED;

--- a/yarpl/include/yarpl/flowable/Flowable_FromObservable.h
+++ b/yarpl/include/yarpl/flowable/Flowable_FromObservable.h
@@ -53,7 +53,7 @@ class FlowableFromObservableSubscription
     if (!started) {
       bool expected = false;
       if (started.compare_exchange_strong(expected, true)) {
-        observable_->subscribe(Reference<yarpl::observable::Observer<T>>(this));
+        observable_->subscribe(get_ref(this));
       }
     }
   }

--- a/yarpl/include/yarpl/flowable/Flowables.h
+++ b/yarpl/include/yarpl/flowable/Flowables.h
@@ -106,8 +106,7 @@ class Flowables {
           OnSubscribe(Reference<Subscriber<T>>),
           void>::value>::type>
   static Reference<Flowable<T>> fromPublisher(OnSubscribe function) {
-    return Reference<Flowable<T>>(
-        new FromPublisherOperator<T, OnSubscribe>(std::move(function)));
+    return make_ref<FromPublisherOperator<T, OnSubscribe>>(std::move(function));
   }
 
   template <typename T>

--- a/yarpl/include/yarpl/flowable/Subscribers.h
+++ b/yarpl/include/yarpl/flowable/Subscribers.h
@@ -25,9 +25,10 @@ class Subscribers {
       typename Next,
       typename =
           typename std::enable_if<std::is_callable<Next(T), void>::value>::type>
-  static auto create(Next next, int64_t batch = kNoFlowControl) {
-    return Reference<Subscriber<T>>(
-        new Base<T, Next>(std::move(next), batch));
+  static Reference<Subscriber<T>> create(
+      Next next,
+      int64_t batch = kNoFlowControl) {
+    return make_ref<Base<T, Next>>(std::move(next), batch);
   }
 
   template <
@@ -37,10 +38,10 @@ class Subscribers {
       typename = typename std::enable_if<
           std::is_callable<Next(T), void>::value &&
           std::is_callable<Error(folly::exception_wrapper), void>::value>::type>
-  static auto
+  static Reference<Subscriber<T>>
   create(Next next, Error error, int64_t batch = kNoFlowControl) {
-    return Reference<Subscriber<T>>(new WithError<T, Next, Error>(
-        std::move(next), std::move(error), batch));
+    return make_ref<WithError<T, Next, Error>>(
+        std::move(next), std::move(error), batch);
   }
 
   template <
@@ -52,17 +53,13 @@ class Subscribers {
           std::is_callable<Next(T), void>::value &&
           std::is_callable<Error(folly::exception_wrapper), void>::value &&
           std::is_callable<Complete(), void>::value>::type>
-  static auto create(
+  static Reference<Subscriber<T>> create(
       Next next,
       Error error,
       Complete complete,
       int64_t batch = kNoFlowControl) {
-    return Reference<Subscriber<T>>(
-        new WithErrorAndComplete<T, Next, Error, Complete>(
-            std::move(next),
-            std::move(error),
-            std::move(complete),
-            batch));
+    return make_ref<WithErrorAndComplete<T, Next, Error, Complete>>(
+        std::move(next), std::move(error), std::move(complete), batch);
   }
 
  private:

--- a/yarpl/include/yarpl/observable/Observable.h
+++ b/yarpl/include/yarpl/observable/Observable.h
@@ -126,61 +126,59 @@ template <typename T>
 template <typename Function>
 auto Observable<T>::map(Function function) {
   using D = typename std::result_of<Function(T)>::type;
-  return Reference<Observable<D>>(new MapOperator<T, D, Function>(
-      Reference<Observable<T>>(this), std::move(function)));
+  return make_ref<MapOperator<T, D, Function>, Observable<D>>(
+      get_ref(this), std::move(function));
 }
 
 template <typename T>
 template <typename Function>
 auto Observable<T>::filter(Function function) {
-  return Reference<Observable<T>>(new FilterOperator<T, Function>(
-      Reference<Observable<T>>(this), std::move(function)));
+  return make_ref<FilterOperator<T, Function>, Observable<T>>(
+      get_ref(this), std::move(function));
 }
 
 template <typename T>
 template <typename Function>
 auto Observable<T>::reduce(Function function) {
   using D = typename std::result_of<Function(T, T)>::type;
-  return Reference<Observable<D>>(new ReduceOperator<T, D, Function>(
-      Reference<Observable<T>>(this), std::move(function)));
+  return make_ref<ReduceOperator<T, D, Function>, Observable<D>>(
+      get_ref(this), std::move(function));
 }
 
 template <typename T>
 auto Observable<T>::take(int64_t limit) {
-  return Reference<Observable<T>>(
-      new TakeOperator<T>(Reference<Observable<T>>(this), limit));
+  return make_ref<TakeOperator<T>, Observable<T>>(get_ref(this), limit);
 }
 
 template <typename T>
 auto Observable<T>::skip(int64_t offset) {
-  return Reference<Observable<T>>(
-      new SkipOperator<T>(Reference<Observable<T>>(this), offset));
+  return make_ref<SkipOperator<T>, Observable<T>>(get_ref(this), offset);
 }
 
 template <typename T>
 auto Observable<T>::ignoreElements() {
-  return Reference<Observable<T>>(
-      new IgnoreElementsOperator<T>(Reference<Observable<T>>(this)));
+  return make_ref<IgnoreElementsOperator<T>, Observable<T>>(get_ref(this));
 }
 
 template <typename T>
 auto Observable<T>::subscribeOn(Scheduler& scheduler) {
-  return Reference<Observable<T>>(
-      new SubscribeOnOperator<T>(Reference<Observable<T>>(this), scheduler));
+  return make_ref<SubscribeOnOperator<T>, Observable<T>>(
+      get_ref(this), scheduler);
 }
 
 template <typename T>
 auto Observable<T>::toFlowable(BackpressureStrategy strategy) {
   // we currently ONLY support the DROP strategy
   // so do not use the strategy parameter for anything
-  auto o = Reference<Observable<T>>(this);
+  auto o = get_ref<Observable<T>>(this);
   return yarpl::flowable::Flowables::fromPublisher<T>([
     o = std::move(o), // the Observable to pass through
     strategy
   ](Reference<yarpl::flowable::Subscriber<T>> s) {
-    s->onSubscribe(Reference<yarpl::flowable::Subscription>(
-        new yarpl::flowable::sources::FlowableFromObservableSubscription<T>(
-            std::move(o), std::move(s))));
+    s->onSubscribe(
+        make_ref<
+            yarpl::flowable::sources::FlowableFromObservableSubscription<T>>(
+            std::move(o), std::move(s)));
   });
 }
 

--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -80,7 +80,7 @@ class ObservableOperator : public Observable<D> {
       }
 
       upstream_ = std::move(subscription);
-      observer_->onSubscribe(Reference<yarpl::observable::Subscription>(this));
+      observer_->onSubscribe(get_ref(this));
     }
 
     void onComplete() override {
@@ -174,8 +174,7 @@ class MapOperator : public ObservableOperator<U, D> {
   void subscribe(Reference<Observer<D>> observer) override {
     ObservableOperator<U, D>::upstream_->subscribe(
         // Note: implicit cast to a reference to a observer.
-        Reference<Subscription>(new Subscription(
-            Reference<Observable<D>>(this), std::move(observer))));
+        make_ref<Subscription>(get_ref(this), std::move(observer)));
   }
 
  private:
@@ -211,8 +210,7 @@ class FilterOperator : public ObservableOperator<U, U> {
   void subscribe(Reference<Observer<U>> observer) override {
     ObservableOperator<U, U>::upstream_->subscribe(
         // Note: implicit cast to a reference to a observer.
-        Reference<Subscription>(new Subscription(
-            Reference<Observable<U>>(this), std::move(observer))));
+        make_ref<Subscription>(get_ref(this), std::move(observer)));
   }
 
  private:
@@ -252,8 +250,7 @@ class ReduceOperator : public ObservableOperator<U, D> {
   void subscribe(Reference<Observer<D>> subscriber) override {
     ObservableOperator<U, D>::upstream_->subscribe(
         // Note: implicit cast to a reference to a subscriber.
-        Reference<Subscription>(new Subscription(
-            Reference<Observable<D>>(this), std::move(subscriber))));
+        make_ref<Subscription>(get_ref(this), std::move(subscriber)));
   }
 
  private:
@@ -300,8 +297,7 @@ class TakeOperator : public ObservableOperator<T, T> {
 
   void subscribe(Reference<Observer<T>> observer) override {
     ObservableOperator<T, T>::upstream_->subscribe(
-        Reference<Subscription>(new Subscription(
-            Reference<Observable<T>>(this), limit_, std::move(observer))));
+        make_ref<Subscription>(get_ref(this), limit_, std::move(observer)));
   }
 
  private:
@@ -341,8 +337,8 @@ class SkipOperator : public ObservableOperator<T, T> {
       : ObservableOperator<T, T>(std::move(upstream)), offset_(offset) {}
 
   void subscribe(Reference<Observer<T>> observer) override {
-    ObservableOperator<T, T>::upstream_->subscribe(make_ref<Subscription>(
-        Reference<Observable<T>>(this), offset_, std::move(observer)));
+    ObservableOperator<T, T>::upstream_->subscribe(
+        make_ref<Subscription>(get_ref(this), offset_, std::move(observer)));
   }
 
  private:
@@ -378,8 +374,8 @@ class IgnoreElementsOperator : public ObservableOperator<T, T> {
       : ObservableOperator<T, T>(std::move(upstream)) {}
 
   void subscribe(Reference<Observer<T>> observer) override {
-    ObservableOperator<T, T>::upstream_->subscribe(Reference<Subscription>(
-        new Subscription(Reference<Observable<T>>(this), std::move(observer))));
+    ObservableOperator<T, T>::upstream_->subscribe(
+        make_ref<Subscription>(get_ref(this), std::move(observer)));
   }
 
  private:
@@ -406,11 +402,8 @@ class SubscribeOnOperator : public ObservableOperator<T, T> {
         worker_(scheduler.createWorker()) {}
 
   void subscribe(Reference<Observer<T>> observer) override {
-    ObservableOperator<T, T>::upstream_->subscribe(
-        Reference<Subscription>(new Subscription(
-            Reference<Observable<T>>(this),
-            std::move(worker_),
-            std::move(observer))));
+    ObservableOperator<T, T>::upstream_->subscribe(make_ref<Subscription>(
+        get_ref(this), std::move(worker_), std::move(observer)));
   }
 
  private:

--- a/yarpl/include/yarpl/observable/Observables.h
+++ b/yarpl/include/yarpl/observable/Observables.h
@@ -74,8 +74,7 @@ class Observables {
           std::is_callable<OnSubscribe(Reference<Observer<T>>), void>::value>::
           type>
   static Reference<Observable<T>> create(OnSubscribe function) {
-    return Reference<Observable<T>>(
-        new FromPublisherOperator<T, OnSubscribe>(std::move(function)));
+    return make_ref<FromPublisherOperator<T, OnSubscribe>>(std::move(function));
   }
 
   template <typename T>

--- a/yarpl/include/yarpl/observable/Observers.h
+++ b/yarpl/include/yarpl/observable/Observers.h
@@ -33,7 +33,7 @@ class Observers {
  public:
   template <typename T, typename Next, typename = EnableIfCompatible<T, Next>>
   static auto create(Next next) {
-    return Reference<Observer<T>>(new Base<T, Next>(std::move(next)));
+    return make_ref<Base<T, Next>, Observer<T>>(std::move(next));
   }
 
   template <
@@ -42,8 +42,8 @@ class Observers {
       typename Error,
       typename = EnableIfCompatible<T, Next, Error>>
   static auto create(Next next, Error error) {
-    return Reference<Observer<T>>(new WithError<T, Next, Error>(
-        std::move(next), std::move(error)));
+    return make_ref<WithError<T, Next, Error>, Observer<T>>(
+        std::move(next), std::move(error));
   }
 
   template <
@@ -53,11 +53,9 @@ class Observers {
       typename Complete,
       typename = EnableIfCompatible<T, Next, Error, Complete>>
   static auto create(Next next, Error error, Complete complete) {
-    return Reference<Observer<T>>(
-        new WithErrorAndComplete<T, Next, Error, Complete>(
-            std::move(next),
-            std::move(error),
-            std::move(complete)));
+    return make_ref<
+        WithErrorAndComplete<T, Next, Error, Complete>,
+        Observer<T>>(std::move(next), std::move(error), std::move(complete));
   }
 
  private:

--- a/yarpl/include/yarpl/single/SingleObservers.h
+++ b/yarpl/include/yarpl/single/SingleObservers.h
@@ -28,8 +28,7 @@ class SingleObservers {
  public:
   template <typename T, typename Next, typename = EnableIfCompatible<T, Next>>
   static auto create(Next next) {
-    return Reference<SingleObserver<T>>(
-        new Base<T, Next>(std::move(next)));
+    return make_ref<Base<T, Next>, SingleObserver<T>>(std::move(next));
   }
 
   template <
@@ -38,8 +37,8 @@ class SingleObservers {
       typename Error,
       typename = EnableIfCompatible<T, Success, Error>>
   static auto create(Success next, Error error) {
-    return Reference<SingleObserver<T>>(new WithError<T, Success, Error>(
-        std::move(next), std::move(error)));
+    return make_ref<WithError<T, Success, Error>, SingleObserver<T>>(
+        std::move(next), std::move(error));
   }
 
  private:

--- a/yarpl/include/yarpl/single/SingleOperator.h
+++ b/yarpl/include/yarpl/single/SingleOperator.h
@@ -58,8 +58,7 @@ class SingleOperator : public Single<D> {
     void onSubscribe(
         Reference<::yarpl::single::SingleSubscription> subscription) override {
       upstreamSubscription_ = std::move(subscription);
-      observer_->onSubscribe(
-          Reference<::yarpl::single::SingleSubscription>(this));
+      observer_->onSubscribe(get_ref(this));
     }
 
     void onError(folly::exception_wrapper error) override {
@@ -110,8 +109,7 @@ class MapOperator : public SingleOperator<U, D> {
   void subscribe(Reference<SingleObserver<D>> observer) override {
     Super::upstream_->subscribe(
         // Note: implicit cast to a reference to a observer.
-        Reference<OperatorSubscription>(new MapSubscription(
-            Reference<ThisOperatorT>(this), std::move(observer))));
+        make_ref<MapSubscription>(get_ref(this), std::move(observer)));
   }
 
  private:

--- a/yarpl/include/yarpl/single/SingleSubscriptions.h
+++ b/yarpl/include/yarpl/single/SingleSubscriptions.h
@@ -116,7 +116,7 @@ class SingleSubscriptions {
     return create([&cancelled]() { cancelled = true; });
   }
   static Reference<SingleSubscription> empty() {
-    return Reference<SingleSubscription>(new AtomicBoolSingleSubscription());
+    return make_ref<AtomicBoolSingleSubscription>();
   }
   static Reference<AtomicBoolSingleSubscription> atomicBoolSubscription() {
     return make_ref<AtomicBoolSingleSubscription>();

--- a/yarpl/include/yarpl/single/Singles.h
+++ b/yarpl/include/yarpl/single/Singles.h
@@ -29,8 +29,7 @@ class Singles {
           OnSubscribe(Reference<SingleObserver<T>>),
           void>::value>::type>
   static Reference<Single<T>> create(OnSubscribe function) {
-    return Reference<Single<T>>(new FromPublisherOperator<T, OnSubscribe>(
-        std::move(function)));
+    return make_ref<FromPublisherOperator<T, OnSubscribe>>(std::move(function));
   }
 
   template <typename T>

--- a/yarpl/src/yarpl/observable/Subscriptions.cpp
+++ b/yarpl/src/yarpl/observable/Subscriptions.cpp
@@ -37,7 +37,7 @@ bool CallbackSubscription::isCancelled() const {
 }
 
 Reference<Subscription> Subscriptions::create(std::function<void()> onCancel) {
-  return Reference<Subscription>(new CallbackSubscription(std::move(onCancel)));
+  return make_ref<CallbackSubscription>(std::move(onCancel));
 }
 
 Reference<Subscription> Subscriptions::create(std::atomic_bool& cancelled) {
@@ -45,11 +45,11 @@ Reference<Subscription> Subscriptions::create(std::atomic_bool& cancelled) {
 }
 
 Reference<Subscription> Subscriptions::empty() {
-  return Reference<Subscription>(new AtomicBoolSubscription());
+  return make_ref<AtomicBoolSubscription>();
 }
 
 Reference<AtomicBoolSubscription> Subscriptions::atomicBoolSubscription() {
-  return Reference<AtomicBoolSubscription>(new AtomicBoolSubscription());
+  return make_ref<AtomicBoolSubscription>();
 }
 }
 }

--- a/yarpl/test/Observable_test.cpp
+++ b/yarpl/test/Observable_test.cpp
@@ -236,7 +236,7 @@ TEST(Observable, SubscriptionCancellation) {
   });
 
   std::vector<int> v;
-  a->subscribe(Reference<Observer<int>>(new TakeObserver(2, v)));
+  a->subscribe(make_ref<TakeObserver>(2, v));
   EXPECT_EQ((unsigned long)2, v.size());
   EXPECT_EQ(2, emitted);
 }

--- a/yarpl/test/RefcountedTest.cpp
+++ b/yarpl/test/RefcountedTest.cpp
@@ -20,7 +20,7 @@ TEST(RefcountedTest, ObjectCountsAreMaintained) {
 }
 
 TEST(RefcountedTest, ReferenceCountingWorks) {
-  auto first = Reference<Refcounted>(new Refcounted);
+  auto first = make_ref<Refcounted>();
   EXPECT_EQ(1U, first->count());
 
   auto second = first;

--- a/yarpl/test/ReferenceTest.cpp
+++ b/yarpl/test/ReferenceTest.cpp
@@ -21,7 +21,7 @@ class MySubscriber : public Subscriber<T> {
 }
 
 TEST(ReferenceTest, Upcast) {
-  Reference<MySubscriber<int>> derived(new MySubscriber<int>());
+  Reference<MySubscriber<int>> derived = yarpl::make_ref<MySubscriber<int>>();
   Reference<Subscriber<int>> base1(derived);
 
   Reference<Subscriber<int>> base2;
@@ -38,48 +38,36 @@ TEST(ReferenceTest, Upcast) {
 
 TEST(RefcountedTest, CopyAssign) {
   using Sub = MySubscriber<int>;
-  Reference<Sub> a(new Sub());
+  Reference<Sub> a = yarpl::make_ref<Sub>();
   Reference<Sub> b(a);
   EXPECT_EQ(2u, a->count());
-  Sub* ptr = nullptr;
-  Reference<Sub> c(ptr = new Sub());
+  Reference<Sub> c = yarpl::make_ref<Sub>();
   b = c;
   EXPECT_EQ(1u, a->count());
-  EXPECT_EQ(ptr, b.get());
+  EXPECT_EQ(2u, b->count());
+  EXPECT_EQ(2u, c->count());
+  EXPECT_EQ(c, b);
 }
 
 TEST(RefcountedTest, MoveAssign) {
   using Sub = MySubscriber<int>;
-  Reference<Sub> a(new Sub());
-  Reference<Sub> b(a);
-  EXPECT_EQ(2u, a->count());
-  Sub* ptr = nullptr;
-  b = Reference<Sub>(ptr = new Sub());
-  EXPECT_EQ(1u, a->count());
-  EXPECT_EQ(ptr, b.get());
-}
+  Reference<Sub> a = yarpl::make_ref<Sub>();
+  Reference<Sub> b(std::move(a));
+  EXPECT_EQ(nullptr, a);
+  EXPECT_EQ(1u, b->count());
 
-TEST(RefcountedTest, CopyAssignTemplate) {
-  using Sub = MySubscriber<int>;
-  Reference<Sub> a(new Sub());
-  Reference<Sub> b(a);
-  EXPECT_EQ(2u, a->count());
-  using Sub2 = MySubscriber<int>;
-  Sub2* ptr = nullptr;
-  Reference<Sub2> c(ptr = new Sub2());
-  b = c;
-  EXPECT_EQ(1u, a->count());
-  EXPECT_EQ(ptr, b.get());
+  Reference<Sub> c;
+  c = std::move(b);
+  EXPECT_EQ(nullptr, b);
+  EXPECT_EQ(1u, c->count());
 }
 
 TEST(RefcountedTest, MoveAssignTemplate) {
   using Sub = MySubscriber<int>;
-  Reference<Sub> a(new Sub());
+  Reference<Sub> a = yarpl::make_ref<Sub>();
   Reference<Sub> b(a);
   EXPECT_EQ(2u, a->count());
   using Sub2 = MySubscriber<int>;
-  Sub2* ptr = nullptr;
-  b = Reference<Sub2>(ptr = new Sub2());
+  b = yarpl::make_ref<Sub2>();
   EXPECT_EQ(1u, a->count());
-  EXPECT_EQ(ptr, b.get());
 }


### PR DESCRIPTION
Changes instances of `new Refcounted` to `make_ref<Refcounted>`, to prepare for removing the `Reference(T*)` public API. With this we can start reducing the surface area for raw pointers held by `Reference`s to be leaked. 