### PR TITLE
Converting uses of `folly::Baton<>::wait() to `timed_wait()`

### DIFF
--- a/benchmarks/Latch.h
+++ b/benchmarks/Latch.h
@@ -13,6 +13,10 @@ class Latch {
     baton_.wait();
   }
 
+  bool timed_wait(std::chrono::milliseconds timeout) {
+    return baton_.timed_wait(timeout);
+  }
+
   void post() {
     auto const old = count_.fetch_add(1);
     if (old == limit_ - 1) {

--- a/benchmarks/RequestResponseThroughputTcp.cpp
+++ b/benchmarks/RequestResponseThroughputTcp.cpp
@@ -99,5 +99,8 @@ BENCHMARK(RequestResponseThroughput, n) {
         ->subscribe(observer);
   }
 
-  latch.wait();
+  constexpr std::chrono::minutes timeout{5};
+  if (!latch.timed_wait(timeout)) {
+    LOG(ERROR) << "Timed out!";
+  }
 }

--- a/benchmarks/StreamThroughputMemory.cpp
+++ b/benchmarks/StreamThroughputMemory.cpp
@@ -166,5 +166,7 @@ BENCHMARK(StreamThroughput, n) {
       ->requestStream(Payload("InMemoryStream"))
       ->subscribe(subscriber);
 
-  subscriber->awaitTerminalEvent();
+  if (!subscriber->timedWait(std::chrono::minutes{5})) {
+    LOG(ERROR) << "Timed out!";
+  }
 }

--- a/benchmarks/StreamThroughputTcp.cpp
+++ b/benchmarks/StreamThroughputTcp.cpp
@@ -96,6 +96,8 @@ BENCHMARK(StreamThroughput, n) {
 
   // TODO: Use a latch, don't serialize all waits.
   for (auto& subscriber : subscribers) {
-    subscriber->awaitTerminalEvent();
+    if (!subscriber->timedWait(std::chrono::minutes{5})) {
+      LOG(ERROR) << "Timed out!";
+    }
   }
 }

--- a/benchmarks/Throughput.h
+++ b/benchmarks/Throughput.h
@@ -58,8 +58,12 @@ class BoundedSubscriber : public yarpl::flowable::Subscriber<Payload> {
     baton_.post();
   }
 
-  void awaitTerminalEvent() {
+  void wait() {
     baton_.wait();
+  }
+
+  bool timedWait(std::chrono::milliseconds timeout) {
+    return baton_.timed_wait(timeout);
   }
 
  private:


### PR DESCRIPTION
Only in rsocket/ and benchmarks/ right now.  We'll give
~RSocketConnectionManager a timeout of 1min, and the benchmarks will get 5min
timeouts.