### PR TITLE
Run tests binary with current_version=0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,7 +443,8 @@ target_compile_options(
 
 add_dependencies(tests gmock ReactiveSocket)
 
-add_test(NAME ReactiveSocketTests COMMAND tests)
+add_test(NAME RSocketTests COMMAND tests)
+add_test(NAME RSocketTests-0.1 COMMAND tests --rs_use_protocol_version=0.1)
 
 ### Fuzzer harnesses
 add_executable(

--- a/rsocket/framing/FrameSerializer_v0.cpp
+++ b/rsocket/framing/FrameSerializer_v0.cpp
@@ -693,10 +693,20 @@ bool FrameSerializerV0::deserializeFrom(
 
     frame.versionMajor_ = cur.readBE<uint16_t>();
     frame.versionMinor_ = cur.readBE<uint16_t>();
+
+    auto keepaliveTime = cur.readBE<int32_t>();
+    if (keepaliveTime <= 0) {
+      return false;
+    }
     frame.keepaliveTime_ =
-        std::min(cur.readBE<uint32_t>(), Frame_SETUP::kMaxKeepaliveTime);
+        std::min<uint32_t>(keepaliveTime, Frame_SETUP::kMaxKeepaliveTime);
+
+    auto maxLifetime = cur.readBE<int32_t>();
+    if (maxLifetime <= 0) {
+      return false;
+    }
     frame.maxLifetime_ =
-        std::min(cur.readBE<uint32_t>(), Frame_SETUP::kMaxLifetime);
+        std::min<uint32_t>(maxLifetime, Frame_SETUP::kMaxLifetime);
 
     // TODO: Remove hack:
     // https://github.com/ReactiveSocket/reactivesocket-cpp/issues/243


### PR DESCRIPTION
Making sure nothing gets broken.  Some of the SetupResumeAcceptor tests were
failing as they very much assumed things to be 1.0.