### PR TITLE
fix concurrency bug in OperatorSubscription::observerOnNext

### DIFF
--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -52,6 +52,8 @@ class ObservableOperator : public Observable<D> {
     }
 
     void observerOnNext(D value) {
+      // in order to keep this method thread safe we need to check the observer
+      // and use the same pointer
       auto observer = observer_;
       if (observer) {
         observer->onNext(std::move(value));

--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -52,8 +52,9 @@ class ObservableOperator : public Observable<D> {
     }
 
     void observerOnNext(D value) {
-      if (observer_) {
-        observer_->onNext(std::move(value));
+      auto observer = observer_;
+      if (observer) {
+        observer->onNext(std::move(value));
       }
     }
 


### PR DESCRIPTION
Fixing concurrency problem detected by the unit test:
https://travis-ci.org/rsocket/rsocket-cpp/jobs/269724602

I believe we have more concurrency bugs in the ObservableOperator implementation. Namely, the cancel method nullifies some of the member variables (references). This happens non atomically and the other methods are still accessing the the member variables (non-atomically). As a consequence we can get into corrupted pointers issues when the instance is used in the concurrent environment.

This is more a bandate than a proper fix.