### PR TITLE
Drop clang-4.0 package from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ matrix:
             - llvm-toolchain-trusty-4.0
           packages:
             - *common_deps
-            - clang-4.0
             - libstdc++-4.9-dev
 
     - env: COMPILER=gcc-4.9


### PR DESCRIPTION
`apt-get` is complaining that it doesn't exist.  Seems like all we need is the
`llvm-toolchain-trusty-4.0` package.