### PR TITLE
capture 'stateMachine_' directly rather than 'this' to avoid use-after-free

### DIFF
--- a/rsocket/RSocketClient.cpp
+++ b/rsocket/RSocketClient.cpp
@@ -123,10 +123,11 @@ folly::Future<folly::Unit> RSocketClient::resume() {
 
 void RSocketClient::disconnect(folly::exception_wrapper ex) {
   CHECK(stateMachine_);
-  evb_->runInEventBaseThread([ this, ex = std::move(ex) ]() mutable {
-    VLOG(2) << "Disconnecting RSocketStateMachine on EventBase";
-    stateMachine_->disconnect(std::move(ex));
-  });
+  evb_->runInEventBaseThread(
+      [ stateMachine = stateMachine_, ex = std::move(ex) ]() mutable {
+        VLOG(2) << "Disconnecting RSocketStateMachine on EventBase";
+        stateMachine->disconnect(std::move(ex));
+      });
 }
 
 void RSocketClient::fromConnection(


### PR DESCRIPTION
fixes this use-after-free originating in `RSocketClientServer.ConnectManyAsync`

```
==8717==ERROR: AddressSanitizer: heap-use-after-free on address 0x6110000383a8 at pc 0x000000b39cda bp 0x2b7f5a3998b0 sp 0x2b7f5a3998a8
READ of size 8 at 0x6110000383a8 thread T18
    #0 0xb39cd9 in std::__shared_ptr<rsocket::RSocketStateMachine, (__gnu_cxx::_Lock_policy)2>::operator->() const /usr/include/c++/6/bits/shared_ptr_base.h:1058
    #1 0xb7fbc7 in operator() /home/travis/build/rsocket/rsocket-cpp/rsocket/RSocketClient.cpp:128
    #2 0xb8c41f in callSmall<rsocket::RSocketClient::disconnect(folly::exception_wrapper)::<lambda()> > /home/travis/folly/include/folly/Function.h:299
    #3 0x2b7f509dc9ba in folly::detail::function::FunctionTraits<void ()>::operator()() ../folly/Function.h:314
    #4 0x2b7f509dc9ba in folly::EventBase::FunctionLoopCallback::runLoopCallback() ../folly/io/async/EventBase.h:175
    #5 0x2b7f509d7305 in folly::EventBase::runLoopCallbacks() io/async/EventBase.cpp:623
    #6 0x2b7f509d7faf in folly::EventBase::loopBody(int) io/async/EventBase.cpp:319
    #7 0x2b7f509d9ce5 in folly::EventBase::loopForever() io/async/EventBase.cpp:451
    #8 0x2b7f509eeebe in run io/async/ScopedEventBaseThread.cpp:40
    #9 0x2b7f5109621e  (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0x9121e)
    #10 0x2b7f50def183 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x8183)
    #11 0x2b7f5234affc in clone (/lib/x86_64-linux-gnu/libc.so.6+0xfdffc)
0x6110000383a8 is located 168 bytes inside of 240-byte region [0x611000038300,0x6110000383f0)
freed by thread T0 here:
    #0 0x2b7f4f4f6ec0 in operator delete(void*, unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xc3ec0)
    #1 0xb2697d in std::_Sp_counted_ptr<rsocket::RSocketClient*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/include/c++/6/bits/shared_ptr_base.h:372
    #2 0x6cac6b in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/include/c++/6/bits/shared_ptr_base.h:150
    #3 0x6c5a3f in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/include/c++/6/bits/shared_ptr_base.h:662
    #4 0x6c456e in std::__shared_ptr<rsocket::RSocketClient, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/include/c++/6/bits/shared_ptr_base.h:928
    #5 0x6c461a in std::shared_ptr<rsocket::RSocketClient>::~shared_ptr() /usr/include/c++/6/bits/shared_ptr.h:93
    #6 0x6cf231 in folly::Try<std::shared_ptr<rsocket::RSocketClient> >::~Try() /home/travis/folly/include/folly/Try-inl.h:94
    #7 0x6eee7f in void std::_Destroy<folly::Try<std::shared_ptr<rsocket::RSocketClient> > >(folly::Try<std::shared_ptr<rsocket::RSocketClient> >*) (/home/travis/build/rsocket/rsocket-cpp/build/tests+0x6eee7f)
    #8 0x6e50be in void std::_Destroy_aux<false>::__destroy<folly::Try<std::shared_ptr<rsocket::RSocketClient> >*>(folly::Try<std::shared_ptr<rsocket::RSocketClient> >*, folly::Try<std::shared_ptr<rsocket::RSocketClient> >*) (/home/travis/build/rsocket/rsocket-cpp/build/tests+0x6e50be)
    #9 0x6dc66d in void std::_Destroy<folly::Try<std::shared_ptr<rsocket::RSocketClient> >*>(folly::Try<std::shared_ptr<rsocket::RSocketClient> >*, folly::Try<std::shared_ptr<rsocket::RSocketClient> >*) (/home/travis/build/rsocket/rsocket-cpp/build/tests+0x6dc66d)
    #10 0x6d16a8 in void std::_Destroy<folly::Try<std::shared_ptr<rsocket::RSocketClient> >*, folly::Try<std::shared_ptr<rsocket::RSocketClient> > >(folly::Try<std::shared_ptr<rsocket::RSocketClient> >*, folly::Try<std::shared_ptr<rsocket::RSocketClient> >*, std::allocator<folly::Try<std::shared_ptr<rsocket::RSocketClient> > >&) (/home/travis/build/rsocket/rsocket-cpp/build/tests+0x6d16a8)
    #11 0x6d1a19 in std::vector<folly::Try<std::shared_ptr<rsocket::RSocketClient> >, std::allocator<folly::Try<std::shared_ptr<rsocket::RSocketClient> > > >::_M_erase_at_end(folly::Try<std::shared_ptr<rsocket::RSocketClient> >*) (/home/travis/build/rsocket/rsocket-cpp/build/tests+0x6d1a19)
    #12 0x6ca085 in std::vector<folly::Try<std::shared_ptr<rsocket::RSocketClient> >, std::allocator<folly::Try<std::shared_ptr<rsocket::RSocketClient> > > >::clear() (/home/travis/build/rsocket/rsocket-cpp/build/tests+0x6ca085)
    #13 0x6b147d in RSocketClientServer_ConnectManyAsync_Test::TestBody() /home/travis/build/rsocket/rsocket-cpp/test/RSocketClientServerTest.cpp:68
    #14 0xdf316f in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xdf316f)
    #15 0xded149 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xded149)
    #16 0xdd3c2e in testing::Test::Run() (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xdd3c2e)
    #17 0xdd44b7 in testing::TestInfo::Run() (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xdd44b7)
    #18 0xdd4b47 in testing::TestCase::Run() (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xdd4b47)
    #19 0xddb28b in testing::internal::UnitTestImpl::RunAllTests() (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xddb28b)
    #20 0xdf454d in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xdf454d)
    #21 0xdedf37 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xdedf37)
    #22 0xdd9f1d in testing::UnitTest::Run() (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xdd9f1d)
    #23 0x985e69 in RUN_ALL_TESTS() /home/travis/build/rsocket/rsocket-cpp/build/gmock-prefix/src/gmock/googletest/include/gtest/gtest.h:2233
    #24 0x985bdd in main /home/travis/build/rsocket/rsocket-cpp/test/Test.cpp:11
    #25 0x2b7f5226ef44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21f44)
previously allocated by thread T0 here:
    #0 0x2b7f4f4f62c0 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xc32c0)
    #1 0xb180ac in rsocket::RSocket::createConnectedClient(std::unique_ptr<rsocket::ConnectionFactory, std::default_delete<rsocket::ConnectionFactory> >, rsocket::SetupParameters, std::shared_ptr<rsocket::RSocketResponder>, std::unique_ptr<rsocket::KeepaliveTimer, std::default_delete<rsocket::KeepaliveTimer> >, std::shared_ptr<rsocket::RSocketStats>, std::shared_ptr<rsocket::RSocketConnectionEvents>, std::shared_ptr<rsocket::ResumeManager>, std::shared_ptr<rsocket::ColdResumeHandler>, std::function<bool (std::vector<unsigned int, std::allocator<unsigned int> >, std::vector<unsigned int, std::allocator<unsigned int> >)>) /home/travis/build/rsocket/rsocket-cpp/rsocket/RSocket.cpp:27
    #2 0x70c165 in rsocket::tests::client_server::makeClientAsync(folly::EventBase*, unsigned short) /home/travis/build/rsocket/rsocket-cpp/test/RSocketTests.cpp:48
    #3 0x6b0de9 in RSocketClientServer_ConnectManyAsync_Test::TestBody() /home/travis/build/rsocket/rsocket-cpp/test/RSocketClientServerTest.cpp:49
    #4 0xdf316f in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xdf316f)
    #5 0xded149 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xded149)
    #6 0xdd3c2e in testing::Test::Run() (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xdd3c2e)
    #7 0xdd44b7 in testing::TestInfo::Run() (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xdd44b7)
    #8 0xdd4b47 in testing::TestCase::Run() (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xdd4b47)
    #9 0xddb28b in testing::internal::UnitTestImpl::RunAllTests() (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xddb28b)
    #10 0xdf454d in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xdf454d)
    #11 0xdedf37 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xdedf37)
    #12 0xdd9f1d in testing::UnitTest::Run() (/home/travis/build/rsocket/rsocket-cpp/build/tests+0xdd9f1d)
    #13 0x985e69 in RUN_ALL_TESTS() /home/travis/build/rsocket/rsocket-cpp/build/gmock-prefix/src/gmock/googletest/include/gtest/gtest.h:2233
    #14 0x985bdd in main /home/travis/build/rsocket/rsocket-cpp/test/Test.cpp:11
    #15 0x2b7f5226ef44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21f44)
Thread T18 created by T0 here:
    #0 0x2b7f4f464619 in __interceptor_pthread_create (/usr/lib/x86_64-linux-gnu/libasan.so.3+0x31619)
    #1 0x2b7f51096514 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0x91514)
SUMMARY: AddressSanitizer: heap-use-after-free /usr/include/c++/6/bits/shared_ptr_base.h:1058 in std::__shared_ptr<rsocket::RSocketStateMachine, (__gnu_cxx::_Lock_policy)2>::operator->() const
Shadow bytes around the buggy address:
  0x0c227ffff020: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fa fa
  0x0c227ffff030: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c227ffff040: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c227ffff050: fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa fa
  0x0c227ffff060: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0c227ffff070: fd fd fd fd fd[fd]fd fd fd fd fd fd fd fd fa fa
  0x0c227ffff080: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c227ffff090: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c227ffff0a0: fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa fa
  0x0c227ffff0b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c227ffff0c0: 00 00 00 00 00 00 00 00 00 00 fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Heap right redzone:      fb
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack partial redzone:   f4
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==8717==ABORTING
```