### PR TITLE
Test for racing case of server sending to client on a canceled Subscription 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,7 @@ add_executable(
   test/RSocketClientTest.cpp
   test/RequestResponseTest.cpp
   test/RequestStreamTest.cpp
+  test/RequestStreamTest_concurrency.cpp
   test/WarmResumptionTest.cpp
   test/ColdResumptionTest.cpp
   test/ConnectionEventsTest.cpp

--- a/rsocket/statemachine/ConsumerBase.cpp
+++ b/rsocket/statemachine/ConsumerBase.cpp
@@ -32,6 +32,7 @@ void ConsumerBase::checkConsumerRequest() {
   CHECK((state_ == State::RESPONDING) == !!consumingSubscriber_);
 }
 
+// TODO: this is probably buggy and misused and not needed (when completeConsumer exists)
 void ConsumerBase::cancelConsumer() {
   state_ = State::CLOSED;
   consumingSubscriber_ = nullptr;
@@ -45,11 +46,14 @@ void ConsumerBase::generateRequest(size_t n) {
 }
 
 void ConsumerBase::endStream(StreamCompletionSignal signal) {
+  VLOG(5) << "ConsumerBase::endStream(" << signal << ")";
   if (auto subscriber = std::move(consumingSubscriber_)) {
     if (signal == StreamCompletionSignal::COMPLETE ||
         signal == StreamCompletionSignal::CANCEL) { // TODO: remove CANCEL
+      VLOG(5) << "Closing ConsumerBase subscriber with calling onComplete";
       subscriber->onComplete();
     } else {
+      VLOG(5) << "Closing ConsumerBase subscriber with calling onError";
       subscriber->onError(StreamInterruptedException(static_cast<int>(signal)));
     }
   }

--- a/rsocket/statemachine/ConsumerBase.cpp
+++ b/rsocket/statemachine/ConsumerBase.cpp
@@ -32,7 +32,8 @@ void ConsumerBase::checkConsumerRequest() {
   CHECK((state_ == State::RESPONDING) == !!consumingSubscriber_);
 }
 
-// TODO: this is probably buggy and misused and not needed (when completeConsumer exists)
+// TODO: this is probably buggy and misused and not needed (when
+// completeConsumer exists)
 void ConsumerBase::cancelConsumer() {
   state_ = State::CLOSED;
   consumingSubscriber_ = nullptr;

--- a/rsocket/statemachine/StreamRequester.cpp
+++ b/rsocket/statemachine/StreamRequester.cpp
@@ -48,14 +48,16 @@ void StreamRequester::request(int64_t n) noexcept {
 }
 
 void StreamRequester::cancel() noexcept {
+  VLOG(5) << "StreamRequester::cancel(requested_=" << requested_ << ")";
   if (requested_) {
-    cancelConsumer();
     cancelStream();
   }
   closeStream(StreamCompletionSignal::CANCEL);
+  completeConsumer();
 }
 
 void StreamRequester::endStream(StreamCompletionSignal signal) {
+  VLOG(5) << "StreamRequester::endStream()";
   ConsumerBase::endStream(signal);
 }
 

--- a/test/RSocketTests.h
+++ b/test/RSocketTests.h
@@ -8,6 +8,12 @@
 
 #include "rsocket/transports/tcp/TcpConnectionFactory.h"
 
+auto const default_baton_timeout = std::chrono::milliseconds(100);
+#define CHECK_WAIT(baton) CHECK(baton.timed_wait(default_baton_timeout))
+// #define CHECK_WAIT(baton) baton.timed_wait(default_baton_timeout)
+// #define CHECK_WAIT(baton) baton.wait()
+
+
 namespace rsocket {
 namespace tests {
 namespace client_server {

--- a/test/RSocketTests.h
+++ b/test/RSocketTests.h
@@ -10,8 +10,6 @@
 
 auto const default_baton_timeout = std::chrono::milliseconds(100);
 #define CHECK_WAIT(baton) CHECK(baton.timed_wait(default_baton_timeout))
-// #define CHECK_WAIT(baton) baton.timed_wait(default_baton_timeout)
-// #define CHECK_WAIT(baton) baton.wait()
 
 namespace rsocket {
 namespace tests {

--- a/test/RSocketTests.h
+++ b/test/RSocketTests.h
@@ -13,7 +13,6 @@ auto const default_baton_timeout = std::chrono::milliseconds(100);
 // #define CHECK_WAIT(baton) baton.timed_wait(default_baton_timeout)
 // #define CHECK_WAIT(baton) baton.wait()
 
-
 namespace rsocket {
 namespace tests {
 namespace client_server {

--- a/test/RequestResponseTest.cpp
+++ b/test/RequestResponseTest.cpp
@@ -157,6 +157,23 @@ TEST(RequestResponseTest, RequestOnDisconnectedClient) {
   ASSERT(did_call_on_error);
 }
 
+// TODO: test that multiple requests on a requestResponse
+// fail in a well-defined way (right now it'd nullptr deref)
+TEST(RequestResponseTest, MultipleRequestsError) {
+  folly::ScopedEventBaseThread worker;
+  auto server = makeServer(std::make_shared<GenericRequestResponseHandler>(
+      [](StringPair const& request) {
+        EXPECT_EQ(request.first, "foo");
+        EXPECT_EQ(request.second, "bar");
+        return payload_response("baz", "quix");
+      }));
+
+  auto client = makeClient(worker.getEventBase(), *server->listeningPort());
+  auto requester = client->getRequester();
+
+  auto flowable = requester->requestResponse(Payload("foo", "bar"));
+}
+
 // TODO: Currently, this hangs when the client sends a request,
 // we should fix this
 TEST(DISABLED_RequestResponseTest, FailureOnRequest) {

--- a/test/RequestStreamTest.cpp
+++ b/test/RequestStreamTest.cpp
@@ -117,6 +117,6 @@ TEST(RequestStreamTest, RequestOnDisconnectedClient) {
             FAIL();
           });
 
-  wait_for_on_error.timed_wait(std::chrono::milliseconds(100));
+  CHECK_WAIT(wait_for_on_error);
   ASSERT(did_call_on_error);
 }

--- a/test/RequestStreamTest_concurrency.cpp
+++ b/test/RequestStreamTest_concurrency.cpp
@@ -1,0 +1,140 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <thread>
+#include <iostream>
+#include <folly/io/async/ScopedEventBaseThread.h>
+#include <gtest/gtest.h>
+
+#include "RSocketTests.h"
+#include "yarpl/Flowable.h"
+#include "yarpl/flowable/TestSubscriber.h"
+
+#include "yarpl/test_utils/Mocks.h"
+
+using namespace yarpl;
+using namespace yarpl::flowable;
+using namespace rsocket;
+using namespace rsocket::tests;
+using namespace rsocket::tests::client_server;
+
+struct LockstepBatons {
+  folly::Baton<> on_second_payload_sent;
+  folly::Baton<> on_cancel_sent;
+  folly::Baton<> on_cancel_recieved_toserver;
+  folly::Baton<> on_cancel_recieved_toclient;
+  folly::Baton<> on_request_recieved;
+  folly::Baton<> client_finished;
+  folly::Baton<> server_finished;
+};
+
+using namespace yarpl::mocks;
+using namespace ::testing;
+
+#define LOCKSTEP_DEBUG(expr) VLOG(3) << expr
+
+class LockstepAsyncHandler : public rsocket::RSocketResponder {
+  LockstepBatons& batons_;
+  Sequence& subscription_seq_;
+ public:
+  LockstepAsyncHandler(LockstepBatons& batons, Sequence& subscription_seq)
+    : batons_(batons), subscription_seq_(subscription_seq) {};
+
+  Reference<Flowable<Payload>> handleRequestStream(Payload p, StreamId) override {
+    EXPECT_EQ(p.moveDataToString(), "initial");
+    return Flowables::fromPublisher<Payload>(
+      [this](Reference<flowable::Subscriber<Payload>> subscriber)
+      {
+        auto subscription = make_ref<StrictMock<MockSubscription>>();
+
+        std::thread([=] {
+            CHECK_WAIT(this->batons_.on_request_recieved);
+
+            LOCKSTEP_DEBUG("SERVER: sending onNext(foo)");
+            subscriber->onNext(Payload("foo"));
+            CHECK_WAIT(this->batons_.on_cancel_sent);
+            CHECK_WAIT(this->batons_.on_cancel_recieved_toserver);
+
+            LOCKSTEP_DEBUG("SERVER: sending onNext(bar)");
+            subscriber->onNext(Payload("bar"));
+            this->batons_.on_second_payload_sent.post();
+            LOCKSTEP_DEBUG("SERVER: sending onComplete()");
+            subscriber->onComplete();
+            LOCKSTEP_DEBUG("SERVER: posting server_finished");
+            this->batons_.server_finished.post();
+        }).detach();
+
+        // checked once the subscription is destroyed
+        EXPECT_CALL(*subscription, request_(2))
+          .InSequence(this->subscription_seq_)
+          .WillOnce(Invoke([=](auto n) {
+            LOCKSTEP_DEBUG("SERVER: got request(" << n << ")");
+            EXPECT_EQ(n, 2);
+            this->batons_.on_request_recieved.post();
+          }));
+
+        EXPECT_CALL(*subscription, cancel_())
+          .InSequence(this->subscription_seq_)
+          .WillOnce(Invoke([=]{
+            LOCKSTEP_DEBUG("SERVER: recieved cancel()");
+              this->batons_.on_cancel_recieved_toclient.post();
+              this->batons_.on_cancel_recieved_toserver.post();
+          }));
+
+        LOCKSTEP_DEBUG("SERVER: sending onSubscribe()");
+        subscriber->onSubscribe(subscription);
+      });
+  }
+};
+
+TEST(RequestStreamTest, OperationsAfterCancel) {
+  LockstepBatons batons;
+  Sequence server_seq;
+  Sequence client_seq;
+
+  auto server = makeServer(std::make_shared<LockstepAsyncHandler>(batons, server_seq));
+  folly::ScopedEventBaseThread worker;
+  auto client = makeClient(worker.getEventBase(), *server->listeningPort());
+  auto requester = client->getRequester();
+
+  auto scbr_mock = make_ref<testing::StrictMock<yarpl::mocks::MockSubscriber<std::string>>>(0);
+
+  Reference<Subscription> subscription;
+  EXPECT_CALL(*scbr_mock, onSubscribe_(_))
+    .InSequence(client_seq)
+    .WillOnce(Invoke([&](auto s) {
+      LOCKSTEP_DEBUG("CLIENT: got onSubscribe(), sending request(2)");
+      EXPECT_NE(s, nullptr);
+      subscription = s;
+      subscription->request(2);
+    }));
+  EXPECT_CALL(*scbr_mock, onNext_("foo"))
+    .InSequence(client_seq)
+    .WillOnce(Invoke([&](auto) {
+      EXPECT_NE(subscription, nullptr);
+      LOCKSTEP_DEBUG("CLIENT: got onNext(foo), sending cancel()");
+      subscription->cancel();
+      batons.on_cancel_sent.post();
+      CHECK_WAIT(batons.on_cancel_recieved_toclient);
+      CHECK_WAIT(batons.on_second_payload_sent);
+    }));
+
+  // shouldn't recieve 'bar', we canceled syncronously with the Subscriber
+  // had 'cancel' been called in a different thread with no synchronization,
+  // the client's Subscriber _could_ have recieved 'bar'
+
+  EXPECT_CALL(*scbr_mock, onComplete_())
+    .InSequence(client_seq)
+    .WillOnce(Invoke([&]() {
+      LOCKSTEP_DEBUG("CLIENT: got onComplete()");
+      batons.client_finished.post();
+    }));
+
+  LOCKSTEP_DEBUG("RUNNER: doing requestStream()");
+  requester->requestStream(Payload("initial"))
+      ->map([](auto p) { return p.moveDataToString(); })
+      ->subscribe(scbr_mock);
+
+  CHECK_WAIT(batons.client_finished);
+  CHECK_WAIT(batons.server_finished);
+  LOCKSTEP_DEBUG("RUNNER: finished!");
+}

--- a/test/RequestStreamTest_concurrency.cpp
+++ b/test/RequestStreamTest_concurrency.cpp
@@ -1,9 +1,9 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-#include <thread>
-#include <iostream>
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <gtest/gtest.h>
+#include <iostream>
+#include <thread>
 
 #include "RSocketTests.h"
 #include "yarpl/Flowable.h"
@@ -35,18 +35,19 @@ using namespace ::testing;
 class LockstepAsyncHandler : public rsocket::RSocketResponder {
   LockstepBatons& batons_;
   Sequence& subscription_seq_;
+
  public:
   LockstepAsyncHandler(LockstepBatons& batons, Sequence& subscription_seq)
-    : batons_(batons), subscription_seq_(subscription_seq) {};
+      : batons_(batons), subscription_seq_(subscription_seq){};
 
-  Reference<Flowable<Payload>> handleRequestStream(Payload p, StreamId) override {
+  Reference<Flowable<Payload>> handleRequestStream(Payload p, StreamId)
+      override {
     EXPECT_EQ(p.moveDataToString(), "initial");
     return Flowables::fromPublisher<Payload>(
-      [this](Reference<flowable::Subscriber<Payload>> subscriber)
-      {
-        auto subscription = make_ref<StrictMock<MockSubscription>>();
+        [this](Reference<flowable::Subscriber<Payload>> subscriber) {
+          auto subscription = make_ref<StrictMock<MockSubscription>>();
 
-        std::thread([=] {
+          std::thread([=] {
             CHECK_WAIT(this->batons_.on_request_recieved);
 
             LOCKSTEP_DEBUG("SERVER: sending onNext(foo)");
@@ -61,28 +62,28 @@ class LockstepAsyncHandler : public rsocket::RSocketResponder {
             subscriber->onComplete();
             LOCKSTEP_DEBUG("SERVER: posting server_finished");
             this->batons_.server_finished.post();
-        }).detach();
+          }).detach();
 
-        // checked once the subscription is destroyed
-        EXPECT_CALL(*subscription, request_(2))
-          .InSequence(this->subscription_seq_)
-          .WillOnce(Invoke([=](auto n) {
-            LOCKSTEP_DEBUG("SERVER: got request(" << n << ")");
-            EXPECT_EQ(n, 2);
-            this->batons_.on_request_recieved.post();
-          }));
+          // checked once the subscription is destroyed
+          EXPECT_CALL(*subscription, request_(2))
+              .InSequence(this->subscription_seq_)
+              .WillOnce(Invoke([=](auto n) {
+                LOCKSTEP_DEBUG("SERVER: got request(" << n << ")");
+                EXPECT_EQ(n, 2);
+                this->batons_.on_request_recieved.post();
+              }));
 
-        EXPECT_CALL(*subscription, cancel_())
-          .InSequence(this->subscription_seq_)
-          .WillOnce(Invoke([=]{
-            LOCKSTEP_DEBUG("SERVER: recieved cancel()");
-              this->batons_.on_cancel_recieved_toclient.post();
-              this->batons_.on_cancel_recieved_toserver.post();
-          }));
+          EXPECT_CALL(*subscription, cancel_())
+              .InSequence(this->subscription_seq_)
+              .WillOnce(Invoke([=] {
+                LOCKSTEP_DEBUG("SERVER: recieved cancel()");
+                this->batons_.on_cancel_recieved_toclient.post();
+                this->batons_.on_cancel_recieved_toserver.post();
+              }));
 
-        LOCKSTEP_DEBUG("SERVER: sending onSubscribe()");
-        subscriber->onSubscribe(subscription);
-      });
+          LOCKSTEP_DEBUG("SERVER: sending onSubscribe()");
+          subscriber->onSubscribe(subscription);
+        });
   }
 };
 
@@ -91,43 +92,46 @@ TEST(RequestStreamTest, OperationsAfterCancel) {
   Sequence server_seq;
   Sequence client_seq;
 
-  auto server = makeServer(std::make_shared<LockstepAsyncHandler>(batons, server_seq));
+  auto server =
+      makeServer(std::make_shared<LockstepAsyncHandler>(batons, server_seq));
   folly::ScopedEventBaseThread worker;
   auto client = makeClient(worker.getEventBase(), *server->listeningPort());
   auto requester = client->getRequester();
 
-  auto scbr_mock = make_ref<testing::StrictMock<yarpl::mocks::MockSubscriber<std::string>>>(0);
+  auto scbr_mock =
+      make_ref<testing::StrictMock<yarpl::mocks::MockSubscriber<std::string>>>(
+          0);
 
   Reference<Subscription> subscription;
   EXPECT_CALL(*scbr_mock, onSubscribe_(_))
-    .InSequence(client_seq)
-    .WillOnce(Invoke([&](auto s) {
-      LOCKSTEP_DEBUG("CLIENT: got onSubscribe(), sending request(2)");
-      EXPECT_NE(s, nullptr);
-      subscription = s;
-      subscription->request(2);
-    }));
+      .InSequence(client_seq)
+      .WillOnce(Invoke([&](auto s) {
+        LOCKSTEP_DEBUG("CLIENT: got onSubscribe(), sending request(2)");
+        EXPECT_NE(s, nullptr);
+        subscription = s;
+        subscription->request(2);
+      }));
   EXPECT_CALL(*scbr_mock, onNext_("foo"))
-    .InSequence(client_seq)
-    .WillOnce(Invoke([&](auto) {
-      EXPECT_NE(subscription, nullptr);
-      LOCKSTEP_DEBUG("CLIENT: got onNext(foo), sending cancel()");
-      subscription->cancel();
-      batons.on_cancel_sent.post();
-      CHECK_WAIT(batons.on_cancel_recieved_toclient);
-      CHECK_WAIT(batons.on_second_payload_sent);
-    }));
+      .InSequence(client_seq)
+      .WillOnce(Invoke([&](auto) {
+        EXPECT_NE(subscription, nullptr);
+        LOCKSTEP_DEBUG("CLIENT: got onNext(foo), sending cancel()");
+        subscription->cancel();
+        batons.on_cancel_sent.post();
+        CHECK_WAIT(batons.on_cancel_recieved_toclient);
+        CHECK_WAIT(batons.on_second_payload_sent);
+      }));
 
   // shouldn't recieve 'bar', we canceled syncronously with the Subscriber
   // had 'cancel' been called in a different thread with no synchronization,
   // the client's Subscriber _could_ have recieved 'bar'
 
   EXPECT_CALL(*scbr_mock, onComplete_())
-    .InSequence(client_seq)
-    .WillOnce(Invoke([&]() {
-      LOCKSTEP_DEBUG("CLIENT: got onComplete()");
-      batons.client_finished.post();
-    }));
+      .InSequence(client_seq)
+      .WillOnce(Invoke([&]() {
+        LOCKSTEP_DEBUG("CLIENT: got onComplete()");
+        batons.client_finished.post();
+      }));
 
   LOCKSTEP_DEBUG("RUNNER: doing requestStream()");
   requester->requestStream(Payload("initial"))

--- a/yarpl/include/yarpl/observable/Observable.h
+++ b/yarpl/include/yarpl/observable/Observable.h
@@ -177,33 +177,39 @@ auto Observable<T>::toFlowable(BackpressureStrategy strategy) {
     strategy
   ](Reference<flowable::Subscriber<T>> subscriber) {
     Reference<flowable::Subscription> subscription;
-    switch(strategy) {
+    switch (strategy) {
       case BackpressureStrategy::DROP:
-        subscription = make_ref<
-            flowable::details::FlowableFromObservableSubscriptionDropStrategy<T>>(
-            thisObservable, subscriber);
+        subscription =
+            make_ref<flowable::details::
+                         FlowableFromObservableSubscriptionDropStrategy<T>>(
+                thisObservable, subscriber);
         break;
       case BackpressureStrategy::ERROR:
-        subscription = make_ref<
-            flowable::details::FlowableFromObservableSubscriptionErrorStrategy<T>>(
-            thisObservable, subscriber);
+        subscription =
+            make_ref<flowable::details::
+                         FlowableFromObservableSubscriptionErrorStrategy<T>>(
+                thisObservable, subscriber);
         break;
       case BackpressureStrategy::BUFFER:
-        subscription = make_ref<
-            flowable::details::FlowableFromObservableSubscriptionBufferStrategy<T>>(
-            thisObservable, subscriber);
+        subscription =
+            make_ref<flowable::details::
+                         FlowableFromObservableSubscriptionBufferStrategy<T>>(
+                thisObservable, subscriber);
         break;
       case BackpressureStrategy::LATEST:
-        subscription = make_ref<
-            flowable::details::FlowableFromObservableSubscriptionLatestStrategy<T>>(
-            thisObservable, subscriber);
+        subscription =
+            make_ref<flowable::details::
+                         FlowableFromObservableSubscriptionLatestStrategy<T>>(
+                thisObservable, subscriber);
         break;
       case BackpressureStrategy::MISSING:
-        subscription = make_ref<
-            flowable::details::FlowableFromObservableSubscriptionMissingStrategy<T>>(
-            thisObservable, subscriber);
+        subscription =
+            make_ref<flowable::details::
+                         FlowableFromObservableSubscriptionMissingStrategy<T>>(
+                thisObservable, subscriber);
         break;
-      default: CHECK(false); // unknown value for strategy
+      default:
+        CHECK(false); // unknown value for strategy
     }
     subscriber->onSubscribe(std::move(subscription));
   });

--- a/yarpl/test/Observable_test.cpp
+++ b/yarpl/test/Observable_test.cpp
@@ -254,7 +254,7 @@ TEST(Observable, CancelFromDifferentThread) {
 }
 
 TEST(Observable, toFlowableDrop) {
-  auto a = Observables::range(1,10);
+  auto a = Observables::range(1, 10);
   auto f = a->toFlowable(BackpressureStrategy::DROP);
 
   std::vector<int64_t> v;
@@ -263,9 +263,7 @@ TEST(Observable, toFlowableDrop) {
 
   EXPECT_CALL(*subscriber, onSubscribe_(_));
   EXPECT_CALL(*subscriber, onNext_(_))
-      .WillRepeatedly(Invoke([&](int64_t value) {
-    v.push_back(value);
-  }));
+      .WillRepeatedly(Invoke([&](int64_t value) { v.push_back(value); }));
   EXPECT_CALL(*subscriber, onComplete_());
 
   f->subscribe(subscriber);
@@ -291,7 +289,7 @@ TEST(Observable, toFlowableDropWithCancel) {
 }
 
 TEST(Observable, toFlowableErrorStrategy) {
-  auto a = Observables::range(1,10);
+  auto a = Observables::range(1, 10);
   auto f = a->toFlowable(BackpressureStrategy::ERROR);
 
   std::vector<int64_t> v;
@@ -300,12 +298,11 @@ TEST(Observable, toFlowableErrorStrategy) {
 
   EXPECT_CALL(*subscriber, onSubscribe_(_));
   EXPECT_CALL(*subscriber, onNext_(_))
-      .WillRepeatedly(Invoke([&](int64_t value) {
-          v.push_back(value);
-      }));
+      .WillRepeatedly(Invoke([&](int64_t value) { v.push_back(value); }));
   EXPECT_CALL(*subscriber, onError_(_))
       .WillOnce(Invoke([&](folly::exception_wrapper ex) {
-          EXPECT_TRUE(ex.is_compatible_with<yarpl::flowable::MissingBackpressureException>());
+        EXPECT_TRUE(ex.is_compatible_with<
+                    yarpl::flowable::MissingBackpressureException>());
       }));
 
   f->subscribe(subscriber);
@@ -314,7 +311,7 @@ TEST(Observable, toFlowableErrorStrategy) {
 }
 
 TEST(Observable, toFlowableBufferStrategy) {
-  auto a = Observables::range(1,10);
+  auto a = Observables::range(1, 10);
   auto f = a->toFlowable(BackpressureStrategy::BUFFER);
 
   std::vector<int64_t> v;
@@ -323,9 +320,7 @@ TEST(Observable, toFlowableBufferStrategy) {
 
   EXPECT_CALL(*subscriber, onSubscribe_(_));
   EXPECT_CALL(*subscriber, onNext_(_))
-      .WillRepeatedly(Invoke([&](int64_t value) {
-          v.push_back(value);
-      }));
+      .WillRepeatedly(Invoke([&](int64_t value) { v.push_back(value); }));
   EXPECT_CALL(*subscriber, onComplete_());
 
   f->subscribe(subscriber);
@@ -336,7 +331,7 @@ TEST(Observable, toFlowableBufferStrategy) {
 }
 
 TEST(Observable, toFlowableLatestStrategy) {
-  auto a = Observables::range(1,10);
+  auto a = Observables::range(1, 10);
   auto f = a->toFlowable(BackpressureStrategy::LATEST);
 
   std::vector<int64_t> v;
@@ -345,9 +340,7 @@ TEST(Observable, toFlowableLatestStrategy) {
 
   EXPECT_CALL(*subscriber, onSubscribe_(_));
   EXPECT_CALL(*subscriber, onNext_(_))
-      .WillRepeatedly(Invoke([&](int64_t value) {
-          v.push_back(value);
-      }));
+      .WillRepeatedly(Invoke([&](int64_t value) { v.push_back(value); }));
   EXPECT_CALL(*subscriber, onComplete_());
 
   f->subscribe(subscriber);

--- a/yarpl/test/yarpl/test_utils/Mocks.h
+++ b/yarpl/test/yarpl/test_utils/Mocks.h
@@ -20,9 +20,12 @@ namespace mocks {
 template <typename T>
 class MockFlowable : public flowable::Flowable<T> {
  public:
-  MOCK_METHOD1_T(subscribe_, void(yarpl::Reference<flowable::Subscriber<T>> subscriber));
+  MOCK_METHOD1_T(
+      subscribe_,
+      void(yarpl::Reference<flowable::Subscriber<T>> subscriber));
 
-  void subscribe(yarpl::Reference<flowable::Subscriber<T>> subscriber) noexcept override {
+  void subscribe(
+      yarpl::Reference<flowable::Subscriber<T>> subscriber) noexcept override {
     subscribe_(std::move(subscriber));
   }
 };
@@ -34,7 +37,9 @@ class MockFlowable : public flowable::Flowable<T> {
 template <typename T>
 class MockSubscriber : public flowable::Subscriber<T> {
  public:
-  MOCK_METHOD1(onSubscribe_, void(yarpl::Reference<flowable::Subscription> subscription));
+  MOCK_METHOD1(
+      onSubscribe_,
+      void(yarpl::Reference<flowable::Subscription> subscription));
   MOCK_METHOD1_T(onNext_, void(const T& value));
   MOCK_METHOD0(onComplete_, void());
   MOCK_METHOD1_T(onError_, void(folly::exception_wrapper ex));
@@ -42,7 +47,8 @@ class MockSubscriber : public flowable::Subscriber<T> {
   explicit MockSubscriber(int64_t initial = std::numeric_limits<int64_t>::max())
       : initial_(initial) {}
 
-  void onSubscribe(yarpl::Reference<flowable::Subscription> subscription) override {
+  void onSubscribe(
+      yarpl::Reference<flowable::Subscription> subscription) override {
     subscription_ = subscription;
     onSubscribe_(subscription);
 


### PR DESCRIPTION
On the client side, rsocket incorrectly would not call `onComplete` or `onError` after the `Subscription` was canceled (in the synchronous case this was deterministic; it races in a multithreading environment however, we should make that clear. This fix does not address multithreading concerns).

I put this test in a separate file because it takes 10+ seconds to build the current RequestStreamTest.cpp file, and linking time isn't slow for us yet.

clang-format results are in a separate commit because it's impossible to filter out the noise otherwise. 