### PR TITLE
unittests for calling subscribe() on a flowable multiple times

### DIFF
--- a/yarpl/test/yarpl-tests.cpp
+++ b/yarpl/test/yarpl-tests.cpp
@@ -1,8 +1,12 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
+#include <folly/init/Init.h>
+#include <glog/logging.h>
 #include <gtest/gtest.h>
 
 int main(int argc, char** argv) {
+  FLAGS_logtostderr = true;
   ::testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
and a fix for EmitterSubscriber, which incorrectly checks that onComplete/onError aren't called after onCancel (which it is allowed to race with). 