### PR TITLE
Disable StreamThroughputTcpTest

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -21,6 +21,7 @@ make_folly_benchmark(stream-throughput-tcp StreamThroughputTcp.cpp)
 make_folly_benchmark(stream-throughput-mem StreamThroughputMemory.cpp)
 
 add_test(NAME RequestResponseThroughputTcpTest COMMAND req-response-throughput-tcp --items 100000)
-add_test(NAME StreamThroughputTcpTest COMMAND stream-throughput-tcp --items 100000)
+#TODO(lehecka):enable test once not flakey
+# add_test(NAME StreamThroughputTcpTest COMMAND stream-throughput-tcp --items 100000)
 #TODO(lehecka):enable test
 #add_test(NAME StreamThroughputMemoryTest COMMAND stream-throughput-mem --items 100000)


### PR DESCRIPTION
Flakey bench (broken in trunk) in clang-4.0 is really cramping our style