### PR TITLE
Adding support for cancellation to Observables

### DIFF
--- a/examples/stream-observable-to-flowable/StreamObservableToFlowable_Server.cpp
+++ b/examples/stream-observable-to-flowable/StreamObservableToFlowable_Server.cpp
@@ -52,10 +52,8 @@ class PushStreamRequestResponder : public rsocket::RSocketResponder {
              // operator is not ready yet. This can eventually
              // be replaced with use of 'subscribeOn'.
              std::thread([s, name]() {
-               auto subscription = Subscriptions::atomicBoolSubscription();
-               s->onSubscribe(subscription);
                int64_t v = 0;
-               while (!subscription->isCancelled()) {
+               while (!s->isUnsubscribed()) {
                  std::stringstream ss;
                  ss << "Event[" << name << "]-" << ++v << "!";
                  std::string payloadData = ss.str();

--- a/yarpl/include/yarpl/Refcounted.h
+++ b/yarpl/include/yarpl/Refcounted.h
@@ -26,6 +26,9 @@ class Reference;
 /// NOTE: Only derive using "virtual public" inheritance.
 class Refcounted {
  public:
+
+  /// dtor is thread safe because we cast thread_fence before
+  /// calling delete this
   virtual ~Refcounted() = default;
 
   // Return the current count.  For testing.

--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -468,7 +468,7 @@ class FromPublisherOperator : public Observable<T> {
       Observer<T>::onSubscribe(std::move(subscription));
     }
 
-    void onSubscribe(Reference<Subscription> subscription) override {
+    void onSubscribe(Reference<Subscription>) override {
       DLOG(ERROR) << "not allowed to call";
     }
 

--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -6,7 +6,7 @@
 
 #include "yarpl/Observable.h"
 #include "yarpl/observable/Observer.h"
-#include "yarpl/observable/Subscription.h"
+#include "yarpl/observable/Subscriptions.h"
 
 namespace yarpl {
 namespace observable {
@@ -32,10 +32,10 @@ class ObservableOperator : public Observable<D> {
   /// against Operators.  Each operator subscription has two functions: as a
   /// subscriber for the previous stage; as a subscription for the next one,
   /// the user-supplied subscriber being the last of the pipeline stages.
-  class Subscription : public ::yarpl::observable::Subscription,
+  class OperatorSubscription : public ::yarpl::observable::Subscription,
                        public Observer<U> {
    protected:
-    Subscription(
+    OperatorSubscription(
         Reference<Observable<D>> observable,
         Reference<Observer<D>> observer)
         : observable_(std::move(observable)), observer_(std::move(observer)) {
@@ -67,6 +67,7 @@ class ObservableOperator : public Observable<D> {
     // Subscription.
 
     void cancel() override {
+      Subscription::cancel();
       terminateImpl(TerminateState::Up());
     }
 
@@ -75,10 +76,10 @@ class ObservableOperator : public Observable<D> {
     void onSubscribe(
         Reference<yarpl::observable::Subscription> subscription) override {
       if (upstream_) {
+        DLOG(ERROR) << "attempt to subscribe twice";
         subscription->cancel();
         return;
       }
-
       upstream_ = std::move(subscription);
       observer_->onSubscribe(get_ref(this));
     }
@@ -154,6 +155,7 @@ class ObservableOperator : public Observable<D> {
     /// calls should be forwarded upstream.  Note that `this` is also a
     /// observer for the upstream stage: thus, there are cycles; all of
     /// the objects drop their references at cancel/complete.
+    //TODO(lehecka): this is extra field... base class has this member so remove it
     Reference<::yarpl::observable::Subscription> upstream_;
   };
 
@@ -171,18 +173,20 @@ class MapOperator : public ObservableOperator<U, D> {
       : ObservableOperator<U, D>(std::move(upstream)),
         function_(std::move(function)) {}
 
-  void subscribe(Reference<Observer<D>> observer) override {
+  Reference<Subscription> subscribe(Reference<Observer<D>> observer) override {
+    auto subscription = make_ref<MapSubscription>(get_ref(this), std::move(observer));
     ObservableOperator<U, D>::upstream_->subscribe(
         // Note: implicit cast to a reference to a observer.
-        make_ref<Subscription>(get_ref(this), std::move(observer)));
+        subscription);
+    return subscription;
   }
 
  private:
-  class Subscription : public ObservableOperator<U, D>::Subscription {
-    using Super = typename ObservableOperator<U, D>::Subscription;
+  class MapSubscription : public ObservableOperator<U, D>::OperatorSubscription {
+    using Super = typename ObservableOperator<U, D>::OperatorSubscription;
 
    public:
-    Subscription(
+    MapSubscription(
         Reference<Observable<D>> observable,
         Reference<Observer<D>> observer)
         : Super(std::move(observable), std::move(observer)) {}
@@ -207,18 +211,20 @@ class FilterOperator : public ObservableOperator<U, U> {
       : ObservableOperator<U, U>(std::move(upstream)),
         function_(std::move(function)) {}
 
-  void subscribe(Reference<Observer<U>> observer) override {
+  Reference<Subscription> subscribe(Reference<Observer<U>> observer) override {
+    auto subscription = make_ref<FilterSubscription>(get_ref(this), std::move(observer));
     ObservableOperator<U, U>::upstream_->subscribe(
         // Note: implicit cast to a reference to a observer.
-        make_ref<Subscription>(get_ref(this), std::move(observer)));
+        subscription);
+    return subscription;
   }
 
  private:
-  class Subscription : public ObservableOperator<U, U>::Subscription {
-    using Super = typename ObservableOperator<U, U>::Subscription;
+  class FilterSubscription : public ObservableOperator<U, U>::OperatorSubscription {
+    using Super = typename ObservableOperator<U, U>::OperatorSubscription;
 
    public:
-    Subscription(
+    FilterSubscription(
         Reference<Observable<U>> observable,
         Reference<Observer<U>> observer)
         : Super(std::move(observable), std::move(observer)) {}
@@ -247,18 +253,20 @@ class ReduceOperator : public ObservableOperator<U, D> {
       : ObservableOperator<U, D>(std::move(upstream)),
         function_(std::move(function)) {}
 
-  void subscribe(Reference<Observer<D>> subscriber) override {
+  Reference<Subscription> subscribe(Reference<Observer<D>> subscriber) override {
+    auto subscription = make_ref<ReduceSubscription>(get_ref(this), std::move(subscriber));
     ObservableOperator<U, D>::upstream_->subscribe(
         // Note: implicit cast to a reference to a subscriber.
-        make_ref<Subscription>(get_ref(this), std::move(subscriber)));
+        subscription);
+    return subscription;
   }
 
  private:
-  class Subscription : public ObservableOperator<U, D>::Subscription {
-    using Super = typename ObservableOperator<U, D>::Subscription;
+  class ReduceSubscription : public ObservableOperator<U, D>::OperatorSubscription {
+    using Super = typename ObservableOperator<U, D>::OperatorSubscription;
 
    public:
-    Subscription(
+    ReduceSubscription(
         Reference<Observable<D>> flowable,
         Reference<Observer<D>> subscriber)
         : Super(std::move(flowable), std::move(subscriber)),
@@ -295,17 +303,19 @@ class TakeOperator : public ObservableOperator<T, T> {
   TakeOperator(Reference<Observable<T>> upstream, int64_t limit)
       : ObservableOperator<T, T>(std::move(upstream)), limit_(limit) {}
 
-  void subscribe(Reference<Observer<T>> observer) override {
+  Reference<Subscription> subscribe(Reference<Observer<T>> observer) override {
+    auto subscription = make_ref<TakeSubscription>(get_ref(this), limit_, std::move(observer));
     ObservableOperator<T, T>::upstream_->subscribe(
-        make_ref<Subscription>(get_ref(this), limit_, std::move(observer)));
+        subscription);
+    return subscription;
   }
 
  private:
-  class Subscription : public ObservableOperator<T, T>::Subscription {
-    using Super = typename ObservableOperator<T, T>::Subscription;
+  class TakeSubscription : public ObservableOperator<T, T>::OperatorSubscription {
+    using Super = typename ObservableOperator<T, T>::OperatorSubscription;
 
    public:
-    Subscription(
+    TakeSubscription(
         Reference<Observable<T>> observable,
         int64_t limit,
         Reference<Observer<T>> observer)
@@ -336,17 +346,19 @@ class SkipOperator : public ObservableOperator<T, T> {
   SkipOperator(Reference<Observable<T>> upstream, int64_t offset)
       : ObservableOperator<T, T>(std::move(upstream)), offset_(offset) {}
 
-  void subscribe(Reference<Observer<T>> observer) override {
+  Reference<Subscription> subscribe(Reference<Observer<T>> observer) override {
+    auto subscription = make_ref<SkipSubscription>(get_ref(this), offset_, std::move(observer));
     ObservableOperator<T, T>::upstream_->subscribe(
-        make_ref<Subscription>(get_ref(this), offset_, std::move(observer)));
+        subscription);
+    return subscription;
   }
 
  private:
-  class Subscription : public ObservableOperator<T, T>::Subscription {
-    using Super = typename ObservableOperator<T, T>::Subscription;
+  class SkipSubscription : public ObservableOperator<T, T>::OperatorSubscription {
+    using Super = typename ObservableOperator<T, T>::OperatorSubscription;
 
    public:
-    Subscription(
+    SkipSubscription(
         Reference<Observable<T>> observable,
         int64_t offset,
         Reference<Observer<T>> observer)
@@ -373,20 +385,22 @@ class IgnoreElementsOperator : public ObservableOperator<T, T> {
   explicit IgnoreElementsOperator(Reference<Observable<T>> upstream)
       : ObservableOperator<T, T>(std::move(upstream)) {}
 
-  void subscribe(Reference<Observer<T>> observer) override {
+  Reference<Subscription> subscribe(Reference<Observer<T>> observer) override {
+    auto subscription = make_ref<IgnoreElementsSubscription>(get_ref(this), std::move(observer));
     ObservableOperator<T, T>::upstream_->subscribe(
-        make_ref<Subscription>(get_ref(this), std::move(observer)));
+        subscription);
+    return subscription;
   }
 
  private:
-  class Subscription : public ObservableOperator<T, T>::Subscription {
-    using Super = typename ObservableOperator<T, T>::Subscription;
+  class IgnoreElementsSubscription : public ObservableOperator<T, T>::OperatorSubscription {
+    using Super = typename ObservableOperator<T, T>::OperatorSubscription;
 
    public:
-    Subscription(
+    IgnoreElementsSubscription(
         Reference<Observable<T>> observable,
         Reference<Observer<T>> observer)
-        : ObservableOperator<T, T>::Subscription(
+        : Super(
               std::move(observable),
               std::move(observer)) {}
 
@@ -401,19 +415,22 @@ class SubscribeOnOperator : public ObservableOperator<T, T> {
       : ObservableOperator<T, T>(std::move(upstream)),
         worker_(scheduler.createWorker()) {}
 
-  void subscribe(Reference<Observer<T>> observer) override {
-    ObservableOperator<T, T>::upstream_->subscribe(make_ref<Subscription>(
-        get_ref(this), std::move(worker_), std::move(observer)));
+  Reference<Subscription> subscribe(Reference<Observer<T>> observer) override {
+    auto subscription = make_ref<SubscribeOnSubscription>(
+        get_ref(this), std::move(worker_), std::move(observer));
+    ObservableOperator<T, T>::upstream_->subscribe(subscription);
+    return subscription;
   }
 
  private:
-  class Subscription : public ObservableOperator<T, T>::Subscription {
+  class SubscribeOnSubscription : public ObservableOperator<T, T>::OperatorSubscription {
+   using Super = typename ObservableOperator<T, T>::OperatorSubscription;
    public:
-    Subscription(
+    SubscribeOnSubscription(
         Reference<Observable<T>> observable,
         std::unique_ptr<Worker> worker,
         Reference<Observer<T>> observer)
-        : ObservableOperator<T, T>::Subscription(
+        : Super(
               std::move(observable),
               std::move(observer)),
           worker_(std::move(worker)) {}
@@ -423,14 +440,13 @@ class SubscribeOnOperator : public ObservableOperator<T, T> {
     }
 
     void onNext(T value) override {
-      auto* observer = ObservableOperator<T, T>::Subscription::observer_.get();
-      observer->onNext(std::move(value));
+      observerOnNext(std::move(value));
     }
 
    private:
     // Trampoline to call superclass method; gcc bug 58972.
     void callSuperCancel() {
-      ObservableOperator<T, T>::Subscription::cancel();
+      Super::cancel();
     }
 
     std::unique_ptr<Worker> worker_;
@@ -445,8 +461,44 @@ class FromPublisherOperator : public Observable<T> {
   explicit FromPublisherOperator(OnSubscribe function)
       : function_(std::move(function)) {}
 
-  void subscribe(Reference<Observer<T>> observer) override {
-    function_(std::move(observer));
+ private:
+  class PublisherObserver : public Observer<T> {
+   public:
+    PublisherObserver(Reference<Observer<T>> inner, Reference<Subscription> subscription) : inner_(std::move(inner)) {
+      Observer<T>::onSubscribe(std::move(subscription));
+    }
+
+    void onSubscribe(Reference<Subscription> subscription) override {
+      DLOG(ERROR) << "not allowed to call";
+    }
+
+    void onComplete() override {
+      inner_->onComplete();
+      Observer<T>::onComplete();
+    }
+
+    void onError(folly::exception_wrapper ex) override {
+      inner_->onError(std::move(ex));
+      Observer<T>::onError(folly::exception_wrapper());
+    }
+
+    void onNext(T t) override {
+      inner_->onNext(std::move(t));
+    }
+
+   private:
+    Reference<Observer<T>> inner_;
+  };
+
+ public:
+  Reference<Subscription> subscribe(Reference<Observer<T>> observer) override {
+    auto subscription = Subscriptions::create();
+    observer->onSubscribe(subscription);
+
+    if(!subscription->isCancelled()) {
+      function_(make_ref<PublisherObserver>(std::move(observer), subscription));
+    }
+    return subscription;
   }
 
  private:

--- a/yarpl/include/yarpl/observable/Observables.h
+++ b/yarpl/include/yarpl/observable/Observables.h
@@ -14,7 +14,6 @@ class Observables {
  public:
   static Reference<Observable<int64_t>> range(int64_t start, int64_t end) {
     auto lambda = [start, end](Reference<Observer<int64_t>> observer) {
-      observer->onSubscribe(Subscriptions::empty());
       for (int64_t i = start; i < end; ++i) {
         observer->onNext(i);
       }
@@ -27,7 +26,6 @@ class Observables {
   template <typename T>
   static Reference<Observable<T>> just(const T& value) {
     auto lambda = [value](Reference<Observer<T>> observer) {
-      observer->onSubscribe(Subscriptions::empty());
       observer->onNext(value);
       observer->onComplete();
     };
@@ -40,7 +38,6 @@ class Observables {
     std::vector<T> vec(list);
 
     auto lambda = [v = std::move(vec)](Reference<Observer<T>> observer) {
-      observer->onSubscribe(Subscriptions::empty());
       for (auto const& elem : v) {
         observer->onNext(elem);
       }
@@ -55,8 +52,6 @@ class Observables {
   static Reference<Observable<T>> justOnce(T value) {
     auto lambda = [ value = std::move(value), used = false ](
         Reference<Observer<T>> observer) mutable {
-      observer->onSubscribe(Subscriptions::empty());
-
       if (used) {
         observer->onError(
             std::runtime_error("justOnce value was already used"));
@@ -84,7 +79,6 @@ class Observables {
   template <typename T>
   static Reference<Observable<T>> empty() {
     auto lambda = [](Reference<Observer<T>> observer) {
-      observer->onSubscribe(Subscriptions::empty());
       observer->onComplete();
     };
     return Observable<T>::create(std::move(lambda));
@@ -93,7 +87,6 @@ class Observables {
   template <typename T>
   static Reference<Observable<T>> error(folly::exception_wrapper ex) {
     auto lambda = [ex = std::move(ex)](Reference<Observer<T>> observer) {
-      observer->onSubscribe(Subscriptions::empty());
       observer->onError(std::move(ex));
     };
     return Observable<T>::create(std::move(lambda));
@@ -102,7 +95,6 @@ class Observables {
   template <typename T, typename ExceptionType>
   static Reference<Observable<T>> error(const ExceptionType& ex) {
     auto lambda = [ex = std::move(ex)](Reference<Observer<T>> observer) {
-      observer->onSubscribe(Subscriptions::empty());
       observer->onError(std::move(ex));
     };
     return Observable<T>::create(std::move(lambda));

--- a/yarpl/include/yarpl/observable/Observer.h
+++ b/yarpl/include/yarpl/observable/Observer.h
@@ -21,6 +21,7 @@ class Observer : public virtual Refcounted {
     DCHECK(subscription);
 
     if (subscription_) {
+      DLOG(ERROR) << "attempt to double subscribe";
       subscription->cancel();
       return;
     }
@@ -42,9 +43,19 @@ class Observer : public virtual Refcounted {
 
   virtual void onNext(T) = 0;
 
+  bool isUnsubscribed() const {
+    CHECK(subscription_);
+    return subscription_->isCancelled();
+  }
+
  protected:
   Subscription* subscription() {
     return subscription_.operator->();
+  }
+
+  void unsubscribe() {
+    CHECK(subscription_);
+    subscription_->cancel();
   }
 
  private:

--- a/yarpl/include/yarpl/observable/Subscription.h
+++ b/yarpl/include/yarpl/observable/Subscription.h
@@ -10,10 +10,10 @@ namespace observable {
 class Subscription : public virtual Refcounted {
  public:
   virtual ~Subscription() = default;
-  virtual void cancel() = 0;
+  virtual void cancel();
+  bool isCancelled() const;
 
- protected:
-  Subscription() = default;
+  std::atomic<bool> cancelled_{false};
 };
 
 } // observable

--- a/yarpl/include/yarpl/observable/Subscriptions.h
+++ b/yarpl/include/yarpl/observable/Subscriptions.h
@@ -14,28 +14,14 @@ namespace yarpl {
 namespace observable {
 
 /**
-* Implementation that allows checking if a Subscription is cancelled.
-*/
-class AtomicBoolSubscription : public Subscription {
- public:
-  void cancel() override;
-  bool isCancelled() const;
-
- private:
-  std::atomic_bool cancelled_{false};
-};
-
-/**
 * Implementation that gets a callback when cancellation occurs.
 */
 class CallbackSubscription : public Subscription {
  public:
   explicit CallbackSubscription(std::function<void()> onCancel);
   void cancel() override;
-  bool isCancelled() const;
 
  private:
-  std::atomic_bool cancelled_{false};
   std::function<void()> onCancel_;
 };
 
@@ -43,8 +29,7 @@ class Subscriptions {
  public:
   static Reference<Subscription> create(std::function<void()> onCancel);
   static Reference<Subscription> create(std::atomic_bool& cancelled);
-  static Reference<Subscription> empty();
-  static Reference<AtomicBoolSubscription> atomicBoolSubscription();
+  static Reference<Subscription> create();
 };
 
 } // observable namespace

--- a/yarpl/perf/Observable_perf.cpp
+++ b/yarpl/perf/Observable_perf.cpp
@@ -10,7 +10,6 @@ using namespace yarpl::observable;
 static void Observable_OnNextOne_ConstructOnly(benchmark::State& state) {
   while (state.KeepRunning()) {
     auto a = Observable<int>::create([](yarpl::Reference<Observer<int>> obs) {
-      obs->onSubscribe(Subscriptions::empty());
       obs->onNext(1);
       obs->onComplete();
     });
@@ -20,7 +19,6 @@ BENCHMARK(Observable_OnNextOne_ConstructOnly);
 
 static void Observable_OnNextOne_SubscribeOnly(benchmark::State& state) {
   auto a = Observable<int>::create([](yarpl::Reference<Observer<int>> obs) {
-    obs->onSubscribe(Subscriptions::empty());
     obs->onNext(1);
     obs->onComplete();
   });
@@ -33,7 +31,6 @@ BENCHMARK(Observable_OnNextOne_SubscribeOnly);
 static void Observable_OnNextN(benchmark::State& state) {
   auto a =
       Observable<int>::create([&state](yarpl::Reference<Observer<int>> obs) {
-        obs->onSubscribe(Subscriptions::empty());
         for (int i = 0; i < state.range(0); i++) {
           obs->onNext(i);
         }

--- a/yarpl/src/yarpl/observable/Subscriptions.cpp
+++ b/yarpl/src/yarpl/observable/Subscriptions.cpp
@@ -10,11 +10,11 @@ namespace observable {
 /**
  * Implementation that allows checking if a Subscription is cancelled.
  */
-void AtomicBoolSubscription::cancel() {
+void Subscription::cancel() {
   cancelled_ = true;
 }
 
-bool AtomicBoolSubscription::isCancelled() const {
+bool Subscription::isCancelled() const {
   return cancelled_;
 }
 
@@ -32,10 +32,6 @@ void CallbackSubscription::cancel() {
   }
 }
 
-bool CallbackSubscription::isCancelled() const {
-  return cancelled_;
-}
-
 Reference<Subscription> Subscriptions::create(std::function<void()> onCancel) {
   return make_ref<CallbackSubscription>(std::move(onCancel));
 }
@@ -44,12 +40,9 @@ Reference<Subscription> Subscriptions::create(std::atomic_bool& cancelled) {
   return create([&cancelled]() { cancelled = true; });
 }
 
-Reference<Subscription> Subscriptions::empty() {
-  return make_ref<AtomicBoolSubscription>();
+Reference<Subscription> Subscriptions::create() {
+  return make_ref<Subscription>();
 }
 
-Reference<AtomicBoolSubscription> Subscriptions::atomicBoolSubscription() {
-  return make_ref<AtomicBoolSubscription>();
-}
 }
 }

--- a/yarpl/test/Observable_test.cpp
+++ b/yarpl/test/Observable_test.cpp
@@ -498,8 +498,10 @@ class InfiniteAsyncTestOperator : public ObservableOperator<int, int> {
     }
 
    public:
-    // gcc bug 58972.
-    using Super::observerOnNext;
+    void sendSuperNext() {
+      // workaround for gcc bug 58972.
+      Super::observerOnNext(1);
+    }
 
     TestSubscription(
         Reference<Observable<int>> observable,
@@ -513,7 +515,7 @@ class InfiniteAsyncTestOperator : public ObservableOperator<int, int> {
       Super::onSubscribe(std::move(subscription));
       t_ = std::thread([this](){
         while (!isCancelled()) {
-          Super::observerOnNext(1);
+          sendSuperNext();
         }
         checkpoint_.Call();
       });


### PR DESCRIPTION
* Merged AtomicBoolSubscription and Subscription. The functionality is needed in the base class and by the reactive streams implementation guide, the Subscription methods should be thread safe. 

Adding similar behaviors as we have in Observables in Java.
* added support to call Observable<T>->subscribe(...)->cancel();
* added support for isCancelled

added new unit tests.