### PR TITLE
Add DCHECKs on base Subscriber classes to ensure we're using them cor…

### DIFF
--- a/yarpl/include/yarpl/flowable/Subscriber.h
+++ b/yarpl/include/yarpl/flowable/Subscriber.h
@@ -2,11 +2,12 @@
 
 #pragma once
 
-#include <folly/ExceptionWrapper.h>
-#include <stdexcept>
-
 #include "yarpl/Refcounted.h"
 #include "yarpl/flowable/Subscription.h"
+
+#include <folly/ExceptionWrapper.h>
+
+#include <glog/logging.h>
 
 namespace yarpl {
 namespace flowable {
@@ -14,19 +15,28 @@ namespace flowable {
 template <typename T>
 class Subscriber : public virtual Refcounted {
  public:
-  // Note: if any of the following methods is overridden in a subclass,
-  // the new methods SHOULD ensure that these are invoked as well.
+  // Note: If any of the following methods is overridden in a subclass, the new
+  // methods SHOULD ensure that these are invoked as well.
   virtual void onSubscribe(Reference<Subscription> subscription) {
-    subscription_ = subscription;
+    DCHECK(subscription);
+
+    if (subscription_) {
+      subscription->cancel();
+      return;
+    }
+
+    subscription_ = std::move(subscription);
   }
 
   // No further calls to the subscription after this method is invoked.
   virtual void onComplete() {
+    DCHECK(subscription_) << "Calling onComplete() without a subscription";
     subscription_.reset();
   }
 
   // No further calls to the subscription after this method is invoked.
   virtual void onError(folly::exception_wrapper) {
+    DCHECK(subscription_) << "Calling onError() without a subscription";
     subscription_.reset();
   }
 
@@ -38,10 +48,7 @@ class Subscriber : public virtual Refcounted {
   }
 
  private:
-  // "Our" reference to the subscription, to ensure that it is retained
-  // while calls to its methods are in-flight.
-  Reference<Subscription> subscription_{nullptr};
+  Reference<Subscription> subscription_;
 };
-
-} // flowable
-} // yarpl
+}
+}

--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -459,6 +459,5 @@ class FromPublisherOperator : public Observable<T> {
  private:
   OnSubscribe function_;
 };
-
-} // observable
-} // yarpl
+}
+}

--- a/yarpl/include/yarpl/observable/Observables.h
+++ b/yarpl/include/yarpl/observable/Observables.h
@@ -5,6 +5,7 @@
 #include <limits>
 
 #include "yarpl/observable/Observable.h"
+#include "yarpl/observable/Subscriptions.h"
 
 namespace yarpl {
 namespace observable {
@@ -13,6 +14,7 @@ class Observables {
  public:
   static Reference<Observable<int64_t>> range(int64_t start, int64_t end) {
     auto lambda = [start, end](Reference<Observer<int64_t>> observer) {
+      observer->onSubscribe(Subscriptions::empty());
       for (int64_t i = start; i < end; ++i) {
         observer->onNext(i);
       }
@@ -25,7 +27,7 @@ class Observables {
   template <typename T>
   static Reference<Observable<T>> just(const T& value) {
     auto lambda = [value](Reference<Observer<T>> observer) {
-      // # requested should be > 0.  Ignoring the actual parameter.
+      observer->onSubscribe(Subscriptions::empty());
       observer->onNext(value);
       observer->onComplete();
     };
@@ -38,6 +40,7 @@ class Observables {
     std::vector<T> vec(list);
 
     auto lambda = [v = std::move(vec)](Reference<Observer<T>> observer) {
+      observer->onSubscribe(Subscriptions::empty());
       for (auto const& elem : v) {
         observer->onNext(elem);
       }
@@ -52,6 +55,8 @@ class Observables {
   static Reference<Observable<T>> justOnce(T value) {
     auto lambda = [ value = std::move(value), used = false ](
         Reference<Observer<T>> observer) mutable {
+      observer->onSubscribe(Subscriptions::empty());
+
       if (used) {
         observer->onError(
             std::runtime_error("justOnce value was already used"));
@@ -59,7 +64,6 @@ class Observables {
       }
 
       used = true;
-      // # requested should be > 0.  Ignoring the actual parameter.
       observer->onNext(std::move(value));
       observer->onComplete();
     };
@@ -81,6 +85,7 @@ class Observables {
   template <typename T>
   static Reference<Observable<T>> empty() {
     auto lambda = [](Reference<Observer<T>> observer) {
+      observer->onSubscribe(Subscriptions::empty());
       observer->onComplete();
     };
     return Observable<T>::create(std::move(lambda));
@@ -89,6 +94,7 @@ class Observables {
   template <typename T>
   static Reference<Observable<T>> error(folly::exception_wrapper ex) {
     auto lambda = [ex = std::move(ex)](Reference<Observer<T>> observer) {
+      observer->onSubscribe(Subscriptions::empty());
       observer->onError(std::move(ex));
     };
     return Observable<T>::create(std::move(lambda));
@@ -97,6 +103,7 @@ class Observables {
   template <typename T, typename ExceptionType>
   static Reference<Observable<T>> error(const ExceptionType& ex) {
     auto lambda = [ex = std::move(ex)](Reference<Observer<T>> observer) {
+      observer->onSubscribe(Subscriptions::empty());
       observer->onError(std::move(ex));
     };
     return Observable<T>::create(std::move(lambda));


### PR DESCRIPTION
…rectly

Stuff like making sure we call onSubscribe() before on{Next,Complete,Error}().
Also be sure to cancel subscriptions in onSubscribe() if we've already got a
subscription running.