### PR TITLE
remove racey checks on what should be idempotent calls

### DIFF
--- a/rsocket/statemachine/ChannelRequester.cpp
+++ b/rsocket/statemachine/ChannelRequester.cpp
@@ -78,7 +78,6 @@ void ChannelRequester::request(int64_t n) noexcept {
     initialResponseAllowance_.release(n);
     return;
   }
-  checkConsumerRequest();
   ConsumerBase::generateRequest(n);
 }
 

--- a/rsocket/statemachine/ChannelResponder.cpp
+++ b/rsocket/statemachine/ChannelResponder.cpp
@@ -42,7 +42,6 @@ void ChannelResponder::tryCompleteChannel() {
 }
 
 void ChannelResponder::request(int64_t n) noexcept {
-  checkConsumerRequest();
   ConsumerBase::generateRequest(n);
 }
 

--- a/rsocket/statemachine/ConsumerBase.cpp
+++ b/rsocket/statemachine/ConsumerBase.cpp
@@ -27,12 +27,6 @@ void ConsumerBase::subscribe(
   consumingSubscriber_->onSubscribe(get_ref(this));
 }
 
-void ConsumerBase::checkConsumerRequest() {
-  // we are either responding and subscribe method was called
-  // or we are already terminated
-  CHECK((state_ == State::RESPONDING) == !!consumingSubscriber_);
-}
-
 // TODO: this is probably buggy and misused and not needed (when
 // completeConsumer exists)
 void ConsumerBase::cancelConsumer() {

--- a/rsocket/statemachine/ConsumerBase.h
+++ b/rsocket/statemachine/ConsumerBase.h
@@ -38,7 +38,6 @@ class ConsumerBase : public StreamStateMachineBase,
   size_t getConsumerAllowance() const override;
 
  protected:
-  void checkConsumerRequest();
   void cancelConsumer();
 
   bool consumerClosed() const {

--- a/rsocket/statemachine/StreamRequester.cpp
+++ b/rsocket/statemachine/StreamRequester.cpp
@@ -43,7 +43,6 @@ void StreamRequester::request(int64_t n) noexcept {
     return;
   }
 
-  checkConsumerRequest();
   generateRequest(n);
 }
 


### PR DESCRIPTION
We're accessing shared state between a Subscriber and a Subscription which indicates if the Subscriber has completed yet; another thread calling cancel() on this Subscription will crash if the StreamRequester thinks it's already in a closed state. 

We shouldn't be making this check at all, as we can't assume any ordering guarantees on calls made across Subscriber/Subscription. 