### PR TITLE
IteratorObservable to encapsulate common 'make from an iterator' pattern

### DIFF
--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -481,6 +481,73 @@ class SubscribeOnOperator
   std::unique_ptr<Worker> worker_;
 };
 
+template <typename T, typename GeneratorClass>
+class IteratorObservable : public Observable<T> {
+public:
+  Reference<Subscription> subscribe(Reference<Observer<T>> observer) override {
+    static_assert(
+      std::is_base_of<
+        IteratorObservable,
+        GeneratorClass
+      >::value,
+      "Inherit from IteratorObservable like `MyClass : public IteratorObservable<T, MyClass>`"
+    );
+
+    // can be stack allocated; we know nothing escapes
+    GeneratorClass instantiated(*static_cast<GeneratorClass const*>(this));
+    // so we can call protected methods on IteratorObservable even if they were
+    // made private in the subclass
+    IteratorObservable* withvtable = &instantiated;
+
+    auto subscription = make_ref<IteratorObservableSubscription>();
+
+    withvtable->beforeOnSubscribe();
+    observer->onSubscribe(subscription);
+
+    while(!subscription->isCancelled() && withvtable->haveNext()) {
+      observer->onNext(withvtable->getNext());
+    }
+    observer->onComplete();
+    withvtable->afterOnComplete();
+
+    return subscription;
+  }
+
+private:
+  struct IteratorObservableSubscription : public Subscription {
+    void cancel() override {
+      cancelled_ = true;
+    }
+  };
+
+protected:
+  virtual bool haveNext() = 0;
+  virtual T getNext() = 0;
+
+  virtual void beforeOnSubscribe() {};
+  virtual void afterOnComplete() {};
+};
+
+template <typename T>
+class RangeObservable : public IteratorObservable<T, RangeObservable<T>> {
+public:
+  // define a ctor to construct with initial parameters
+  RangeObservable(T from, T to) : from_(from), to_(to) {}
+  // define a ctor to construct from another RangeObservable
+  RangeObservable(RangeObservable<T> const& other) : from_(other.from_), to_(other.to_) {}
+
+private:
+  bool haveNext() override {
+    return from_ < to_;
+  }
+  T getNext() override {
+    DCHECK(haveNext());
+    return from_++;
+  }
+
+  T from_, to_;
+};
+
 template <typename T, typename OnSubscribe>
 class FromPublisherOperator : public Observable<T> {
  public:

--- a/yarpl/include/yarpl/observable/Observer.h
+++ b/yarpl/include/yarpl/observable/Observer.h
@@ -53,13 +53,8 @@ class Observer : public virtual Refcounted {
   }
 
  protected:
-  Subscription* subscription() {
-    return subscription_.operator->();
-  }
-
-  void unsubscribe() {
-    CHECK(subscription_);
-    subscription_->cancel();
+  Reference<Subscription>& subscription() {
+    return subscription_;
   }
 
  private:

--- a/yarpl/test/Observable_test.cpp
+++ b/yarpl/test/Observable_test.cpp
@@ -638,3 +638,15 @@ TEST(Observable, CancelSubscriptionChain) {
 
   LOG(INFO) << "cancelled after " << emitted << " items";
 }
+
+TEST(Observable, RangeIteratorObservable) {
+  auto range_observable = make_ref<RangeObservable<int>>(10, 15);
+
+  auto collector = make_ref<CollectingObserver<int>>();
+  auto sub = range_observable->subscribe(collector);
+
+  EXPECT_EQ(sub->isCancelled(), false);
+  EXPECT_EQ(collector->values(), std::vector<int>({10, 11, 12, 13, 14}));
+  EXPECT_EQ(collector->complete(), true);
+  EXPECT_EQ(collector->error(), false);
+}


### PR DESCRIPTION
Opens up implementing 'range', 'just', 'justn', 'justOnce' without nested lambdas and Observable<T>::create (which does confusing things wrt lifecycle of Subscriptions). Also enables creating an Observable from an arbitrary range (by putting it in a subclass of IteratorObservable and supplying a copy constructor). 

Idea for this came from talking from @benjchristensen and @lehecka about a `::fromIterator` static method on Flowable and Observable. We wanted to avoid separate "generator" lambdas and holding the initial state of a Flowable in whatever superclass implements `fromIterator`. This puts the responsibility of maintaining that initial state in the subclass, as we as being a generator for when `subscribe` is called multiple times. 

Subclasses encapsulate state for an iterator, and implement two methods: `haveNext` and `getNext` to signal to the superclass if the iterator is empty and to get the next element. Superclass handles cancellation. 

Not merge ready, looking for feedback on how the API looks. 