### PR TITLE
Fix use-after-free in RSocketStateMachine::processFrame()

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -21,7 +21,6 @@ make_folly_benchmark(stream-throughput-tcp StreamThroughputTcp.cpp)
 make_folly_benchmark(stream-throughput-mem StreamThroughputMemory.cpp)
 
 add_test(NAME RequestResponseThroughputTcpTest COMMAND req-response-throughput-tcp --items 100000)
-#TODO(lehecka):enable test once not flakey
-# add_test(NAME StreamThroughputTcpTest COMMAND stream-throughput-tcp --items 100000)
+add_test(NAME StreamThroughputTcpTest COMMAND stream-throughput-tcp --items 100000)
 #TODO(lehecka):enable test
 #add_test(NAME StreamThroughputMemoryTest COMMAND stream-throughput-mem --items 100000)

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -353,6 +353,10 @@ void RSocketStateMachine::closeStreams(StreamCompletionSignal signal) {
 void RSocketStateMachine::processFrame(std::unique_ptr<folly::IOBuf> frame) {
   CHECK(!isClosed());
 
+  // Necessary in case the only stream state machine closes itself, and takes
+  // the RSocketStateMachine with it.
+  auto self = shared_from_this();
+
   if (!ensureOrAutodetectFrameSerializer(*frame)) {
     constexpr folly::StringPiece message{"Cannot detect protocol version"};
     closeWithError(Frame_ERROR::connectionError(message.str()));
@@ -558,7 +562,7 @@ void RSocketStateMachine::handleStreamFrame(
       break;
     }
     case FrameType::CANCEL: {
-      VLOG(3) << "In: " << Frame_CANCEL();
+      VLOG(3) << "In: " << Frame_CANCEL(streamId);
       stateMachine->handleCancel();
       break;
     }


### PR DESCRIPTION
processFrame() might be processing the CANCEL frame for the last stream state
machine in the RSocketStateMachine.  This ends up destroying the entire
RSocketStateMachine object, but we still try to use the frame afterwards
(tracking it for resumption).

Repros locally on Linux with gcc-7.1.1, running
benchmarks/StreamThroughputTcp.cpp under valgrind.

Also fix VLOG printing of CANCEL frames in RSocketStateMachine.  They were using
the default ctor, which doesn't set the FrameType to CANCEL, printing it as
RESERVED instead.