### PR TITLE
Sharing ConnectionFactory instance for RSocketClient instances

### DIFF
--- a/examples/resumption/ColdResumption_Client.cpp
+++ b/examples/resumption/ColdResumption_Client.cpp
@@ -142,7 +142,7 @@ int main(int argc, char* argv[]) {
         HelloSubscribers({{firstPayload, firstSub}}));
     auto secondClient = RSocket::createResumedClient(
                             getConnFactory(worker.getEventBase()),
-                            getSetupParams(token),
+                            token,
                             resumeManager,
                             coldResumeHandler)
                             .get();
@@ -172,7 +172,7 @@ int main(int argc, char* argv[]) {
             {{firstPayload, firstSub}, {secondPayload, secondSub}}));
     auto thirdClient = RSocket::createResumedClient(
                            getConnFactory(worker.getEventBase()),
-                           getSetupParams(token),
+                           token,
                            resumeManager,
                            coldResumeHandler)
                            .get();

--- a/examples/resumption/WarmResumption_Client.cpp
+++ b/examples/resumption/WarmResumption_Client.cpp
@@ -67,7 +67,7 @@ class HelloSubscriber : public virtual yarpl::Refcounted,
 };
 }
 
-std::shared_ptr<RSocketClient> getClientAndRequestStream(
+std::unique_ptr<RSocketClient> getClientAndRequestStream(
     folly::EventBase* eventBase,
     yarpl::Reference<HelloSubscriber> subscriber) {
   folly::SocketAddress address;

--- a/rsocket/RSocket.cpp
+++ b/rsocket/RSocket.cpp
@@ -2,77 +2,106 @@
 
 #include "rsocket/RSocket.h"
 
-#include <folly/io/async/EventBaseManager.h>
-
 namespace rsocket {
 
-folly::Future<std::shared_ptr<RSocketClient>> RSocket::createConnectedClient(
-    std::unique_ptr<ConnectionFactory> connectionFactory,
+folly::Future<std::unique_ptr<RSocketClient>> RSocket::createConnectedClient(
+    std::shared_ptr<ConnectionFactory> connectionFactory,
     SetupParameters setupParameters,
     std::shared_ptr<RSocketResponder> responder,
     std::unique_ptr<KeepaliveTimer> keepaliveTimer,
     std::shared_ptr<RSocketStats> stats,
     std::shared_ptr<RSocketConnectionEvents> connectionEvents,
     std::shared_ptr<ResumeManager> resumeManager,
-    std::shared_ptr<ColdResumeHandler> coldResumeHandler,
-    OnRSocketResume) {
-  auto c = std::shared_ptr<RSocketClient>(new RSocketClient(
-      std::move(connectionFactory),
-      std::move(setupParameters),
-      std::move(responder),
-      std::move(keepaliveTimer),
-      std::move(stats),
-      std::move(connectionEvents),
-      std::move(resumeManager),
-      std::move(coldResumeHandler)));
+    std::shared_ptr<ColdResumeHandler> coldResumeHandler) {
+  auto createRSC = [
+      connectionFactory,
+      setupParameters = std::move(setupParameters),
+      responder = std::move(responder),
+      keepaliveTimer = std::move(keepaliveTimer),
+      stats = std::move(stats),
+      connectionEvents = std::move(connectionEvents),
+      resumeManager = std::move(resumeManager),
+      coldResumeHandler = std::move(coldResumeHandler)](
+      ConnectionFactory::ConnectedDuplexConnection connection) mutable {
+    VLOG(3) << "createConnectedClient received DuplexConnection";
+    return RSocket::createClientFromConnection(
+        std::move(connection.connection),
+        connection.eventBase,
+        std::move(setupParameters),
+        std::move(connectionFactory),
+        std::move(responder),
+        std::move(keepaliveTimer),
+        std::move(stats),
+        std::move(connectionEvents),
+        std::move(resumeManager),
+        std::move(coldResumeHandler));
+  };
 
-  return c->connect().then([c]() mutable { return c; });
+  return connectionFactory->connect().then(
+      [createRSC = std::move(createRSC)](
+          ConnectionFactory::ConnectedDuplexConnection connection) mutable {
+        // fromConnection method must be called from the eventBase and since
+        // there is no guarantee that the Future returned from the
+        // connectionFactory::connect method is executed on the event base,
+        // we have to ensure it by using folly::via
+        auto* eventBase = &connection.eventBase;
+        return via(eventBase).then(
+            [connection = std::move(
+                connection), createRSC = std::move(createRSC)]() mutable {
+              return createRSC(std::move(connection));
+            });
+      });
 }
 
-folly::Future<std::shared_ptr<RSocketClient>> RSocket::createResumedClient(
-    std::unique_ptr<ConnectionFactory> connectionFactory,
-    SetupParameters setupParameters,
+folly::Future<std::unique_ptr<RSocketClient>> RSocket::createResumedClient(
+    std::shared_ptr<ConnectionFactory> connectionFactory,
+    ResumeIdentificationToken token,
     std::shared_ptr<ResumeManager> resumeManager,
     std::shared_ptr<ColdResumeHandler> coldResumeHandler,
-    OnRSocketResume,
     std::shared_ptr<RSocketResponder> responder,
     std::unique_ptr<KeepaliveTimer> keepaliveTimer,
     std::shared_ptr<RSocketStats> stats,
-    std::shared_ptr<RSocketConnectionEvents> connectionEvents) {
-  auto c = std::shared_ptr<RSocketClient>(new RSocketClient(
+    std::shared_ptr<RSocketConnectionEvents> connectionEvents,
+    ProtocolVersion protocolVersion) {
+  auto* c = new RSocketClient(
       std::move(connectionFactory),
-      std::move(setupParameters),
+      std::move(protocolVersion),
+      std::move(token),
       std::move(responder),
       std::move(keepaliveTimer),
       std::move(stats),
       std::move(connectionEvents),
       std::move(resumeManager),
-      std::move(coldResumeHandler)));
+      std::move(coldResumeHandler));
 
-  return c->resume().then([c]() mutable { return c; });
+  return c->resume().then(
+      [client = std::unique_ptr<RSocketClient>(c)]() mutable {
+        return std::move(client);
+      });
 }
 
-std::shared_ptr<RSocketClient> RSocket::createClientFromConnection(
+std::unique_ptr<RSocketClient> RSocket::createClientFromConnection(
     std::unique_ptr<DuplexConnection> connection,
     folly::EventBase& eventBase,
     SetupParameters setupParameters,
+    std::shared_ptr<ConnectionFactory> connectionFactory,
     std::shared_ptr<RSocketResponder> responder,
     std::unique_ptr<KeepaliveTimer> keepaliveTimer,
     std::shared_ptr<RSocketStats> stats,
     std::shared_ptr<RSocketConnectionEvents> connectionEvents,
     std::shared_ptr<ResumeManager> resumeManager,
-    std::shared_ptr<ColdResumeHandler> coldResumeHandler,
-    OnRSocketResume) {
-  auto c = std::shared_ptr<RSocketClient>(new RSocketClient(
-      nullptr,
-      std::move(setupParameters),
+    std::shared_ptr<ColdResumeHandler> coldResumeHandler) {
+  auto c = std::unique_ptr<RSocketClient>(new RSocketClient(
+      std::move(connectionFactory),
+      setupParameters.protocolVersion,
+      setupParameters.token,
       std::move(responder),
       std::move(keepaliveTimer),
       std::move(stats),
       std::move(connectionEvents),
       std::move(resumeManager),
       std::move(coldResumeHandler)));
-  c->fromConnection(std::move(connection), eventBase);
+  c->fromConnection(std::move(connection), eventBase, std::move(setupParameters));
   return c;
 }
 

--- a/rsocket/RSocket.cpp
+++ b/rsocket/RSocket.cpp
@@ -45,7 +45,7 @@ folly::Future<std::unique_ptr<RSocketClient>> RSocket::createConnectedClient(
         // connectionFactory::connect method is executed on the event base,
         // we have to ensure it by using folly::via
         auto* eventBase = &connection.eventBase;
-        return via(eventBase).then(
+        return via(eventBase,
             [connection = std::move(
                 connection), createRSC = std::move(createRSC)]() mutable {
               return createRSC(std::move(connection));

--- a/rsocket/RSocket.h
+++ b/rsocket/RSocket.h
@@ -13,8 +13,8 @@ namespace rsocket {
 class RSocket {
  public:
   // Creates a RSocketClient which is connected to the remoteside.
-  static folly::Future<std::shared_ptr<RSocketClient>> createConnectedClient(
-      std::unique_ptr<ConnectionFactory>,
+  static folly::Future<std::unique_ptr<RSocketClient>> createConnectedClient(
+      std::shared_ptr<ConnectionFactory>,
       SetupParameters setupParameters = SetupParameters(),
       std::shared_ptr<RSocketResponder> responder =
           std::make_shared<RSocketResponder>(),
@@ -25,31 +25,29 @@ class RSocket {
           std::shared_ptr<RSocketConnectionEvents>(),
       std::shared_ptr<ResumeManager> resumeManager = nullptr,
       std::shared_ptr<ColdResumeHandler> coldResumeHandler =
-          std::shared_ptr<ColdResumeHandler>(),
-      OnRSocketResume onRSocketResume =
-          [](std::vector<StreamId>, std::vector<StreamId>) { return false; });
+          std::shared_ptr<ColdResumeHandler>());
 
   // Creates a RSocketClient which cold-resumes from the provided state
-  static folly::Future<std::shared_ptr<RSocketClient>> createResumedClient(
-      std::unique_ptr<ConnectionFactory>,
-      SetupParameters setupParameters,
+  static folly::Future<std::unique_ptr<RSocketClient>> createResumedClient(
+      std::shared_ptr<ConnectionFactory>,
+      ResumeIdentificationToken token,
       std::shared_ptr<ResumeManager> resumeManager,
       std::shared_ptr<ColdResumeHandler> coldResumeHandler,
-      OnRSocketResume onRSocketResume =
-          [](std::vector<StreamId>, std::vector<StreamId>) { return false; },
       std::shared_ptr<RSocketResponder> responder =
           std::make_shared<RSocketResponder>(),
       std::unique_ptr<KeepaliveTimer> keepaliveTimer =
           std::unique_ptr<KeepaliveTimer>(),
       std::shared_ptr<RSocketStats> stats = RSocketStats::noop(),
       std::shared_ptr<RSocketConnectionEvents> connectionEvents =
-          std::shared_ptr<RSocketConnectionEvents>());
+          std::shared_ptr<RSocketConnectionEvents>(),
+      ProtocolVersion protocolVersion = ProtocolVersion::Current());
 
   // Creates a RSocketClient from an existing DuplexConnection
-  static std::shared_ptr<RSocketClient> createClientFromConnection(
+  static std::unique_ptr<RSocketClient> createClientFromConnection(
       std::unique_ptr<DuplexConnection> connection,
       folly::EventBase& eventBase,
       SetupParameters setupParameters = SetupParameters(),
+      std::shared_ptr<ConnectionFactory> connectionFactory = nullptr,
       std::shared_ptr<RSocketResponder> responder =
           std::make_shared<RSocketResponder>(),
       std::unique_ptr<KeepaliveTimer> keepaliveTimer =
@@ -59,9 +57,7 @@ class RSocket {
           std::shared_ptr<RSocketConnectionEvents>(),
       std::shared_ptr<ResumeManager> resumeManager = nullptr,
       std::shared_ptr<ColdResumeHandler> coldResumeHandler =
-          std::shared_ptr<ColdResumeHandler>(),
-      OnRSocketResume onRSocketResume =
-          [](std::vector<StreamId>, std::vector<StreamId>) { return false; });
+          std::shared_ptr<ColdResumeHandler>());
 
   // A convenience function to create RSocketServer
   static std::unique_ptr<RSocketServer> createServer(

--- a/rsocket/RSocketClient.cpp
+++ b/rsocket/RSocketClient.cpp
@@ -33,7 +33,7 @@ RSocketClient::RSocketClient(
       resumeManager_(resumeManager),
       coldResumeHandler_(coldResumeHandler),
       protocolVersion_(protocolVersion),
-      token_(token) {}
+      token_(std::move(token)) {}
 
 RSocketClient::~RSocketClient() {
   VLOG(4) << "RSocketClient destroyed ..";

--- a/rsocket/RSocketClient.cpp
+++ b/rsocket/RSocketClient.cpp
@@ -14,52 +14,33 @@ using namespace folly;
 
 namespace rsocket {
 
-RSocketClient::~RSocketClient() {
-  VLOG(4) << "RSocketClient destroyed ..";
-}
-
-const std::shared_ptr<RSocketRequester>& RSocketClient::getRequester() const {
-  return requester_;
-}
-
 RSocketClient::RSocketClient(
-    std::unique_ptr<ConnectionFactory> connectionFactory,
-    SetupParameters setupParameters,
+    std::shared_ptr<ConnectionFactory> connectionFactory,
+    ProtocolVersion protocolVersion,
+    ResumeIdentificationToken token,
     std::shared_ptr<RSocketResponder> responder,
     std::unique_ptr<KeepaliveTimer> keepaliveTimer,
     std::shared_ptr<RSocketStats> stats,
     std::shared_ptr<RSocketConnectionEvents> connectionEvents,
     std::shared_ptr<ResumeManager> resumeManager,
-    std::shared_ptr<ColdResumeHandler> coldResumeHandler,
-    OnRSocketResume)
+    std::shared_ptr<ColdResumeHandler> coldResumeHandler)
     : connectionFactory_(std::move(connectionFactory)),
       connectionManager_(std::make_unique<RSocketConnectionManager>()),
-      setupParameters_(std::move(setupParameters)),
       responder_(std::move(responder)),
       keepaliveTimer_(std::move(keepaliveTimer)),
       stats_(stats),
       connectionEvents_(connectionEvents),
       resumeManager_(resumeManager),
       coldResumeHandler_(coldResumeHandler),
-      protocolVersion_(setupParameters_.protocolVersion),
-      token_(setupParameters_.token) {}
+      protocolVersion_(protocolVersion),
+      token_(token) {}
 
-folly::Future<folly::Unit> RSocketClient::connect() {
-  VLOG(2) << "Starting connection";
+RSocketClient::~RSocketClient() {
+  VLOG(4) << "RSocketClient destroyed ..";
+}
 
-  return connectionFactory_->connect().then([this](
-      ConnectionFactory::ConnectedDuplexConnection connection) mutable {
-    VLOG(3) << "onConnect received DuplexConnection";
-
-    // fromConnection method must be called from the eventBase and since
-    // there is no guarantee that the Future returned from the factory::connect
-    // method is executed on the event base, we have to ensure it by using
-    // folly::via
-    return via(&connection.eventBase).then([this, connection = std::move(
-        connection.connection), eventBase = &connection.eventBase]() mutable {
-      fromConnection(std::move(connection), *eventBase);
-    });
-  });
+const std::shared_ptr<RSocketRequester>& RSocketClient::getRequester() const {
+  return requester_;
 }
 
 folly::Future<folly::Unit> RSocketClient::resume() {
@@ -131,7 +112,9 @@ void RSocketClient::disconnect(folly::exception_wrapper ex) {
 
 void RSocketClient::fromConnection(
     std::unique_ptr<DuplexConnection> connection,
-    folly::EventBase& eventBase) {
+    folly::EventBase& eventBase,
+    SetupParameters setupParameters
+) {
   evb_ = &eventBase;
   createState(eventBase);
   std::unique_ptr<DuplexConnection> framedConnection;
@@ -139,10 +122,10 @@ void RSocketClient::fromConnection(
     framedConnection = std::move(connection);
   } else {
     framedConnection = std::make_unique<FramedDuplexConnection>(
-        std::move(connection), setupParameters_.protocolVersion);
+        std::move(connection), setupParameters.protocolVersion);
   }
   stateMachine_->connectClientSendSetup(
-      std::move(framedConnection), std::move(setupParameters_));
+      std::move(framedConnection), std::move(setupParameters));
 }
 
 void RSocketClient::createState(folly::EventBase& eventBase) {

--- a/rsocket/RSocketClient.h
+++ b/rsocket/RSocketClient.h
@@ -51,34 +51,28 @@ class RSocketClient {
   // Private constructor.  RSocket class should be used to create instances
   // of RSocketClient.
   explicit RSocketClient(
-      std::unique_ptr<ConnectionFactory>,
-      SetupParameters setupParameters = SetupParameters(),
-      std::shared_ptr<RSocketResponder> responder =
-          std::make_shared<RSocketResponder>(),
-      std::unique_ptr<KeepaliveTimer> keepaliveTimer =
-          std::unique_ptr<KeepaliveTimer>(),
-      std::shared_ptr<RSocketStats> stats = RSocketStats::noop(),
-      std::shared_ptr<RSocketConnectionEvents> connectionEvents =
-          std::shared_ptr<RSocketConnectionEvents>(),
-      std::shared_ptr<ResumeManager> resumeManager = nullptr,
-      std::shared_ptr<ColdResumeHandler> coldResumeHandler = nullptr,
-      OnRSocketResume onRSocketResume =
-          [](std::vector<StreamId>, std::vector<StreamId>) { return false; });
-
-  // Connects to the remote side and creates state.
-  folly::Future<folly::Unit> connect();
+      std::shared_ptr<ConnectionFactory>,
+      ProtocolVersion protocolVersion,
+      ResumeIdentificationToken token,
+      std::shared_ptr<RSocketResponder> responder,
+      std::unique_ptr<KeepaliveTimer> keepaliveTimer,
+      std::shared_ptr<RSocketStats> stats,
+      std::shared_ptr<RSocketConnectionEvents> connectionEvents,
+      std::shared_ptr<ResumeManager> resumeManager,
+      std::shared_ptr<ColdResumeHandler> coldResumeHandler);
 
   // Create stateMachine with the given DuplexConnection
   void fromConnection(
       std::unique_ptr<DuplexConnection> connection,
-      folly::EventBase& eventBase);
+      folly::EventBase& eventBase,
+      SetupParameters setupParameters
+  );
 
   // Creates RSocketStateMachine and RSocketRequester
   void createState(folly::EventBase& eventBase);
 
-  std::unique_ptr<ConnectionFactory> connectionFactory_;
+  std::shared_ptr<ConnectionFactory> connectionFactory_;
   std::unique_ptr<RSocketConnectionManager> connectionManager_;
-  SetupParameters setupParameters_;
   std::shared_ptr<RSocketResponder> responder_;
   std::unique_ptr<KeepaliveTimer> keepaliveTimer_;
   std::shared_ptr<RSocketStats> stats_;

--- a/rsocket/RSocketParameters.h
+++ b/rsocket/RSocketParameters.h
@@ -31,8 +31,7 @@ class SetupParameters : public RSocketParameters {
       bool _resumable = false,
       const ResumeIdentificationToken& _token =
           ResumeIdentificationToken::generateNew(),
-      ProtocolVersion _protocolVersion =
-          FrameSerializer::getCurrentProtocolVersion())
+      ProtocolVersion _protocolVersion = ProtocolVersion::Current())
       : RSocketParameters(_resumable, _protocolVersion),
         metadataMimeType(std::move(_metadataMimeType)),
         dataMimeType(std::move(_dataMimeType)),

--- a/rsocket/framing/FrameSerializer.cpp
+++ b/rsocket/framing/FrameSerializer.cpp
@@ -20,7 +20,7 @@ namespace rsocket {
 constexpr const ProtocolVersion ProtocolVersion::Latest =
     FrameSerializerV1_0::Version;
 
-ProtocolVersion FrameSerializer::getCurrentProtocolVersion() {
+const ProtocolVersion ProtocolVersion::Current() {
   if (FLAGS_rs_use_protocol_version.empty()) {
     return ProtocolVersion::Latest;
   }
@@ -54,10 +54,6 @@ std::unique_ptr<FrameSerializer> FrameSerializer::createFrameSerializer(
   LOG_IF(ERROR, protocolVersion != ProtocolVersion::Unknown)
       << "unknown protocol version " << protocolVersion;
   return nullptr;
-}
-
-std::unique_ptr<FrameSerializer> FrameSerializer::createCurrentVersion() {
-  return createFrameSerializer(getCurrentProtocolVersion());
 }
 
 std::unique_ptr<FrameSerializer> FrameSerializer::createAutodetectedSerializer(

--- a/rsocket/framing/FrameSerializer.cpp
+++ b/rsocket/framing/FrameSerializer.cpp
@@ -20,7 +20,7 @@ namespace rsocket {
 constexpr const ProtocolVersion ProtocolVersion::Latest =
     FrameSerializerV1_0::Version;
 
-const ProtocolVersion ProtocolVersion::Current() {
+ProtocolVersion ProtocolVersion::Current() {
   if (FLAGS_rs_use_protocol_version.empty()) {
     return ProtocolVersion::Latest;
   }

--- a/rsocket/framing/FrameSerializer.h
+++ b/rsocket/framing/FrameSerializer.h
@@ -17,10 +17,8 @@ class FrameSerializer {
 
   virtual ProtocolVersion protocolVersion() = 0;
 
-  static ProtocolVersion getCurrentProtocolVersion();
   static std::unique_ptr<FrameSerializer> createFrameSerializer(
       const ProtocolVersion& protocolVersion);
-  static std::unique_ptr<FrameSerializer> createCurrentVersion();
 
   static std::unique_ptr<FrameSerializer> createAutodetectedSerializer(
       const folly::IOBuf& firstFrame);

--- a/rsocket/internal/Common.h
+++ b/rsocket/internal/Common.h
@@ -124,6 +124,7 @@ struct ProtocolVersion {
 
   static const ProtocolVersion Unknown;
   static const ProtocolVersion Latest;
+  static const ProtocolVersion Current();
 };
 
 #pragma pop_macro("major")

--- a/rsocket/internal/Common.h
+++ b/rsocket/internal/Common.h
@@ -124,7 +124,7 @@ struct ProtocolVersion {
 
   static const ProtocolVersion Unknown;
   static const ProtocolVersion Latest;
-  static const ProtocolVersion Current();
+  static ProtocolVersion Current();
 };
 
 #pragma pop_macro("major")

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -716,9 +716,9 @@ void RSocketStateMachine::tryClientResume(
     CHECK(coldResumeHandler_);
     coldResumeInProgress_ = true;
     setFrameSerializer(
-        protocolVersion == ProtocolVersion::Unknown
-            ? FrameSerializer::createCurrentVersion()
-            : FrameSerializer::createFrameSerializer(protocolVersion));
+        FrameSerializer::createFrameSerializer(
+            protocolVersion == ProtocolVersion::Unknown
+            ? ProtocolVersion::Current() : protocolVersion));
   }
 
   Frame_RESUME resumeFrame(
@@ -853,10 +853,9 @@ void RSocketStateMachine::connectClientSendSetup(
     std::unique_ptr<DuplexConnection> connection,
     SetupParameters setupParams) {
   setFrameSerializer(
-      setupParams.protocolVersion == ProtocolVersion::Unknown
-          ? FrameSerializer::createCurrentVersion()
-          : FrameSerializer::createFrameSerializer(
-                setupParams.protocolVersion));
+      FrameSerializer::createFrameSerializer(
+          setupParams.protocolVersion == ProtocolVersion::Unknown
+          ? ProtocolVersion::Current() : setupParams.protocolVersion));
 
   setResumable(setupParams.resumable);
 

--- a/rsocket/transports/tcp/TcpConnectionFactory.cpp
+++ b/rsocket/transports/tcp/TcpConnectionFactory.cpp
@@ -41,7 +41,6 @@ class ConnectCallback : public folly::AsyncSocket::ConnectCallback {
 
   void connectSuccess() noexcept override {
     std::unique_ptr<ConnectCallback> deleter(this);
-
     VLOG(4) << "connectSuccess() on " << address_;
 
     auto connection = TcpConnectionFactory::createDuplexConnectionFromSocket(
@@ -54,7 +53,6 @@ class ConnectCallback : public folly::AsyncSocket::ConnectCallback {
 
   void connectErr(const folly::AsyncSocketException& ex) noexcept override {
     std::unique_ptr<ConnectCallback> deleter(this);
-
     VLOG(4) << "connectErr(" << ex.what() << ") on " << address_;
     connectPromise_.setException(ex);
   }
@@ -87,7 +85,6 @@ TcpConnectionFactory::connect() {
       [ this, connectPromise = std::move(connectPromise) ]() mutable {
         new ConnectCallback(address_, std::move(connectPromise));
       });
-
   return connectFuture;
 }
 

--- a/test/ColdResumptionTest.cpp
+++ b/test/ColdResumptionTest.cpp
@@ -91,13 +91,6 @@ class HelloResumeHandler : public ColdResumeHandler {
  private:
   HelloSubscribers subscribers_;
 };
-
-SetupParameters getSetupParams(ResumeIdentificationToken token) {
-  SetupParameters setupParameters;
-  setupParameters.resumable = true;
-  setupParameters.token = token;
-  return setupParameters;
-}
 }
 
 // There are three sessions and three streams.
@@ -162,7 +155,7 @@ TEST(ColdResumptionTest, SuccessfulResumption) {
               RSocket::createResumedClient(
                   getConnFactory(
                       worker.getEventBase(), *server->listeningPort()),
-                  getSetupParams(token),
+                  token,
                   resumeManager,
                   coldResumeHandler)
                   .get());
@@ -197,7 +190,7 @@ TEST(ColdResumptionTest, SuccessfulResumption) {
         thirdClient =
             RSocket::createResumedClient(
                 getConnFactory(worker.getEventBase(), *server->listeningPort()),
-                getSetupParams(token),
+                token,
                 resumeManager,
                 coldResumeHandler)
                 .get());

--- a/test/framing/FrameTest.cpp
+++ b/test/framing/FrameTest.cpp
@@ -17,7 +17,8 @@ template <typename Frame, typename... Args>
 Frame reserialize_resume(bool resumable, Args... args) {
   Frame givenFrame, newFrame;
   givenFrame = Frame(std::forward<Args>(args)...);
-  auto frameSerializer = FrameSerializer::createCurrentVersion();
+  auto frameSerializer = FrameSerializer::createFrameSerializer(
+      ProtocolVersion::Current());
   EXPECT_TRUE(frameSerializer->deserializeFrom(
       newFrame,
       frameSerializer->serializeOut(std::move(givenFrame), resumable),
@@ -28,7 +29,8 @@ Frame reserialize_resume(bool resumable, Args... args) {
 template <typename Frame, typename... Args>
 Frame reserialize(Args... args) {
   Frame givenFrame = Frame(std::forward<Args>(args)...);
-  auto frameSerializer = FrameSerializer::createCurrentVersion();
+  auto frameSerializer = FrameSerializer::createFrameSerializer(
+      ProtocolVersion::Current());
   auto serializedFrame = frameSerializer->serializeOut(std::move(givenFrame));
   Frame newFrame;
   EXPECT_TRUE(
@@ -157,7 +159,7 @@ TEST(FrameTest, Frame_KEEPALIVE) {
   expectHeader(
       FrameType::KEEPALIVE, FrameFlags::KEEPALIVE_RESPOND, streamId, frame);
   // Default position
-  auto currProtVersion = FrameSerializer::getCurrentProtocolVersion();
+  auto currProtVersion = ProtocolVersion::Current();
   if (currProtVersion == ProtocolVersion(0, 1)) {
     EXPECT_EQ(0, frame.position_);
   } else if (currProtVersion == ProtocolVersion(1, 0)) {

--- a/test/internal/SetupResumeAcceptorTest.cpp
+++ b/test/internal/SetupResumeAcceptorTest.cpp
@@ -19,7 +19,7 @@ namespace {
  * Make a legitimate-looking SETUP frame.
  */
 Frame_SETUP makeSetup() {
-  auto version = FrameSerializer::getCurrentProtocolVersion();
+  auto version = ProtocolVersion::Current();
 
   Frame_SETUP frame;
   frame.header_ = FrameHeader{FrameType::SETUP, FrameFlags::EMPTY, 0};
@@ -112,7 +112,8 @@ TEST(SetupResumeAcceptor, SingleSetup) {
 
   auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
       [](auto input) {
-        auto serializer = FrameSerializer::createCurrentVersion();
+        auto serializer = FrameSerializer::createFrameSerializer(
+            ProtocolVersion::Current());
         input->onNext(serializer->serializeOut(makeSetup()));
       },
       [](auto output) {
@@ -141,7 +142,8 @@ TEST(SetupResumeAcceptor, InvalidSetup) {
 
   auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
       [](auto input) {
-        auto serializer = FrameSerializer::createCurrentVersion();
+        auto serializer = FrameSerializer::createFrameSerializer(
+            ProtocolVersion::Current());
 
         // Bogus keepalive time that can't be deserialized.
         auto setup = makeSetup();
@@ -152,7 +154,8 @@ TEST(SetupResumeAcceptor, InvalidSetup) {
       [](auto output) {
         EXPECT_CALL(*output, onSubscribe_(_));
         EXPECT_CALL(*output, onNext_(_)).WillOnce(Invoke([](auto const& buf) {
-          auto serializer = FrameSerializer::createCurrentVersion();
+          auto serializer = FrameSerializer::createFrameSerializer(
+              ProtocolVersion::Current());
           Frame_ERROR frame;
           EXPECT_TRUE(serializer->deserializeFrom(frame, buf->clone()));
           EXPECT_EQ(frame.errorCode_, ErrorCode::CONNECTION_ERROR);
@@ -171,13 +174,15 @@ TEST(SetupResumeAcceptor, RejectedSetup) {
 
   auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
       [](auto input) {
-        auto serializer = FrameSerializer::createCurrentVersion();
+        auto serializer = FrameSerializer::createFrameSerializer(
+            ProtocolVersion::Current());
         input->onNext(serializer->serializeOut(makeSetup()));
       },
       [](auto output) {
         EXPECT_CALL(*output, onSubscribe_(_));
         EXPECT_CALL(*output, onNext_(_)).WillOnce(Invoke([](auto const& buf) {
-          auto serializer = FrameSerializer::createCurrentVersion();
+          auto serializer = FrameSerializer::createFrameSerializer(
+              ProtocolVersion::Current());
           Frame_ERROR frame;
           EXPECT_TRUE(serializer->deserializeFrom(frame, buf->clone()));
           EXPECT_EQ(frame.errorCode_, ErrorCode::REJECTED_SETUP);
@@ -206,13 +211,15 @@ TEST(SetupResumeAcceptor, RejectedResume) {
 
   auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
       [](auto input) {
-        auto serializer = FrameSerializer::createCurrentVersion();
+        auto serializer = FrameSerializer::createFrameSerializer(
+            ProtocolVersion::Current());
         input->onNext(serializer->serializeOut(makeResume()));
       },
       [](auto output) {
         EXPECT_CALL(*output, onSubscribe_(_));
         EXPECT_CALL(*output, onNext_(_)).WillOnce(Invoke([](auto const& buf) {
-          auto serializer = FrameSerializer::createCurrentVersion();
+          auto serializer = FrameSerializer::createFrameSerializer(
+              ProtocolVersion::Current());
           Frame_ERROR frame;
           EXPECT_TRUE(serializer->deserializeFrom(frame, buf->clone()));
           EXPECT_EQ(frame.errorCode_, ErrorCode::REJECTED_RESUME);


### PR DESCRIPTION
The core of this PR is change of unique_ptr<ConnectionFactory> to shared_ptr<ConnectionFactory> in the constructor methods of RSocketClient. The Reason for this is that in the case of HTTPConnectionFactory if we reuse the same instance, we can reuse the same HTTP session object and within the session object we can just create HTTP streams for each duplex connection.

Along the way I noticed some unused parameters in the ctor of RSocketClient so I removed them.

I also removed the awkward call sequence for createConnectedClient. Now it is straightforward that after we get DuplexConnection instance we create RSocketClient instance. It allowed cleaning up of setupParams_ member variable which was used only from the connect method.