### PR TITLE
add test/fix for racing to call 'cancel' on client subscription

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,6 +405,7 @@ add_executable(
   test/RequestResponseTest.cpp
   test/RequestStreamTest.cpp
   test/RequestStreamTest_concurrency.cpp
+  test/RequestStreamTest_CancelAfterRequest.cpp
   test/WarmResumptionTest.cpp
   test/ColdResumptionTest.cpp
   test/ConnectionEventsTest.cpp

--- a/test/RSocketTests.h
+++ b/test/RSocketTests.h
@@ -10,6 +10,10 @@
 
 auto const default_baton_timeout = std::chrono::milliseconds(100);
 #define CHECK_WAIT(baton) CHECK(baton.timed_wait(default_baton_timeout))
+#define CHECK_WAIT_FOR(baton, ms) \
+  CHECK(baton.timed_wait(std::chrono::milliseconds(ms)))
+
+#define LOCKSTEP_DEBUG(expr) VLOG(1) << expr
 
 namespace rsocket {
 namespace tests {

--- a/test/RequestStreamTest.cpp
+++ b/test/RequestStreamTest.cpp
@@ -1,18 +1,24 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-#include <thread>
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <gtest/gtest.h>
+#include <random>
+#include <thread>
 
 #include "RSocketTests.h"
 #include "yarpl/Flowable.h"
 #include "yarpl/flowable/TestSubscriber.h"
+
+#include "yarpl/test_utils/Mocks.h"
 
 using namespace yarpl;
 using namespace yarpl::flowable;
 using namespace rsocket;
 using namespace rsocket::tests;
 using namespace rsocket::tests::client_server;
+
+using namespace yarpl::mocks;
+using namespace ::testing;
 
 namespace {
 class TestHandlerSync : public rsocket::RSocketResponder {
@@ -119,4 +125,103 @@ TEST(RequestStreamTest, RequestOnDisconnectedClient) {
 
   CHECK_WAIT(wait_for_on_error);
   ASSERT(did_call_on_error);
+}
+
+class RequestAfterCancelTestHandler : public rsocket::RSocketResponder {
+ public:
+  struct Batons {
+    folly::Baton<> serverFinished;
+    folly::Baton<> clientFinished;
+  };
+
+ private:
+  Batons& batons_;
+  Sequence& subscription_seq_;
+
+ public:
+  RequestAfterCancelTestHandler(Batons& batons, Sequence& subscription_seq)
+      : batons_(batons), subscription_seq_(subscription_seq) {}
+
+  Reference<Flowable<Payload>> handleRequestStream(Payload p, StreamId)
+      override {
+    EXPECT_EQ(p.moveDataToString(), "initial");
+    return Flowables::fromPublisher<Payload>(
+        [this](Reference<flowable::Subscriber<Payload>> subscriber) {
+          auto subscription = make_ref<StrictMock<MockSubscription>>();
+
+          // checked once the subscription is destroyed
+          EXPECT_CALL(*subscription, request_(1))
+              .InSequence(this->subscription_seq_)
+              .WillOnce(Invoke([=](auto n) {
+                LOCKSTEP_DEBUG("SERVER: got request(" << n << ")");
+                EXPECT_EQ(n, 1);
+
+                LOCKSTEP_DEBUG("SERVER: sending onNext('foo')");
+                subscriber->onNext(Payload("foo"));
+              }));
+
+          EXPECT_CALL(*subscription, cancel_())
+              .InSequence(this->subscription_seq_)
+              .WillOnce(Invoke([=] {
+                LOCKSTEP_DEBUG("SERVER: received cancel()");
+                subscriber->onComplete();
+                this->batons_.serverFinished.post();
+              }));
+
+          // should not recieve another request after the 'cancel'
+
+          LOCKSTEP_DEBUG("SERVER: sending onSubscribe()");
+          subscriber->onSubscribe(subscription);
+        });
+  }
+};
+
+TEST(RequestStreamTest, RequestAfterCancel) {
+  Sequence server_seq;
+  Sequence client_seq;
+  RequestAfterCancelTestHandler::Batons batons;
+
+  folly::ScopedEventBaseThread worker;
+  auto server = makeServer(
+      std::make_shared<RequestAfterCancelTestHandler>(batons, server_seq));
+  auto client = makeClient(worker.getEventBase(), *server->listeningPort());
+  auto requester = client->getRequester();
+
+  auto subscriber_mock =
+      make_ref<testing::StrictMock<yarpl::mocks::MockSubscriber<std::string>>>(
+          0);
+
+  Reference<Subscription> subscription;
+  EXPECT_CALL(*subscriber_mock, onSubscribe_(_))
+      .InSequence(client_seq)
+      .WillOnce(Invoke([&](auto s) {
+        LOCKSTEP_DEBUG("CLIENT: got onSubscribe(), sending request(1)");
+        EXPECT_NE(s, nullptr);
+        subscription = s;
+        subscription->request(1);
+      }));
+  EXPECT_CALL(*subscriber_mock, onNext_("foo"))
+      .InSequence(client_seq)
+      .WillRepeatedly(Invoke([&](auto) {
+        EXPECT_NE(subscription, nullptr);
+        LOCKSTEP_DEBUG(
+            "CLIENT: got onNext(foo), sending cancel() then request(1)");
+        subscription->cancel();
+        subscription->request(1); // should just be a no-op
+      }));
+  EXPECT_CALL(*subscriber_mock, onComplete_())
+      .InSequence(client_seq)
+      .WillOnce(Invoke([&]() {
+        LOCKSTEP_DEBUG("CLIENT: got onComplete()");
+        batons.clientFinished.post();
+      }));
+
+  LOCKSTEP_DEBUG("RUNNER: doing requestStream()");
+  requester->requestStream(Payload("initial"))
+      ->map([](auto p) { return p.moveDataToString(); })
+      ->subscribe(subscriber_mock);
+
+  CHECK_WAIT(batons.clientFinished);
+  CHECK_WAIT(batons.serverFinished);
+  LOCKSTEP_DEBUG("RUNNER: finished!");
 }

--- a/test/RequestStreamTest_CancelAfterRequest.cpp
+++ b/test/RequestStreamTest_CancelAfterRequest.cpp
@@ -1,0 +1,157 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <folly/io/async/ScopedEventBaseThread.h>
+#include <gtest/gtest.h>
+#include <random>
+#include <thread>
+
+#include "RSocketTests.h"
+#include "yarpl/Flowable.h"
+#include "yarpl/flowable/TestSubscriber.h"
+
+#include "yarpl/test_utils/Mocks.h"
+
+using namespace yarpl;
+using namespace yarpl::flowable;
+using namespace rsocket;
+using namespace rsocket::tests;
+using namespace rsocket::tests::client_server;
+
+using namespace yarpl::mocks;
+using namespace ::testing;
+
+struct Batons {
+  folly::Baton<> serverFinished;
+  folly::Baton<> clientFinished;
+
+  void reset() {
+    serverFinished.reset();
+    clientFinished.reset();
+  }
+};
+
+class RaceyRequestAfterCancelTestHandler : public rsocket::RSocketResponder {
+ private:
+  class RaceySubscription : public ::yarpl::flowable::Subscription {
+   public:
+    RaceySubscription(Reference<Subscriber<Payload>> s, Batons& batons)
+        : subscriber_(std::move(s)), batons_(batons) {}
+
+    void request(int64_t n) {
+      LOCKSTEP_DEBUG("SERVER: recieve request(" << n << ")");
+      for (int i = 0; i < n; i++) {
+        subscriber_->onNext(Payload("f"));
+      }
+    }
+
+    void cancel() {
+      LOCKSTEP_DEBUG("SERVER: recieve cancel(), sending onComplete()");
+      subscriber_->onComplete();
+      subscriber_ = nullptr;
+      this->batons_.serverFinished.post();
+    }
+
+   private:
+    Reference<Subscriber<Payload>> subscriber_;
+    Batons& batons_;
+  };
+
+ public:
+  RaceyRequestAfterCancelTestHandler(Batons& batons) : batons_(batons) {}
+
+  Reference<Flowable<Payload>> handleRequestStream(Payload p, StreamId)
+      override {
+    EXPECT_EQ(p.moveDataToString(), "initial");
+    return Flowables::fromPublisher<Payload>(
+        [this](Reference<flowable::Subscriber<Payload>> subscriber) {
+
+          LOCKSTEP_DEBUG("SERVER: sending onSubscribe()");
+          auto subscription = make_ref<RaceySubscription>(subscriber, batons_);
+          subscriber->onSubscribe(subscription);
+        });
+  }
+
+ private:
+  Batons& batons_;
+};
+
+TEST(RequestStreamTest, RaceyRequestAfterCancel) {
+  std::mt19937 rand(123); // we want a PRNG here
+  std::uniform_int_distribution<> dis_0_100(0, 100);
+
+  // number to request each request(n) call
+  auto const will_request = 100;
+
+  Batons batons;
+  folly::ScopedEventBaseThread worker;
+  auto server =
+      makeServer(std::make_shared<RaceyRequestAfterCancelTestHandler>(batons));
+  auto client = makeClient(worker.getEventBase(), *server->listeningPort());
+  auto requester = client->getRequester();
+
+  for (int i = 0; i < 1000; i++) {
+    auto at_response = 0;
+    Reference<Subscription> subscription;
+
+    auto subscriber = Subscribers::create<std::string>(
+        // onSubscribe
+        [&](Reference<Subscription> subscription_) {
+          subscription = subscription_;
+          subscription->request(will_request);
+
+          auto chance = dis_0_100(rand);
+          LOCKSTEP_DEBUG(
+              "CLIENT: got onSubscribe(), sending request(" << will_request
+                                                            << "), rand: "
+                                                            << chance);
+          // 1% chance subscription is canceled immediately in the same thread
+          if (chance == 0) {
+            LOCKSTEP_DEBUG("CLIENT: immediately sending cancel()");
+            subscription->cancel();
+          }
+          // 99% chance subscription is canceled from another thread (with a
+          // random delay)
+          else {
+            std::thread([&] {
+              std::this_thread::sleep_for(
+                  std::chrono::nanoseconds(dis_0_100(rand)));
+              LOCKSTEP_DEBUG("CLIENT: delayed sending cancel()");
+              subscription->cancel();
+            }).detach();
+          }
+        },
+
+        // onNext
+        [&](auto) {
+          if (++at_response == will_request) {
+            LOCKSTEP_DEBUG(
+                "CLIENT: sending request(" << will_request << ") again");
+            at_response = 0;
+            subscription->request(
+                will_request); // we *might* be canceled here just be a no-op
+          }
+        },
+
+        // onError
+        [&](auto) { FAIL(); },
+
+        // onComplete
+        [&]() {
+          LOCKSTEP_DEBUG(
+              "CLIENT: got onComplete(), ended with "
+              << at_response
+              << " recieved in current batch");
+          batons.clientFinished.post();
+        });
+
+    LOCKSTEP_DEBUG("RUNNER: doing requestStream()");
+    requester->requestStream(Payload("initial"))
+        ->map([](auto p) { return p.moveDataToString(); })
+        ->subscribe(subscriber);
+
+    CHECK_WAIT_FOR(batons.clientFinished, 1000);
+    CHECK_WAIT_FOR(batons.serverFinished, 1000);
+    LOCKSTEP_DEBUG("RUNNER: finished!");
+    batons.reset();
+  }
+}

--- a/test/RequestStreamTest_CancelAfterRequest.cpp
+++ b/test/RequestStreamTest_CancelAfterRequest.cpp
@@ -20,6 +20,7 @@ using namespace rsocket::tests::client_server;
 using namespace yarpl::mocks;
 using namespace ::testing;
 
+namespace {
 struct Batons {
   folly::Baton<> serverFinished;
   folly::Baton<> clientFinished;
@@ -75,12 +76,12 @@ class RaceyRequestAfterCancelTestHandler : public rsocket::RSocketResponder {
   Batons& batons_;
 };
 
+// number to request each request(n) call
+auto const will_request = 100;
+
 TEST(RequestStreamTest, RaceyRequestAfterCancel) {
   std::mt19937 rand(123); // we want a PRNG here
   std::uniform_int_distribution<> dis_0_100(0, 100);
-
-  // number to request each request(n) call
-  auto const will_request = 100;
 
   Batons batons;
   folly::ScopedEventBaseThread worker;
@@ -154,4 +155,5 @@ TEST(RequestStreamTest, RaceyRequestAfterCancel) {
     LOCKSTEP_DEBUG("RUNNER: finished!");
     batons.reset();
   }
+}
 }

--- a/test/RequestStreamTest_concurrency.cpp
+++ b/test/RequestStreamTest_concurrency.cpp
@@ -30,8 +30,6 @@ struct LockstepBatons {
 using namespace yarpl::mocks;
 using namespace ::testing;
 
-#define LOCKSTEP_DEBUG(expr) VLOG(3) << expr
-
 class LockstepAsyncHandler : public rsocket::RSocketResponder {
   LockstepBatons& batons_;
   Sequence& subscription_seq_;

--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -127,18 +127,14 @@ class FlowableOperator : public Flowable<D> {
     void terminateImpl(
         TerminateState state,
         folly::exception_wrapper ex = folly::exception_wrapper{nullptr}) {
-      if (isTerminated()) {
-        return;
-      }
-
-      if (auto upstream = std::move(upstream_)) {
-        if (state.up) {
+      if (state.up) {
+        if (auto upstream = std::move(upstream_)) {
           upstream->cancel();
         }
       }
 
-      if (auto subscriber = std::move(subscriber_)) {
-        if (state.down) {
+      if (state.down) {
+        if (auto subscriber = std::move(subscriber_)) {
           if (ex) {
             subscriber->onError(std::move(ex));
           } else {

--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -51,7 +51,8 @@ class FlowableOperator : public Flowable<D> {
 
     void subscriberOnNext(D value) {
       if (subscriber_) {
-        subscriber_->onNext(std::move(value));
+        auto ref = subscriber_;
+        ref->onNext(std::move(value));
       }
     }
 
@@ -87,7 +88,8 @@ class FlowableOperator : public Flowable<D> {
       }
 
       upstream_ = std::move(subscription);
-      subscriber_->onSubscribe(get_ref(this));
+      auto ref = subscriber_;
+      ref->onSubscribe(get_ref(this));
     }
 
     void onComplete() override {


### PR DESCRIPTION
Also fixes a bug in FlowableOperator, which wasn't calling onComplete or onError of its Subscription if cancel() was called on it (another bug related to inheriting, and sharing state between, a Subscriber and Subscription in one object. Multiple inheritance is the devil). 