### PR TITLE
Lint fixes

### DIFF
--- a/benchmarks/BaselinesAsyncSocket.cpp
+++ b/benchmarks/BaselinesAsyncSocket.cpp
@@ -11,9 +11,9 @@
 
 using namespace folly;
 
-//namespace {
+// namespace {
 //
-//class TcpReader : public ::folly::AsyncTransportWrapper::ReadCallback {
+// class TcpReader : public ::folly::AsyncTransportWrapper::ReadCallback {
 // public:
 //  TcpReader(
 //      folly::AsyncSocket::UniquePtr&& socket,
@@ -71,7 +71,8 @@ using namespace folly;
 //
 //  void close() {
 //    if (socket_) {
-//      LOG(INFO) << "received " << receivedLength_ << " via " << reads_ << " reads";
+//      LOG(INFO) << "received " << receivedLength_ << " via " << reads_
+//                << " reads";
 //      auto socket = std::move(socket_);
 //      socket->close();
 //      eventBase_.terminateLoopSoon();
@@ -88,7 +89,7 @@ using namespace folly;
 //  int reads_{0};
 //};
 //
-//class ServerAcceptCallback : public AsyncServerSocket::AcceptCallback {
+// class ServerAcceptCallback : public AsyncServerSocket::AcceptCallback {
 // public:
 //  ServerAcceptCallback(
 //      EventBase& eventBase,
@@ -119,13 +120,15 @@ using namespace folly;
 //  const size_t recvBufferLength_;
 //};
 //
-//class TcpWriter : public ::folly::AsyncTransportWrapper::WriteCallback {
+// class TcpWriter : public ::folly::AsyncTransportWrapper::WriteCallback {
 // public:
 //  ~TcpWriter() {
-//    LOG(INFO) << "writes=" << writes_ << " success=" << success_ << " errors=" << errors_;
+//    LOG(INFO) << "writes=" << writes_ << " success=" << success_ << " errors="
+//              << errors_;
 //  }
 //
-//  void startWriting(AsyncSocket& socket, size_t loadSize, size_t messageSize) {
+//  void startWriting(AsyncSocket& socket, size_t loadSize,
+//                    size_t messageSize) {
 //    size_t bytesSent{0};
 //
 //    while (!closed_ && bytesSent < loadSize) {
@@ -156,9 +159,10 @@ using namespace folly;
 //  int errors_{0};
 //};
 //
-//class ClientConnectCallback : public AsyncSocket::ConnectCallback {
+// class ClientConnectCallback : public AsyncSocket::ConnectCallback {
 // public:
-//  ClientConnectCallback(EventBase& eventBase, size_t loadSize, size_t msgLength)
+//  ClientConnectCallback(EventBase& eventBase, size_t loadSize,
+//                        size_t msgLength)
 //      : eventBase_(eventBase), loadSize_(loadSize), msgLength_(msgLength) {}
 //
 //  void connect() {
