### PR TITLE
Allow cold-resume even if the old transport closure is delayed

### DIFF
--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -88,6 +88,10 @@ void RSocketStateMachine::connectServer(
 bool RSocketStateMachine::resumeServer(
     yarpl::Reference<FrameTransport> frameTransport,
     const ResumeParameters& resumeParams) {
+  if (!isDisconnectedOrClosed()) {
+    disconnect(folly::exception_wrapper(
+        std::runtime_error("A new transport is resuming the session")));
+  }
   CHECK(connect(
       std::move(frameTransport), resumeParams.protocolVersion));
   return resumeFromPositionOrClose(

--- a/test/ColdResumptionTest.cpp
+++ b/test/ColdResumptionTest.cpp
@@ -149,7 +149,6 @@ TEST(ColdResumptionTest, SuccessfulResumption) {
   }
 
   VLOG(1) << "============== First Cold Resumption ================";
-  sleep(1);
 
   {
     auto firstSub = yarpl::make_ref<HelloSubscriber>(firstLatestValue);
@@ -185,7 +184,6 @@ TEST(ColdResumptionTest, SuccessfulResumption) {
   }
 
   VLOG(1) << "============= Second Cold Resumption ===============";
-  sleep(1);
 
   {
     auto firstSub = yarpl::make_ref<HelloSubscriber>(firstLatestValue);


### PR DESCRIPTION
If the client cold-resumes quickly (before the old connection to the server is properly terminated), then the cold-resume fails `CHECK(isClosedOrDisconnected())` in `resumeServer()`.  This change proactively closes the old transport (if it is still open) on cold-resumption at the server.