### PR TITLE
Delete FrameBufferAllocator

### DIFF
--- a/rsocket/framing/Frame.cpp
+++ b/rsocket/framing/Frame.cpp
@@ -16,19 +16,6 @@ const uint32_t Frame_LEASE::kMaxNumRequests;
 const uint32_t Frame_SETUP::kMaxKeepaliveTime;
 const uint32_t Frame_SETUP::kMaxLifetime;
 
-std::unique_ptr<folly::IOBuf> FrameBufferAllocator::allocate(size_t size) {
-  // Purposely leak the allocator, since it's hard to deterministically
-  // guarantee that threads will stop using it before it would get statically
-  // destructed.
-  static auto* singleton = new FrameBufferAllocator;
-  return singleton->allocateBuffer(size);
-}
-
-std::unique_ptr<folly::IOBuf> FrameBufferAllocator::allocateBuffer(
-    size_t size) {
-  return folly::IOBuf::createCombined(size);
-}
-
 std::ostream&
 writeFlags(std::ostream& os, FrameFlags frameFlags, FrameType frameType) {
   constexpr const char* kEmpty = "0x00";

--- a/rsocket/framing/Frame.h
+++ b/rsocket/framing/Frame.h
@@ -51,17 +51,6 @@ class FrameHeader {
 
 std::ostream& operator<<(std::ostream&, const FrameHeader&);
 
-class FrameBufferAllocator {
- public:
-  static std::unique_ptr<folly::IOBuf> allocate(size_t size);
-
-  virtual ~FrameBufferAllocator() = default;
-
- private:
-  virtual std::unique_ptr<folly::IOBuf> allocateBuffer(size_t size);
-};
-
-/// @{
 /// Frames do not form hierarchy, as we never perform type erasure on a frame.
 /// We use inheritance only to save code duplication.
 ///

--- a/rsocket/framing/FrameSerializer.cpp
+++ b/rsocket/framing/FrameSerializer.cpp
@@ -72,5 +72,4 @@ std::unique_ptr<FrameSerializer> FrameSerializer::createAutodetectedSerializer(
 std::ostream& operator<<(std::ostream& os, const ProtocolVersion& version) {
   return os << version.major << "." << version.minor;
 }
-
-} // reactivesocket
+}

--- a/rsocket/framing/FrameSerializer.h
+++ b/rsocket/framing/FrameSerializer.h
@@ -3,9 +3,9 @@
 #pragma once
 
 #include <folly/Optional.h>
-#include <iosfwd>
+
 #include <memory>
-#include <string>
+
 #include "rsocket/framing/Frame.h"
 
 namespace rsocket {
@@ -86,5 +86,4 @@ class FrameSerializer {
       Frame_RESUME_OK&,
       std::unique_ptr<folly::IOBuf>) = 0;
 };
-
-} // reactivesocket
+}

--- a/rsocket/framing/FrameSerializer_v0.cpp
+++ b/rsocket/framing/FrameSerializer_v0.cpp
@@ -59,7 +59,7 @@ constexpr inline bool operator!(FrameFlags_V0 a) {
 } // namespace
 
 static folly::IOBufQueue createBufferQueue(size_t bufferSize) {
-  auto buf = rsocket::FrameBufferAllocator::allocate(bufferSize);
+  auto buf = folly::IOBuf::createCombined(bufferSize);
   folly::IOBufQueue queue(folly::IOBufQueue::cacheChainLength());
   queue.append(std::move(buf));
   return queue;

--- a/rsocket/framing/FrameSerializer_v1_0.cpp
+++ b/rsocket/framing/FrameSerializer_v1_0.cpp
@@ -20,7 +20,7 @@ ProtocolVersion FrameSerializerV1_0::protocolVersion() {
 }
 
 static folly::IOBufQueue createBufferQueue(size_t bufferSize) {
-  auto buf = rsocket::FrameBufferAllocator::allocate(bufferSize);
+  auto buf = folly::IOBuf::createCombined(bufferSize);
   folly::IOBufQueue queue(folly::IOBufQueue::cacheChainLength());
   queue.append(std::move(buf));
   return queue;
@@ -678,5 +678,4 @@ ProtocolVersion FrameSerializerV1_0::detectProtocolVersion(
   }
   return ProtocolVersion::Unknown;
 }
-
-} // reactivesocket
+}

--- a/rsocket/framing/FrameSerializer_v1_0.h
+++ b/rsocket/framing/FrameSerializer_v1_0.h
@@ -63,4 +63,4 @@ class FrameSerializerV1_0 : public FrameSerializer {
       folly::io::Cursor& cur,
       FrameFlags flags);
 };
-} // reactivesocket
+}


### PR DESCRIPTION
This was planned on being passed into FrameSerializer so we could have the
serializer allocate frames with extra headroom for the frame length if needed.

This shouldn't be hidden by an external allocator however.  If we're adding
frame lengths, then the frame serializer should know about it and it should be
the one serializing and deserializing them.