### PR TITLE
Call Subscriber's onError when client is closed

### DIFF
--- a/rsocket/RSocketClient.h
+++ b/rsocket/RSocketClient.h
@@ -45,7 +45,7 @@ class RSocketClient {
   folly::Future<folly::Unit> resume();
 
   // Disconnect the underlying transport
-  void disconnect(folly::exception_wrapper);
+  void disconnect(folly::exception_wrapper = folly::exception_wrapper{});
 
  private:
   // Private constructor.  RSocket class should be used to create instances

--- a/rsocket/RSocketRequester.cpp
+++ b/rsocket/RSocketRequester.cpp
@@ -53,9 +53,14 @@ RSocketRequester::requestChannel(
               std::move(subscriber), *eb));
       // responseSink is wrapped with thread scheduling
       // so all emissions happen on the right thread
-      requestStream->subscribe(
-          yarpl::make_ref<ScheduledSubscriber<Payload>>(std::move(responseSink),
-                                                        *eb));
+
+      // if we don't get a responseSink back, that means that
+      // the requesting peer wasn't connected (or similar error)
+      // and the Flowable it gets back will immediately call onError
+      if (responseSink) {
+        requestStream->subscribe(yarpl::make_ref<ScheduledSubscriber<Payload>>(
+            std::move(responseSink), *eb));
+      }
     });
   });
 }

--- a/rsocket/statemachine/StreamsFactory.cpp
+++ b/rsocket/statemachine/StreamsFactory.cpp
@@ -10,6 +10,9 @@
 #include "rsocket/statemachine/StreamRequester.h"
 #include "rsocket/statemachine/StreamResponder.h"
 
+#include "yarpl/flowable/Flowable.h"
+#include "yarpl/single/Singles.h"
+
 namespace rsocket {
 
 using namespace yarpl;
@@ -25,9 +28,30 @@ StreamsFactory::StreamsFactory(
               : 2 /*streams initiated by the server MUST use
                     even-numbered stream identifiers*/) {}
 
+void subscribeToErrorFlowable(
+    Reference<yarpl::flowable::Subscriber<Payload>> responseSink) {
+  yarpl::flowable::Flowables::error<Payload>(
+      std::runtime_error(
+          "state machine is disconnected/closed"))
+      ->subscribe(std::move(responseSink));
+}
+
+void subscribeToErrorSingle(
+    Reference<yarpl::single::SingleObserver<Payload>> responseSink) {
+  yarpl::single::Singles::error<Payload>(
+      std::runtime_error(
+          "state machine is disconnected/closed"))
+      ->subscribe(std::move(responseSink));
+}
+
 Reference<yarpl::flowable::Subscriber<Payload>>
 StreamsFactory::createChannelRequester(
     Reference<yarpl::flowable::Subscriber<Payload>> responseSink) {
+  if (connection_.isDisconnectedOrClosed()) {
+    subscribeToErrorFlowable(std::move(responseSink));
+    return nullptr;
+  }
+
   ChannelRequester::Parameters params(
       connection_.shared_from_this(), getNextStreamId());
   auto stateMachine = yarpl::make_ref<ChannelRequester>(params);
@@ -39,6 +63,11 @@ StreamsFactory::createChannelRequester(
 void StreamsFactory::createStreamRequester(
     Payload request,
     Reference<yarpl::flowable::Subscriber<Payload>> responseSink) {
+  if (connection_.isDisconnectedOrClosed()) {
+    subscribeToErrorFlowable(std::move(responseSink));
+    return;
+  }
+
   StreamRequester::Parameters params(
       connection_.shared_from_this(), getNextStreamId());
   auto stateMachine =
@@ -51,6 +80,11 @@ void StreamsFactory::createStreamRequester(
     Reference<yarpl::flowable::Subscriber<Payload>> responseSink,
     StreamId streamId,
     uint32_t n) {
+  if (connection_.isDisconnectedOrClosed()) {
+    subscribeToErrorFlowable(std::move(responseSink));
+    return;
+  }
+
   StreamRequester::Parameters params(connection_.shared_from_this(), streamId);
   auto stateMachine = yarpl::make_ref<StreamRequester>(params, Payload());
   // Set requested to true (since cold resumption)
@@ -62,6 +96,11 @@ void StreamsFactory::createStreamRequester(
 void StreamsFactory::createRequestResponseRequester(
     Payload payload,
     Reference<yarpl::single::SingleObserver<Payload>> responseSink) {
+  if (connection_.isDisconnectedOrClosed()) {
+    subscribeToErrorSingle(std::move(responseSink));
+    return;
+  }
+
   RequestResponseRequester::Parameters params(
       connection_.shared_from_this(), getNextStreamId());
   auto stateMachine =

--- a/test/RSocketTests.h
+++ b/test/RSocketTests.h
@@ -26,6 +26,9 @@ std::shared_ptr<RSocketClient> makeClient(
     folly::EventBase* eventBase,
     uint16_t port);
 
+std::shared_ptr<RSocketClient> makeDisconnectedClient(
+    folly::EventBase* eventBase);
+
 folly::Future<std::shared_ptr<RSocketClient>> makeClientAsync(
     folly::EventBase* eventBase,
     uint16_t port);

--- a/test/test_utils/GenericRequestResponseHandler.h
+++ b/test/test_utils/GenericRequestResponseHandler.h
@@ -64,11 +64,11 @@ struct GenericRequestResponseHandler : public rsocket::RSocketResponder {
   std::unique_ptr<HandlerFunc> handler_;
 };
 
-Response payload_response(StringPair const& sp) {
+inline Response payload_response(StringPair const& sp) {
   return std::make_unique<ResponseImpl>(sp);
 }
 
-Response payload_response(std::string const& a, std::string const& b) {
+inline Response payload_response(std::string const& a, std::string const& b) {
   return payload_response({a, b});
 }
 
@@ -77,7 +77,7 @@ Response error_response(T const& err) {
   return std::make_unique<ResponseImpl>(err);
 }
 
-StringPair payload_to_stringpair(Payload p) {
+inline StringPair payload_to_stringpair(Payload p) {
   return StringPair(p.moveDataToString(), p.moveMetadataToString());
 }
 }


### PR DESCRIPTION
Previously we just dropped those requests on the floor, this now calls the application provided Subscriber's `onError` method, so the application can tell if its request even went through or not.

Adds tests for requestResponse, requestStream, and requestChannel