@@ -198,26 +202,28 @@ static void BM_Baseline_AsyncSocket_SendReceive(
     size_t loadSize,
     size_t msgLength,
     size_t recvLength) {
-  LOG_EVERY_N(INFO, 10000) << "TODO(lehecka): benchmark needs updating, it has memory corruption bugs";
-//  EventBase serverEventBase;
-//  auto serverSocket = AsyncServerSocket::newSocket(&serverEventBase);
-//
-//  ServerAcceptCallback serverCallback(serverEventBase, loadSize, recvLength);
-//
-//  SocketAddress addr("::", PORT);
-//
-//  serverSocket->setReusePortEnabled(true);
-//  serverSocket->bind(addr);
-//  serverSocket->addAcceptCallback(&serverCallback, &serverEventBase);
-//  serverSocket->listen(1);
-//  serverSocket->startAccepting();
-//
-//  ScopedEventBaseThread clientThread;
-//  auto* clientCallback = new ClientConnectCallback(
-//      *clientThread.getEventBase(), loadSize, msgLength);
-//  clientCallback->connect();
-//
-//  serverEventBase.loopForever();
+  LOG_EVERY_N(INFO, 10000) << "TODO(lehecka): benchmark needs updating, "
+                           << "it has memory corruption bugs";
+  //  EventBase serverEventBase;
+  //  auto serverSocket = AsyncServerSocket::newSocket(&serverEventBase);
+  //
+  //  ServerAcceptCallback serverCallback(serverEventBase, loadSize,
+  //  recvLength);
+  //
+  //  SocketAddress addr("::", PORT);
+  //
+  //  serverSocket->setReusePortEnabled(true);
+  //  serverSocket->bind(addr);
+  //  serverSocket->addAcceptCallback(&serverCallback, &serverEventBase);
+  //  serverSocket->listen(1);
+  //  serverSocket->startAccepting();
+  //
+  //  ScopedEventBaseThread clientThread;
+  //  auto* clientCallback = new ClientConnectCallback(
+  //      *clientThread.getEventBase(), loadSize, msgLength);
+  //  clientCallback->connect();
+  //
+  //  serverEventBase.loopForever();
 }
 
 BENCHMARK(BM_Baseline_AsyncSocket_Throughput_100MB_s40B_r1024B, n) {

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -81,7 +81,7 @@ void RSocketStateMachine::connectServer(
   sendPendingFrames();
 }
 
-//TODO: ensure the return value is not ignored!
+// TODO: ensure the return value is not ignored!
 bool RSocketStateMachine::resumeServer(
     yarpl::Reference<FrameTransport> frameTransport,
     const ResumeParameters& resumeParams) {
@@ -89,13 +89,12 @@ bool RSocketStateMachine::resumeServer(
     disconnect(folly::exception_wrapper(
         std::runtime_error("A new transport is resuming the session")));
   }
-  CHECK(connect(
-      std::move(frameTransport), resumeParams.protocolVersion));
+  CHECK(connect(std::move(frameTransport), resumeParams.protocolVersion));
   return resumeFromPositionOrClose(
       resumeParams.serverPosition, resumeParams.clientPosition);
 }
 
-//TODO : ensure the return value is not ignored!!
+// TODO : ensure the return value is not ignored!!
 bool RSocketStateMachine::connect(
     yarpl::Reference<FrameTransport> frameTransport,
     ProtocolVersion protocolVersion) {
@@ -147,7 +146,7 @@ void RSocketStateMachine::sendPendingFrames() {
   // not all frames might be sent if the connection breaks, the rest of them
   // will queue up again
   auto outputFrames = streamState_.moveOutputPendingFrames();
-  for (auto &frame : outputFrames) {
+  for (auto& frame : outputFrames) {
     outputFrameOrEnqueue(std::move(frame));
   }
 
@@ -469,11 +468,12 @@ void RSocketStateMachine::handleConnectionFrame(
           auto streamToken = resumeManager_->getStreamToken(streamId);
           auto subscriber = coldResumeHandler_->handleRequesterResumeStream(
               streamToken, consumerAllowance);
-          //TODO(somatsun): ensure that subscription is called from the correct
+          // TODO(somatsun): ensure that subscription is called from the correct
           // thread (eventBase) without using EventBaseManager
           streamsFactory().createStreamRequester(
               yarpl::make_ref<ScheduledSubscriptionSubscriber<Payload>>(
-                  std::move(subscriber), *folly::EventBaseManager::get()->getEventBase()),
+                  std::move(subscriber),
+                  *folly::EventBaseManager::get()->getEventBase()),
               streamId,
               consumerAllowance);
         }

--- a/rsocket/transports/tcp/TcpDuplexConnection.cpp
+++ b/rsocket/transports/tcp/TcpDuplexConnection.cpp
@@ -14,7 +14,6 @@ using namespace yarpl::flowable;
 
 class TcpReaderWriter : public folly::AsyncTransportWrapper::WriteCallback,
                         public folly::AsyncTransportWrapper::ReadCallback {
-
   friend void intrusive_ptr_add_ref(TcpReaderWriter* x);
   friend void intrusive_ptr_release(TcpReaderWriter* x);
 
@@ -172,12 +171,12 @@ class TcpReaderWriter : public folly::AsyncTransportWrapper::WriteCallback,
 void intrusive_ptr_add_ref(TcpReaderWriter* x);
 void intrusive_ptr_release(TcpReaderWriter* x);
 
-inline void intrusive_ptr_add_ref(TcpReaderWriter* x){
+inline void intrusive_ptr_add_ref(TcpReaderWriter* x) {
   ++x->refCount_;
 }
 
-inline void intrusive_ptr_release(TcpReaderWriter* x){
-  if(--x->refCount_ == 0)
+inline void intrusive_ptr_release(TcpReaderWriter* x) {
+  if (--x->refCount_ == 0)
     delete x;
 }
 
@@ -185,7 +184,8 @@ namespace {
 
 class TcpOutputSubscriber : public DuplexConnection::Subscriber {
  public:
-  explicit TcpOutputSubscriber(boost::intrusive_ptr<TcpReaderWriter> tcpReaderWriter)
+  explicit TcpOutputSubscriber(
+      boost::intrusive_ptr<TcpReaderWriter> tcpReaderWriter)
       : tcpReaderWriter_(std::move(tcpReaderWriter)) {
     CHECK(tcpReaderWriter_);
   }
@@ -242,8 +242,7 @@ class TcpInputSubscription : public Subscription {
 TcpDuplexConnection::TcpDuplexConnection(
     folly::AsyncSocket::UniquePtr&& socket,
     std::shared_ptr<RSocketStats> stats)
-    : tcpReaderWriter_(
-          new TcpReaderWriter(std::move(socket), stats)),
+    : tcpReaderWriter_(new TcpReaderWriter(std::move(socket), stats)),
       stats_(stats) {
   if (stats_) {
     stats_->duplexConnectionCreated("tcp", this);

--- a/test/ColdResumptionTest.cpp
+++ b/test/ColdResumptionTest.cpp
@@ -32,7 +32,7 @@ class HelloSubscriber : public virtual Refcounted, public Subscriber<Payload> {
     auto count = 3;
     while (value != latestValue_ && count > 0) {
       VLOG(1) << "Wait for " << count << " seconds for latest value";
-      sleep(1);
+      /* sleep override */ sleep(1);
       count--;
       std::this_thread::yield();
     }

--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -34,7 +34,7 @@ class ObservableOperator : public Observable<D> {
   /// subscriber for the previous stage; as a subscription for the next one,
   /// the user-supplied subscriber being the last of the pipeline stages.
   class OperatorSubscription : public ::yarpl::observable::Subscription,
-                       public Observer<U> {
+                               public Observer<U> {
    protected:
     OperatorSubscription(
         Reference<ThisOperatorT> observable,
@@ -158,7 +158,8 @@ class ObservableOperator : public Observable<D> {
     /// calls should be forwarded upstream.  Note that `this` is also a
     /// observer for the upstream stage: thus, there are cycles; all of
     /// the objects drop their references at cancel/complete.
-    //TODO(lehecka): this is extra field... base class has this member so remove it
+    // TODO(lehecka): this is extra field... base class has this member so
+    // remove it
     Reference<::yarpl::observable::Subscription> upstream_;
   };
 
@@ -179,7 +180,8 @@ class MapOperator : public ObservableOperator<U, D, MapOperator<U, D, F>> {
       : Super(std::move(upstream)), function_(std::move(function)) {}
 
   Reference<Subscription> subscribe(Reference<Observer<D>> observer) override {
-    auto subscription = make_ref<MapSubscription>(get_ref(this), std::move(observer));
+    auto subscription =
+        make_ref<MapSubscription>(get_ref(this), std::move(observer));
     Super::upstream_->subscribe(
         // Note: implicit cast to a reference to a observer.
         subscription);
@@ -219,7 +221,8 @@ class FilterOperator : public ObservableOperator<U, U, FilterOperator<U, F>> {
       : Super(std::move(upstream)), function_(std::move(function)) {}
 
   Reference<Subscription> subscribe(Reference<Observer<U>> observer) override {
-    auto subscription = make_ref<FilterSubscription>(get_ref(this), std::move(observer));
+    auto subscription =
+        make_ref<FilterSubscription>(get_ref(this), std::move(observer));
     Super::upstream_->subscribe(
         // Note: implicit cast to a reference to a observer.
         subscription);
@@ -263,8 +266,10 @@ class ReduceOperator
   ReduceOperator(Reference<Observable<U>> upstream, F function)
       : Super(std::move(upstream)), function_(std::move(function)) {}
 
-  Reference<Subscription> subscribe(Reference<Observer<D>> subscriber) override {
-    auto subscription = make_ref<ReduceSubscription>(get_ref(this), std::move(subscriber));
+  Reference<Subscription> subscribe(
+      Reference<Observer<D>> subscriber) override {
+    auto subscription =
+        make_ref<ReduceSubscription>(get_ref(this), std::move(subscriber));
     Super::upstream_->subscribe(
         // Note: implicit cast to a reference to a subscriber.
         subscription);
@@ -317,9 +322,9 @@ class TakeOperator : public ObservableOperator<T, T, TakeOperator<T>> {
       : Super(std::move(upstream)), limit_(limit) {}
 
   Reference<Subscription> subscribe(Reference<Observer<T>> observer) override {
-    auto subscription = make_ref<TakeSubscription>(get_ref(this), limit_, std::move(observer));
-    Super::upstream_->subscribe(
-        subscription);
+    auto subscription =
+        make_ref<TakeSubscription>(get_ref(this), limit_, std::move(observer));
+    Super::upstream_->subscribe(subscription);
     return subscription;
   }
 
@@ -363,9 +368,9 @@ class SkipOperator : public ObservableOperator<T, T, SkipOperator<T>> {
       : Super(std::move(upstream)), offset_(offset) {}
 
   Reference<Subscription> subscribe(Reference<Observer<T>> observer) override {
-    auto subscription = make_ref<SkipSubscription>(get_ref(this), offset_, std::move(observer));
-    Super::upstream_->subscribe(
-        subscription);
+    auto subscription =
+        make_ref<SkipSubscription>(get_ref(this), offset_, std::move(observer));
+    Super::upstream_->subscribe(subscription);
     return subscription;
   }
 
@@ -407,9 +412,9 @@ class IgnoreElementsOperator
       : Super(std::move(upstream)) {}
 
   Reference<Subscription> subscribe(Reference<Observer<T>> observer) override {
-    auto subscription = make_ref<IgnoreElementsSubscription>(get_ref(this), std::move(observer));
-    Super::upstream_->subscribe(
-        subscription);
+    auto subscription = make_ref<IgnoreElementsSubscription>(
+        get_ref(this), std::move(observer));
+    Super::upstream_->subscribe(subscription);
     return subscription;
   }
 
@@ -485,7 +490,10 @@ class FromPublisherOperator : public Observable<T> {
  private:
   class PublisherObserver : public Observer<T> {
    public:
-    PublisherObserver(Reference<Observer<T>> inner, Reference<Subscription> subscription) : inner_(std::move(inner)) {
+    PublisherObserver(
+        Reference<Observer<T>> inner,
+        Reference<Subscription> subscription)
+        : inner_(std::move(inner)) {
       Observer<T>::onSubscribe(std::move(subscription));
     }
 
@@ -517,7 +525,7 @@ class FromPublisherOperator : public Observable<T> {
     auto subscription = Subscriptions::create();
     observer->onSubscribe(subscription);
 
-    if(!subscription->isCancelled()) {
+    if (!subscription->isCancelled()) {
       function_(make_ref<PublisherObserver>(std::move(observer), subscription));
     }
     return subscription;

--- a/yarpl/test/Observable_test.cpp
+++ b/yarpl/test/Observable_test.cpp
@@ -1,8 +1,8 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include <folly/Baton.h>
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <atomic>
 #include <condition_variable>
 
@@ -231,7 +231,7 @@ TEST(Observable, CancelFromDifferentThread) {
 
   std::thread t;
   auto a = Observable<int>::create([&](Reference<Observer<int>> obs) {
-    t = std::thread([obs, &emitted](){
+    t = std::thread([obs, &emitted]() {
       while (!obs->isUnsubscribed()) {
         ++emitted;
         obs->onNext(0);
@@ -239,10 +239,11 @@ TEST(Observable, CancelFromDifferentThread) {
     });
   });
 
-  auto subscription = a->subscribe([](int){});
+  auto subscription = a->subscribe([](int) {});
 
   std::unique_lock<std::mutex> lk(m);
-  CHECK(cv.wait_for(lk, std::chrono::seconds(1), [&]{return emitted >= 1000;}));
+  CHECK(cv.wait_for(
+      lk, std::chrono::seconds(1), [&] { return emitted >= 1000; }));
 
   subscription->cancel();
   t.join();
@@ -301,13 +302,9 @@ TEST(Observable, SingleMovable) {
   EXPECT_EQ(std::size_t{1}, observable->count());
 
   auto values = run(std::move(observable));
-  EXPECT_EQ(
-      values.size(),
-      size_t(1));
+  EXPECT_EQ(values.size(), size_t(1));
 
-  EXPECT_EQ(
-      *values[0],
-      123456);
+  EXPECT_EQ(*values[0], 123456);
 }
 
 TEST(Observable, Range) {
@@ -325,29 +322,27 @@ TEST(Observable, RangeWithMap) {
 }
 
 TEST(Observable, RangeWithReduce) {
-  auto observable = Observables::range(0, 10)
-      ->reduce([](int64_t acc, int64_t v) { return acc + v; });
-  EXPECT_EQ(
-      run(std::move(observable)), std::vector<int64_t>({45}));
+  auto observable = Observables::range(0, 10)->reduce(
+      [](int64_t acc, int64_t v) { return acc + v; });
+  EXPECT_EQ(run(std::move(observable)), std::vector<int64_t>({45}));
 }
 
 TEST(Observable, RangeWithReduceByMultiplication) {
-  auto observable = Observables::range(0, 10)
-      ->reduce([](int64_t acc, int64_t v) { return acc * v; });
-  EXPECT_EQ(
-      run(std::move(observable)), std::vector<int64_t>({0}));
+  auto observable = Observables::range(0, 10)->reduce(
+      [](int64_t acc, int64_t v) { return acc * v; });
+  EXPECT_EQ(run(std::move(observable)), std::vector<int64_t>({0}));
 
-  observable = Observables::range(1, 10)
-      ->reduce([](int64_t acc, int64_t v) { return acc * v; });
+  observable = Observables::range(1, 10)->reduce(
+      [](int64_t acc, int64_t v) { return acc * v; });
   EXPECT_EQ(
-      run(std::move(observable)), std::vector<int64_t>({2*3*4*5*6*7*8*9}));
+      run(std::move(observable)),
+      std::vector<int64_t>({2 * 3 * 4 * 5 * 6 * 7 * 8 * 9}));
 }
 
 TEST(Observable, RangeWithReduceOneItem) {
-  auto observable = Observables::range(5, 6)
-      ->reduce([](int64_t acc, int64_t v) { return acc + v; });
-  EXPECT_EQ(
-      run(std::move(observable)), std::vector<int64_t>({5}));
+  auto observable = Observables::range(5, 6)->reduce(
+      [](int64_t acc, int64_t v) { return acc + v; });
+  EXPECT_EQ(run(std::move(observable)), std::vector<int64_t>({5}));
 }
 
 TEST(Observable, RangeWithReduceNoItem) {
@@ -360,11 +355,11 @@ TEST(Observable, RangeWithReduceNoItem) {
 }
 
 TEST(Observable, RangeWithReduceToBiggerType) {
-  auto observable = Observables::range(5, 6)
-      ->map([](int64_t v){ return (int32_t)v; })
-      ->reduce([](int64_t acc, int32_t v) { return acc + v; });
-  EXPECT_EQ(
-      run(std::move(observable)), std::vector<int64_t>({5}));
+  auto observable =
+      Observables::range(5, 6)
+          ->map([](int64_t v) { return (int32_t)v; })
+          ->reduce([](int64_t acc, int32_t v) { return acc + v; });
+  EXPECT_EQ(run(std::move(observable)), std::vector<int64_t>({5}));
 }
 
 TEST(Observable, StringReduce) {
@@ -485,8 +480,10 @@ class InfiniteAsyncTestOperator
       testing::MockFunction<void()>& checkpoint)
       : Super(std::move(upstream)), checkpoint_(checkpoint) {}
 
-  Reference<Subscription> subscribe(Reference<Observer<int>> observer) override {
-    auto subscription = make_ref<TestSubscription>(get_ref(this), std::move(observer), checkpoint_);
+  Reference<Subscription> subscribe(
+      Reference<Observer<int>> observer) override {
+    auto subscription = make_ref<TestSubscription>(
+        get_ref(this), std::move(observer), checkpoint_);
     Super::upstream_->subscribe(
         // Note: implicit cast to a reference to a observer.
         subscription);
@@ -516,15 +513,14 @@ class InfiniteAsyncTestOperator
 
     void onSubscribe(yarpl::Reference<Subscription> subscription) override {
       SuperSub::onSubscribe(std::move(subscription));
-      t_ = std::thread([this](){
+      t_ = std::thread([this]() {
         while (!isCancelled()) {
           sendSuperNext();
         }
         checkpoint_.Call();
       });
     }
-    void onNext(int value) override {
-    }
+    void onNext(int value) override {}
 
     std::thread t_;
     testing::MockFunction<void()>& checkpoint_;
@@ -546,7 +542,7 @@ TEST(Observable, CancelSubscriptionChain) {
     EXPECT_CALL(checkpoint, Call()).Times(1);
     EXPECT_CALL(checkpoint2, Call()).Times(1);
     EXPECT_CALL(checkpoint3, Call()).Times(1);
-    t = std::thread([obs, &emitted, &checkpoint](){
+    t = std::thread([obs, &emitted, &checkpoint]() {
       while (!obs->isUnsubscribed()) {
         ++emitted;
         obs->onNext(0);
@@ -559,10 +555,11 @@ TEST(Observable, CancelSubscriptionChain) {
   auto test2 = make_ref<InfiniteAsyncTestOperator>(test1->skip(1), checkpoint3);
   auto skip = test2->skip(8);
 
-  auto subscription = skip->subscribe([](int){});
+  auto subscription = skip->subscribe([](int) {});
 
   std::unique_lock<std::mutex> lk(m);
-  CHECK(cv.wait_for(lk, std::chrono::seconds(1), [&]{return emitted >= 1000;}));
+  CHECK(cv.wait_for(
+      lk, std::chrono::seconds(1), [&] { return emitted >= 1000; }));
 
   subscription->cancel();
   t.join();


### PR DESCRIPTION
Mostly 80 char violations.  Running `M-x clang-format-buffer` on all affected
files.