### PR TITLE
Delete StreamStateMachineBase::Parameters

### DIFF
--- a/rsocket/statemachine/ChannelRequester.cpp
+++ b/rsocket/statemachine/ChannelRequester.cpp
@@ -7,9 +7,6 @@ namespace rsocket {
 using namespace yarpl;
 using namespace yarpl::flowable;
 
-ChannelRequester::ChannelRequester(const ConsumerBase::Parameters& params)
-    : ConsumerBase(params), PublisherBase(/*initialRequestN=*/1) {}
-
 void ChannelRequester::onSubscribe(
     Reference<Subscription> subscription) noexcept {
   CHECK(!requested_);
@@ -17,11 +14,11 @@ void ChannelRequester::onSubscribe(
 }
 
 void ChannelRequester::onNext(Payload request) noexcept {
-  if(!requested_) {
+  if (!requested_) {
     requested_ = true;
 
-    size_t initialN = initialResponseAllowance_.drainWithLimit(
-        Frame_REQUEST_N::kMaxRequestN);
+    size_t initialN =
+        initialResponseAllowance_.drainWithLimit(Frame_REQUEST_N::kMaxRequestN);
     size_t remainingN = initialResponseAllowance_.drain();
     // Send as much as possible with the initial request.
     CHECK_GE(Frame_REQUEST_N::kMaxRequestN, initialN);
@@ -42,7 +39,7 @@ void ChannelRequester::onNext(Payload request) noexcept {
   }
 
   checkPublisherOnNext();
-  if(!publisherClosed()) {
+  if (!publisherClosed()) {
     writePayload(std::move(request), false);
   }
 }
@@ -53,7 +50,7 @@ void ChannelRequester::onComplete() noexcept {
     closeStream(StreamCompletionSignal::CANCEL);
     return;
   }
-  if(!publisherClosed()) {
+  if (!publisherClosed()) {
     publisherComplete();
     completeStream();
     tryCompleteChannel();
@@ -65,7 +62,7 @@ void ChannelRequester::onError(folly::exception_wrapper ex) noexcept {
     closeStream(StreamCompletionSignal::CANCEL);
     return;
   }
-  if(!publisherClosed()) {
+  if (!publisherClosed()) {
     publisherComplete();
     applicationError(ex.get_exception()->what());
     tryCompleteChannel();
@@ -135,4 +132,4 @@ void ChannelRequester::handleCancel() {
   publisherComplete();
   tryCompleteChannel();
 }
-} // reactivesocket
+}

--- a/rsocket/statemachine/ChannelRequester.h
+++ b/rsocket/statemachine/ChannelRequester.h
@@ -2,16 +2,10 @@
 
 #pragma once
 
-#include <iosfwd>
-
 #include "rsocket/Payload.h"
 #include "rsocket/statemachine/ConsumerBase.h"
 #include "rsocket/statemachine/PublisherBase.h"
 #include "yarpl/flowable/Subscriber.h"
-
-namespace folly {
-class exception_wrapper;
-}
 
 namespace rsocket {
 
@@ -20,7 +14,9 @@ class ChannelRequester : public ConsumerBase,
                          public PublisherBase,
                          public yarpl::flowable::Subscriber<Payload> {
  public:
-  explicit ChannelRequester(const ConsumerBase::Parameters& params);
+  ChannelRequester(std::shared_ptr<StreamsWriter> writer, StreamId streamId)
+      : ConsumerBase(std::move(writer), streamId),
+        PublisherBase(1 /*initialRequestN*/) {}
 
  private:
   void onSubscribe(yarpl::Reference<yarpl::flowable::Subscription>
@@ -29,7 +25,6 @@ class ChannelRequester : public ConsumerBase,
   void onComplete() noexcept override;
   void onError(folly::exception_wrapper) noexcept override;
 
-  // implementation from ConsumerBase::SubscriptionBase
   void request(int64_t) noexcept override;
   void cancel() noexcept override;
 
@@ -46,5 +41,4 @@ class ChannelRequester : public ConsumerBase,
   AllowanceSemaphore initialResponseAllowance_;
   bool requested_{false};
 };
-
-} // reactivesocket
+}

--- a/rsocket/statemachine/ChannelResponder.cpp
+++ b/rsocket/statemachine/ChannelResponder.cpp
@@ -14,13 +14,13 @@ void ChannelResponder::onSubscribe(
 
 void ChannelResponder::onNext(Payload response) noexcept {
   checkPublisherOnNext();
-  if(!publisherClosed()) {
+  if (!publisherClosed()) {
     writePayload(std::move(response), false);
   }
 }
 
 void ChannelResponder::onComplete() noexcept {
-  if(!publisherClosed()) {
+  if (!publisherClosed()) {
     publisherComplete();
     completeStream();
     tryCompleteChannel();
@@ -28,7 +28,7 @@ void ChannelResponder::onComplete() noexcept {
 }
 
 void ChannelResponder::onError(folly::exception_wrapper ex) noexcept {
-  if(!publisherClosed()) {
+  if (!publisherClosed()) {
     publisherComplete();
     applicationError(ex.get_exception()->what());
     tryCompleteChannel();
@@ -96,8 +96,7 @@ void ChannelResponder::handleRequestN(uint32_t n) {
   processRequestN(n);
 }
 
-void ChannelResponder::handleError(
-    folly::exception_wrapper ex) {
+void ChannelResponder::handleError(folly::exception_wrapper ex) {
   errorConsumer(std::move(ex));
   tryCompleteChannel();
 }

--- a/rsocket/statemachine/ChannelResponder.h
+++ b/rsocket/statemachine/ChannelResponder.h
@@ -15,10 +15,12 @@ class ChannelResponder : public ConsumerBase,
                          public PublisherBase,
                          public yarpl::flowable::Subscriber<Payload> {
  public:
-  explicit ChannelResponder(
-      uint32_t initialRequestN,
-      const ConsumerBase::Parameters& params)
-      : ConsumerBase(params), PublisherBase(initialRequestN) {}
+  ChannelResponder(
+      std::shared_ptr<StreamsWriter> writer,
+      StreamId streamId,
+      uint32_t initialRequestN)
+      : ConsumerBase(std::move(writer), streamId),
+        PublisherBase(initialRequestN) {}
 
   void processInitialFrame(Frame_REQUEST_CHANNEL&&);
 
@@ -29,7 +31,6 @@ class ChannelResponder : public ConsumerBase,
   void onComplete() noexcept override;
   void onError(folly::exception_wrapper) noexcept override;
 
-  // implementation from ConsumerBase::SubscriptionBase
   void request(int64_t n) noexcept override;
   void cancel() noexcept override;
 
@@ -48,4 +49,4 @@ class ChannelResponder : public ConsumerBase,
 
   void tryCompleteChannel();
 };
-} // reactivesocket
+}

--- a/rsocket/statemachine/ConsumerBase.cpp
+++ b/rsocket/statemachine/ConsumerBase.cpp
@@ -2,8 +2,9 @@
 
 #include "rsocket/statemachine/ConsumerBase.h"
 
-#include <glog/logging.h>
 #include <algorithm>
+
+#include <glog/logging.h>
 
 #include "rsocket/Payload.h"
 #include "yarpl/flowable/Subscription.h"
@@ -15,7 +16,7 @@ using namespace yarpl::flowable;
 
 void ConsumerBase::subscribe(
     Reference<yarpl::flowable::Subscriber<Payload>> subscriber) {
-  if (Base::isTerminated()) {
+  if (isTerminated()) {
     subscriber->onSubscribe(yarpl::flowable::Subscription::empty());
     subscriber->onComplete();
     return;
@@ -39,7 +40,6 @@ void ConsumerBase::cancelConsumer() {
   consumingSubscriber_ = nullptr;
 }
 
-
 void ConsumerBase::generateRequest(size_t n) {
   allowance_.release(n);
   pendingAllowance_.release(n);
@@ -58,7 +58,7 @@ void ConsumerBase::endStream(StreamCompletionSignal signal) {
       subscriber->onError(StreamInterruptedException(static_cast<int>(signal)));
     }
   }
-  Base::endStream(signal);
+  StreamStateMachineBase::endStream(signal);
 }
 
 size_t ConsumerBase::getConsumerAllowance() const {
@@ -109,5 +109,4 @@ void ConsumerBase::handleFlowControlError() {
   }
   errorStream("flow control error");
 }
-
 }

--- a/rsocket/statemachine/ConsumerBase.h
+++ b/rsocket/statemachine/ConsumerBase.h
@@ -4,7 +4,6 @@
 
 #include <folly/ExceptionWrapper.h>
 #include <cstddef>
-#include <iostream>
 
 #include "rsocket/Payload.h"
 #include "rsocket/internal/AllowanceSemaphore.h"
@@ -20,10 +19,8 @@ enum class StreamCompletionSignal;
 /// A class that represents a flow-control-aware consumer of data.
 class ConsumerBase : public StreamStateMachineBase,
                      public yarpl::flowable::Subscription {
-  using Base = StreamStateMachineBase;
-
  public:
-  using Base::Base;
+  using StreamStateMachineBase::StreamStateMachineBase;
 
   /// Adds implicit allowance.
   ///
@@ -33,12 +30,10 @@ class ConsumerBase : public StreamStateMachineBase,
     allowance_.release(n);
   }
 
-  /// @{
   void subscribe(
       yarpl::Reference<yarpl::flowable::Subscriber<Payload>> subscriber);
 
   void generateRequest(size_t n);
-  /// @}
 
   size_t getConsumerAllowance() const override;
 
@@ -51,9 +46,6 @@ class ConsumerBase : public StreamStateMachineBase,
   }
 
   void endStream(StreamCompletionSignal signal) override;
-
-//  void pauseStream(RequestHandler& requestHandler) override;
-//  void resumeStream(RequestHandler& requestHandler) override;
 
   void processPayload(Payload&&, bool onNext);
 

--- a/rsocket/statemachine/PublisherBase.cpp
+++ b/rsocket/statemachine/PublisherBase.cpp
@@ -9,7 +9,7 @@
 namespace rsocket {
 
 PublisherBase::PublisherBase(uint32_t initialRequestN)
-      : initialRequestN_(initialRequestN) {}
+    : initialRequestN_(initialRequestN) {}
 
 void PublisherBase::publisherSubscribe(
     yarpl::Reference<yarpl::flowable::Subscription> subscription) {

--- a/rsocket/statemachine/RequestResponseRequester.cpp
+++ b/rsocket/statemachine/RequestResponseRequester.cpp
@@ -2,8 +2,6 @@
 
 #include "rsocket/statemachine/RequestResponseRequester.h"
 
-#include <folly/ExceptionWrapper.h>
-
 #include "rsocket/internal/Common.h"
 #include "rsocket/statemachine/RSocketStateMachine.h"
 

--- a/rsocket/statemachine/RequestResponseRequester.h
+++ b/rsocket/statemachine/RequestResponseRequester.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <iosfwd>
 #include "rsocket/Payload.h"
 #include "rsocket/statemachine/StreamStateMachineBase.h"
 #include "yarpl/single/SingleObserver.h"
@@ -14,11 +13,13 @@ namespace rsocket {
 /// requester
 class RequestResponseRequester : public StreamStateMachineBase,
                                  public yarpl::single::SingleSubscription {
-  using Base = StreamStateMachineBase;
-
  public:
-  explicit RequestResponseRequester(const Parameters& params, Payload payload)
-      : Base(params), initialPayload_(std::move(payload)) {}
+  RequestResponseRequester(
+      std::shared_ptr<StreamsWriter> writer,
+      StreamId streamId,
+      Payload payload)
+      : StreamStateMachineBase(std::move(writer), streamId),
+        initialPayload_(std::move(payload)) {}
 
   void subscribe(
       yarpl::Reference<yarpl::single::SingleObserver<Payload>> subscriber);

--- a/rsocket/statemachine/RequestResponseResponder.cpp
+++ b/rsocket/statemachine/RequestResponseResponder.cpp
@@ -50,14 +50,6 @@ void RequestResponseResponder::onError(folly::exception_wrapper ex) noexcept {
   }
 }
 
-//void RequestResponseResponder::pauseStream(RequestHandler& requestHandler) {
-//  pausePublisherStream(requestHandler);
-//}
-//
-//void RequestResponseResponder::resumeStream(RequestHandler& requestHandler) {
-//  resumePublisherStream(requestHandler);
-//}
-
 void RequestResponseResponder::endStream(StreamCompletionSignal signal) {
   switch (state_) {
     case State::RESPONDING:
@@ -85,5 +77,4 @@ void RequestResponseResponder::handleCancel() {
       break;
   }
 }
-
-} // reactivesocket
+}

--- a/rsocket/statemachine/RequestResponseResponder.h
+++ b/rsocket/statemachine/RequestResponseResponder.h
@@ -14,8 +14,10 @@ namespace rsocket {
 class RequestResponseResponder : public StreamStateMachineBase,
                                  public yarpl::single::SingleObserver<Payload> {
  public:
-  explicit RequestResponseResponder(const Parameters& params)
-      : StreamStateMachineBase(params) {}
+  RequestResponseResponder(
+      std::shared_ptr<StreamsWriter> writer,
+      StreamId streamId)
+      : StreamStateMachineBase(std::move(writer), streamId) {}
 
  private:
   void onSubscribe(yarpl::Reference<yarpl::single::SingleSubscription>
@@ -25,8 +27,6 @@ class RequestResponseResponder : public StreamStateMachineBase,
 
   void handleCancel() override;
 
-//  void pauseStream(RequestHandler&) override;
-//  void resumeStream(RequestHandler&) override;
   void endStream(StreamCompletionSignal) override;
 
   /// State of the Subscription responder.
@@ -37,5 +37,4 @@ class RequestResponseResponder : public StreamStateMachineBase,
 
   yarpl::Reference<yarpl::single::SingleSubscription> producingSubscription_;
 };
-
-} // reactivesocket
+}

--- a/rsocket/statemachine/StreamRequester.cpp
+++ b/rsocket/statemachine/StreamRequester.cpp
@@ -38,13 +38,13 @@ void StreamRequester::request(int64_t n) noexcept {
     // Pump the remaining allowance into the ConsumerBase _after_ sending the
     // initial request.
     if (remainingN) {
-      Base::generateRequest(remainingN);
+      generateRequest(remainingN);
     }
     return;
   }
 
   checkConsumerRequest();
-  ConsumerBase::generateRequest(n);
+  generateRequest(n);
 }
 
 void StreamRequester::cancel() noexcept {

--- a/rsocket/statemachine/StreamRequester.h
+++ b/rsocket/statemachine/StreamRequester.h
@@ -21,13 +21,17 @@ class StreamRequester : public ConsumerBase {
  public:
   // initialization of the ExecutorBase will be ignored for any of the
   // derived classes
-  explicit StreamRequester(const Base::Parameters& params, Payload payload)
-      : Base(params), initialPayload_(std::move(payload)) {}
+  StreamRequester(
+      std::shared_ptr<StreamsWriter> writer,
+      StreamId streamId,
+      Payload payload)
+      : ConsumerBase(std::move(writer), streamId),
+        initialPayload_(std::move(payload)) {}
 
   void setRequested(size_t n);
 
  private:
-  // implementation from ConsumerBase::SubscriptionBase
+  // implementation from ConsumerBase::Subscription
   void request(int64_t) noexcept override;
   void cancel() noexcept override;
 
@@ -44,4 +48,4 @@ class StreamRequester : public ConsumerBase {
   Payload initialPayload_;
   bool requested_{false};
 };
-} // reactivesocket
+}

--- a/rsocket/statemachine/StreamResponder.cpp
+++ b/rsocket/statemachine/StreamResponder.cpp
@@ -14,13 +14,13 @@ void StreamResponder::onSubscribe(
 
 void StreamResponder::onNext(Payload response) noexcept {
   checkPublisherOnNext();
-  if(!publisherClosed()) {
+  if (!publisherClosed()) {
     writePayload(std::move(response), false);
   }
 }
 
 void StreamResponder::onComplete() noexcept {
-  if(!publisherClosed()) {
+  if (!publisherClosed()) {
     publisherComplete();
     completeStream();
     closeStream(StreamCompletionSignal::COMPLETE);
@@ -28,20 +28,12 @@ void StreamResponder::onComplete() noexcept {
 }
 
 void StreamResponder::onError(folly::exception_wrapper ex) noexcept {
-  if(!publisherClosed()) {
+  if (!publisherClosed()) {
     publisherComplete();
     applicationError(ex.get_exception()->what());
     closeStream(StreamCompletionSignal::ERROR);
   }
 }
-
-//void StreamResponder::pauseStream(RequestHandler& requestHandler) {
-//  pausePublisherStream(requestHandler);
-//}
-//
-//void StreamResponder::resumeStream(RequestHandler& requestHandler) {
-//  resumePublisherStream(requestHandler);
-//}
 
 void StreamResponder::endStream(StreamCompletionSignal signal) {
   terminatePublisher();

--- a/rsocket/statemachine/StreamResponder.h
+++ b/rsocket/statemachine/StreamResponder.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <iosfwd>
 #include "rsocket/statemachine/PublisherBase.h"
 #include "rsocket/statemachine/StreamStateMachineBase.h"
 #include "yarpl/flowable/Subscriber.h"
@@ -14,10 +13,12 @@ class StreamResponder : public StreamStateMachineBase,
                         public PublisherBase,
                         public yarpl::flowable::Subscriber<Payload> {
  public:
-  // initialization of the ExecutorBase will be ignored for any of the
-  // derived classes
-  explicit StreamResponder(uint32_t initialRequestN, const Parameters& params)
-      : StreamStateMachineBase(params), PublisherBase(initialRequestN) {}
+  StreamResponder(
+      std::shared_ptr<StreamsWriter> writer,
+      StreamId streamId,
+      uint32_t initialRequestN)
+      : StreamStateMachineBase(std::move(writer), streamId),
+        PublisherBase(initialRequestN) {}
 
  protected:
   void handleCancel() override;
@@ -30,8 +31,6 @@ class StreamResponder : public StreamStateMachineBase,
   void onComplete() noexcept override;
   void onError(folly::exception_wrapper) noexcept override;
 
-//  void pauseStream(RequestHandler&) override;
-//  void resumeStream(RequestHandler&) override;
   void endStream(StreamCompletionSignal) override;
 };
-} // reactivesocket
+}

--- a/rsocket/statemachine/StreamStateMachineBase.cpp
+++ b/rsocket/statemachine/StreamStateMachineBase.cpp
@@ -61,9 +61,7 @@ void StreamStateMachineBase::applicationError(std::string errorPayload) {
 
 void StreamStateMachineBase::errorStream(std::string errorPayload) {
   writer_->writeCloseStream(
-      streamId_,
-      StreamCompletionSignal::ERROR,
-      std::move(errorPayload));
+      streamId_, StreamCompletionSignal::ERROR, std::move(errorPayload));
   closeStream(StreamCompletionSignal::ERROR);
 }
 
@@ -79,4 +77,4 @@ void StreamStateMachineBase::closeStream(StreamCompletionSignal signal) {
   writer_->onStreamClosed(streamId_, signal);
   // TODO: set writer_ to nullptr
 }
-} // reactivesocket
+}

--- a/rsocket/statemachine/StreamStateMachineBase.h
+++ b/rsocket/statemachine/StreamStateMachineBase.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <functional>
-#include <iosfwd>
 #include <memory>
 
 #include <folly/ExceptionWrapper.h>
@@ -20,27 +18,16 @@ namespace rsocket {
 class StreamsWriter;
 struct Payload;
 
-///
 /// A common base class of all state machines.
 ///
 /// The instances might be destroyed on a different thread than they were
 /// created.
 class StreamStateMachineBase : public virtual yarpl::Refcounted {
  public:
-  /// A dependent type which encapsulates all parameters needed to initialise
-  /// any of the classes and the final automata. Must be the only argument to
-  /// the
-  /// constructor of any class and must be passed by const& to class's Base.
-  struct Parameters {
-    Parameters(std::shared_ptr<StreamsWriter> _writer, StreamId _streamId)
-        : writer(std::move(_writer)), streamId(_streamId) {}
-
-    std::shared_ptr<StreamsWriter> writer;
-    StreamId streamId{0};
-  };
-
-  explicit StreamStateMachineBase(Parameters params)
-      : writer_(std::move(params.writer)), streamId_(params.streamId) {}
+  StreamStateMachineBase(
+      std::shared_ptr<StreamsWriter> writer,
+      StreamId streamId)
+      : writer_{std::move(writer)}, streamId_(streamId) {}
   virtual ~StreamStateMachineBase() = default;
 
   virtual void handlePayload(Payload&& payload, bool complete, bool flagsNext);
@@ -62,10 +49,6 @@ class StreamStateMachineBase : public virtual yarpl::Refcounted {
   /// corresponding
   ///   terminal signal to the connection.
   virtual void endStream(StreamCompletionSignal signal);
-  /// @}
-
-//  virtual void pauseStream(RequestHandler& requestHandler) = 0;
-//  virtual void resumeStream(RequestHandler& requestHandler) = 0;
 
  protected:
   bool isTerminated() const {


### PR DESCRIPTION
It's just two parameters, pass them manually without all the hassle.

Gets rid of some unneeded "Base" typedefs along the way, kills commented out
code, removes some unused headers, and of course runs clang-format.