### PR TITLE
Enable calling `get_ref` inside of constructors without fear of deallocation

### DIFF
--- a/yarpl/include/yarpl/flowable/EmitterFlowable.h
+++ b/yarpl/include/yarpl/flowable/EmitterFlowable.h
@@ -25,7 +25,7 @@ class EmiterBase : public virtual Refcounted {
  * of a request(n) call.
  */
 template <typename T>
-class EmiterSubscription : private Subscription, private Subscriber<T> {
+class EmiterSubscription : public Subscription, public Subscriber<T> {
   constexpr static auto kCanceled = credits::kCanceled;
   constexpr static auto kNoFlowControl = credits::kNoFlowControl;
 
@@ -203,7 +203,7 @@ class EmitterWrapper : public EmiterBase<T>, public Flowable<T> {
   explicit EmitterWrapper(Emitter emitter) : emitter_(std::move(emitter)) {}
 
   void subscribe(Reference<Subscriber<T>> subscriber) override {
-    new EmiterSubscription<T>(get_ref(this), std::move(subscriber));
+    make_ref<EmiterSubscription<T>>(get_ref(this), std::move(subscriber));
   }
 
   std::tuple<int64_t, bool> emit(

--- a/yarpl/test/RefcountedTest.cpp
+++ b/yarpl/test/RefcountedTest.cpp
@@ -13,7 +13,7 @@ TEST(RefcountedTest, ObjectCountsAreMaintained) {
   std::vector<std::unique_ptr<Refcounted>> v;
   for (std::size_t i = 0; i < 16; ++i) {
     v.push_back(std::make_unique<Refcounted>());
-    EXPECT_EQ(0U, v[i]->count()); // no references.
+    EXPECT_EQ(1U, v[i]->count()); // no references.
   }
 
   v.resize(11);
@@ -45,4 +45,17 @@ TEST(RefcountedTest, ReferenceCountingWorks) {
   EXPECT_EQ(nullptr, fourth.get());
   EXPECT_EQ(2U, first->count());
 }
+
+
+class MyRefInside : public virtual Refcounted {
+public:
+  MyRefInside() {
+    auto r = get_ref(this);
+  }
+};
+
+TEST(RefcountedTest, CanCallGetRefInCtor) {
+  make_ref<MyRefInside>();
+}
+
 } // yarpl


### PR DESCRIPTION
What's on the tin