### PR TITLE
make get_ref a 'covariant' method on objects rather than a free function

### DIFF
--- a/rsocket/framing/FrameTransport.cpp
+++ b/rsocket/framing/FrameTransport.cpp
@@ -31,7 +31,7 @@ void FrameTransport::connect() {
   }
 
   connectionOutput_ = connection_->getOutput();
-  connectionOutput_->onSubscribe(yarpl::get_ref(this));
+  connectionOutput_->onSubscribe(this->ref_from_this(this));
 
   // The onSubscribe call on the previous line may have called the terminating
   // signal which would call disconnect/close.
@@ -43,7 +43,7 @@ void FrameTransport::connect() {
     // will create a hard reference for that case and keep the object alive
     // until setInput method returns
     auto connectionCopy = connection_;
-    connectionCopy->setInput(yarpl::get_ref(this));
+    connectionCopy->setInput(this->ref_from_this(this));
   }
 }
 

--- a/rsocket/framing/FramedReader.cpp
+++ b/rsocket/framing/FramedReader.cpp
@@ -93,7 +93,7 @@ void FramedReader::parseFrames() {
 
   // delivering onNext can trigger termination and destroying this instance
   // while in this method so we will make sure we survive
-  auto thisPtr = yarpl::get_ref(this);
+  auto thisPtr = this->ref_from_this(this);
 
   dispatchingFrames_ = true;
 
@@ -174,7 +174,7 @@ void FramedReader::setInput(
   CHECK(!frames_)
       << "FrameReader should be closed before setting another input.";
   frames_ = std::move(frames);
-  frames_->onSubscribe(yarpl::get_ref(this));
+  frames_->onSubscribe(this->ref_from_this(this));
 }
 
 bool FramedReader::ensureOrAutodetectProtocolVersion() {

--- a/rsocket/statemachine/ConsumerBase.cpp
+++ b/rsocket/statemachine/ConsumerBase.cpp
@@ -24,7 +24,7 @@ void ConsumerBase::subscribe(
 
   DCHECK(!consumingSubscriber_);
   consumingSubscriber_ = std::move(subscriber);
-  consumingSubscriber_->onSubscribe(get_ref(this));
+  consumingSubscriber_->onSubscribe(this->ref_from_this(this));
 }
 
 // TODO: this is probably buggy and misused and not needed (when

--- a/rsocket/statemachine/ConsumerBase.h
+++ b/rsocket/statemachine/ConsumerBase.h
@@ -18,7 +18,8 @@ enum class StreamCompletionSignal;
 
 /// A class that represents a flow-control-aware consumer of data.
 class ConsumerBase : public StreamStateMachineBase,
-                     public yarpl::flowable::Subscription {
+                     public yarpl::flowable::Subscription,
+                     public yarpl::enable_get_ref {
  public:
   using StreamStateMachineBase::StreamStateMachineBase;
 

--- a/rsocket/statemachine/RequestResponseRequester.cpp
+++ b/rsocket/statemachine/RequestResponseRequester.cpp
@@ -15,7 +15,7 @@ void RequestResponseRequester::subscribe(
   DCHECK(!isTerminated());
   DCHECK(!consumingSubscriber_);
   consumingSubscriber_ = std::move(subscriber);
-  consumingSubscriber_->onSubscribe(get_ref(this));
+  consumingSubscriber_->onSubscribe(this->ref_from_this(this));
 
   if (state_ == State::NEW) {
     state_ = State::REQUESTED;

--- a/rsocket/statemachine/RequestResponseRequester.h
+++ b/rsocket/statemachine/RequestResponseRequester.h
@@ -12,7 +12,8 @@ namespace rsocket {
 /// Implementation of stream stateMachine that represents a RequestResponse
 /// requester
 class RequestResponseRequester : public StreamStateMachineBase,
-                                 public yarpl::single::SingleSubscription {
+                                 public yarpl::single::SingleSubscription,
+                                 public yarpl::enable_get_ref {
  public:
   RequestResponseRequester(
       std::shared_ptr<StreamsWriter> writer,

--- a/yarpl/include/yarpl/flowable/EmitterFlowable.h
+++ b/yarpl/include/yarpl/flowable/EmitterFlowable.h
@@ -34,7 +34,7 @@ class EmiterSubscription : public Subscription, public Subscriber<T> {
       Reference<EmiterBase<T>> emiter,
       Reference<Subscriber<T>> subscriber)
       : emiter_(std::move(emiter)), subscriber_(std::move(subscriber)) {
-    subscriber_->onSubscribe(get_ref<Subscription>(this));
+    subscriber_->onSubscribe(this->ref_from_this(this));
   }
 
   virtual ~EmiterSubscription() {
@@ -126,7 +126,7 @@ class EmiterSubscription : public Subscription, public Subscriber<T> {
 
     // Keep a reference to ourselves here in case the emit() call
     // frees all other references to 'this'
-    auto this_subscriber = get_ref<Subscriber<T>>(this);
+    auto this_subscriber = this->ref_from_this(this);
 
     while (true) {
       auto current = requested_.load(std::memory_order_relaxed);
@@ -191,7 +191,7 @@ class EmitterWrapper : public EmiterBase<T>, public Flowable<T> {
   explicit EmitterWrapper(Emitter emitter) : emitter_(std::move(emitter)) {}
 
   void subscribe(Reference<Subscriber<T>> subscriber) override {
-    make_ref<EmiterSubscription<T>>(get_ref(this), std::move(subscriber));
+    make_ref<EmiterSubscription<T>>(this->ref_from_this(this), std::move(subscriber));
   }
 
   std::tuple<int64_t, bool> emit(

--- a/yarpl/include/yarpl/flowable/Flowable.h
+++ b/yarpl/include/yarpl/flowable/Flowable.h
@@ -19,7 +19,7 @@ namespace yarpl {
 namespace flowable {
 
 template <typename T>
-class Flowable : public virtual Refcounted {
+class Flowable : public virtual Refcounted, public yarpl::enable_get_ref {
  public:
   virtual void subscribe(Reference<Subscriber<T>>) = 0;
 
@@ -120,41 +120,41 @@ template <typename T>
 template <typename Function, typename R>
 Reference<Flowable<R>> Flowable<T>::map(Function function) {
   return make_ref<MapOperator<T, R, Function>>(
-      get_ref(this), std::move(function));
+      this->ref_from_this(this), std::move(function));
 }
 
 template <typename T>
 template <typename Function>
 Reference<Flowable<T>> Flowable<T>::filter(Function function) {
   return make_ref<FilterOperator<T, Function>>(
-      get_ref(this), std::move(function));
+      this->ref_from_this(this), std::move(function));
 }
 
 template <typename T>
 template <typename Function, typename R>
 Reference<Flowable<R>> Flowable<T>::reduce(Function function) {
   return make_ref<ReduceOperator<T, R, Function>>(
-      get_ref(this), std::move(function));
+      this->ref_from_this(this), std::move(function));
 }
 
 template <typename T>
 Reference<Flowable<T>> Flowable<T>::take(int64_t limit) {
-  return make_ref<TakeOperator<T>>(get_ref(this), limit);
+  return make_ref<TakeOperator<T>>(this->ref_from_this(this), limit);
 }
 
 template <typename T>
 Reference<Flowable<T>> Flowable<T>::skip(int64_t offset) {
-  return make_ref<SkipOperator<T>>(get_ref(this), offset);
+  return make_ref<SkipOperator<T>>(this->ref_from_this(this), offset);
 }
 
 template <typename T>
 Reference<Flowable<T>> Flowable<T>::ignoreElements() {
-  return make_ref<IgnoreElementsOperator<T>>(get_ref(this));
+  return make_ref<IgnoreElementsOperator<T>>(this->ref_from_this(this));
 }
 
 template <typename T>
 Reference<Flowable<T>> Flowable<T>::subscribeOn(Scheduler& scheduler) {
-  return make_ref<SubscribeOnOperator<T>>(get_ref(this), scheduler);
+  return make_ref<SubscribeOnOperator<T>>(this->ref_from_this(this), scheduler);
 }
 
 } // flowable

--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -87,7 +87,7 @@ class FlowableOperator : public Flowable<D> {
       }
 
       upstream_ = std::move(subscription);
-      subscriber_->onSubscribe(get_ref(this));
+      subscriber_->onSubscribe(this->ref_from_this(this));
     }
 
     void onComplete() override {
@@ -182,7 +182,7 @@ class MapOperator : public FlowableOperator<U, D, MapOperator<U, D, F>> {
 
   void subscribe(Reference<Subscriber<D>> subscriber) override {
     Super::upstream_->subscribe(
-        make_ref<Subscription>(get_ref(this), std::move(subscriber)));
+        make_ref<Subscription>(this->ref_from_this(this), std::move(subscriber)));
   }
 
  private:
@@ -219,7 +219,7 @@ class FilterOperator : public FlowableOperator<U, U, FilterOperator<U, F>> {
 
   void subscribe(Reference<Subscriber<U>> subscriber) override {
     Super::upstream_->subscribe(
-        make_ref<Subscription>(get_ref(this), std::move(subscriber)));
+        make_ref<Subscription>(this->ref_from_this(this), std::move(subscriber)));
   }
 
  private:
@@ -261,7 +261,7 @@ class ReduceOperator : public FlowableOperator<U, D, ReduceOperator<U, D, F>> {
 
   void subscribe(Reference<Subscriber<D>> subscriber) override {
     Super::upstream_->subscribe(
-        make_ref<Subscription>(get_ref(this), std::move(subscriber)));
+        make_ref<Subscription>(this->ref_from_this(this), std::move(subscriber)));
   }
 
  private:
@@ -314,8 +314,8 @@ class TakeOperator : public FlowableOperator<T, T, TakeOperator<T>> {
       : Super(std::move(upstream)), limit_(limit) {}
 
   void subscribe(Reference<Subscriber<T>> subscriber) override {
-    Super::upstream_->subscribe(
-        make_ref<Subscription>(get_ref(this), limit_, std::move(subscriber)));
+    Super::upstream_->subscribe(make_ref<Subscription>(
+        this->ref_from_this(this), limit_, std::move(subscriber)));
   }
 
  private:
@@ -367,8 +367,8 @@ class SkipOperator : public FlowableOperator<T, T, SkipOperator<T>> {
       : Super(std::move(upstream)), offset_(offset) {}
 
   void subscribe(Reference<Subscriber<T>> subscriber) override {
-    Super::upstream_->subscribe(
-        make_ref<Subscription>(get_ref(this), offset_, std::move(subscriber)));
+    Super::upstream_->subscribe(make_ref<Subscription>(
+        this->ref_from_this(this), offset_, std::move(subscriber)));
   }
 
  private:
@@ -418,7 +418,7 @@ class IgnoreElementsOperator
 
   void subscribe(Reference<Subscriber<T>> subscriber) override {
     Super::upstream_->subscribe(
-        make_ref<Subscription>(get_ref(this), std::move(subscriber)));
+        make_ref<Subscription>(this->ref_from_this(this), std::move(subscriber)));
   }
 
  private:
@@ -446,7 +446,7 @@ class SubscribeOnOperator
 
   void subscribe(Reference<Subscriber<T>> subscriber) override {
     Super::upstream_->subscribe(make_ref<Subscription>(
-        get_ref(this), std::move(worker_), std::move(subscriber)));
+        this->ref_from_this(this), std::move(worker_), std::move(subscriber)));
   }
 
  private:

--- a/yarpl/include/yarpl/flowable/Flowable_FromObservable.h
+++ b/yarpl/include/yarpl/flowable/Flowable_FromObservable.h
@@ -60,10 +60,10 @@ class FlowableFromObservableSubscription : public flowable::Subscription,
     // onNext calls which the processing chain might cancel. The cancel signal
     // will remove all references to this class and we need to keep this
     // instance around to finish this method
-    auto thisPtr = get_ref(this);
+    auto thisPtr = this->ref_from_this(this);
 
     if (!started.exchange(true)) {
-      observable_->subscribe(get_ref(this));
+      observable_->subscribe(this->ref_from_this(this));
 
       // the credits might have changed since subscribe
       r = requested_.load();

--- a/yarpl/include/yarpl/flowable/Subscriber.h
+++ b/yarpl/include/yarpl/flowable/Subscriber.h
@@ -13,7 +13,7 @@ namespace yarpl {
 namespace flowable {
 
 template <typename T>
-class Subscriber : public virtual Refcounted {
+class Subscriber : public virtual Refcounted, public yarpl::enable_get_ref {
  public:
   // Note: If any of the following methods is overridden in a subclass, the new
   // methods SHOULD ensure that these are invoked as well.

--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -84,7 +84,7 @@ class ObservableOperator : public Observable<D> {
         return;
       }
       upstream_ = std::move(subscription);
-      observer_->onSubscribe(get_ref(this));
+      observer_->onSubscribe(this->ref_from_this(this));
     }
 
     void onComplete() override {
@@ -181,7 +181,7 @@ class MapOperator : public ObservableOperator<U, D, MapOperator<U, D, F>> {
 
   Reference<Subscription> subscribe(Reference<Observer<D>> observer) override {
     auto subscription =
-        make_ref<MapSubscription>(get_ref(this), std::move(observer));
+        make_ref<MapSubscription>(this->ref_from_this(this), std::move(observer));
     Super::upstream_->subscribe(
         // Note: implicit cast to a reference to a observer.
         subscription);
@@ -222,7 +222,7 @@ class FilterOperator : public ObservableOperator<U, U, FilterOperator<U, F>> {
 
   Reference<Subscription> subscribe(Reference<Observer<U>> observer) override {
     auto subscription =
-        make_ref<FilterSubscription>(get_ref(this), std::move(observer));
+        make_ref<FilterSubscription>(this->ref_from_this(this), std::move(observer));
     Super::upstream_->subscribe(
         // Note: implicit cast to a reference to a observer.
         subscription);
@@ -268,8 +268,8 @@ class ReduceOperator
 
   Reference<Subscription> subscribe(
       Reference<Observer<D>> subscriber) override {
-    auto subscription =
-        make_ref<ReduceSubscription>(get_ref(this), std::move(subscriber));
+    auto subscription = make_ref<ReduceSubscription>(
+        this->ref_from_this(this), std::move(subscriber));
     Super::upstream_->subscribe(
         // Note: implicit cast to a reference to a subscriber.
         subscription);
@@ -322,8 +322,8 @@ class TakeOperator : public ObservableOperator<T, T, TakeOperator<T>> {
       : Super(std::move(upstream)), limit_(limit) {}
 
   Reference<Subscription> subscribe(Reference<Observer<T>> observer) override {
-    auto subscription =
-        make_ref<TakeSubscription>(get_ref(this), limit_, std::move(observer));
+    auto subscription = make_ref<TakeSubscription>(
+        this->ref_from_this(this), limit_, std::move(observer));
     Super::upstream_->subscribe(subscription);
     return subscription;
   }
@@ -368,8 +368,8 @@ class SkipOperator : public ObservableOperator<T, T, SkipOperator<T>> {
       : Super(std::move(upstream)), offset_(offset) {}
 
   Reference<Subscription> subscribe(Reference<Observer<T>> observer) override {
-    auto subscription =
-        make_ref<SkipSubscription>(get_ref(this), offset_, std::move(observer));
+    auto subscription = make_ref<SkipSubscription>(
+        this->ref_from_this(this), offset_, std::move(observer));
     Super::upstream_->subscribe(subscription);
     return subscription;
   }
@@ -413,7 +413,7 @@ class IgnoreElementsOperator
 
   Reference<Subscription> subscribe(Reference<Observer<T>> observer) override {
     auto subscription = make_ref<IgnoreElementsSubscription>(
-        get_ref(this), std::move(observer));
+        this->ref_from_this(this), std::move(observer));
     Super::upstream_->subscribe(subscription);
     return subscription;
   }
@@ -444,7 +444,7 @@ class SubscribeOnOperator
 
   Reference<Subscription> subscribe(Reference<Observer<T>> observer) override {
     auto subscription = make_ref<SubscribeOnSubscription>(
-        get_ref(this), std::move(worker_), std::move(observer));
+        this->ref_from_this(this), std::move(worker_), std::move(observer));
     Super::upstream_->subscribe(subscription);
     return subscription;
   }

--- a/yarpl/include/yarpl/observable/Observer.h
+++ b/yarpl/include/yarpl/observable/Observer.h
@@ -13,7 +13,7 @@ namespace yarpl {
 namespace observable {
 
 template <typename T>
-class Observer : public virtual Refcounted {
+class Observer : public virtual Refcounted, public yarpl::enable_get_ref {
  public:
   // Note: If any of the following methods is overridden in a subclass, the new
   // methods SHOULD ensure that these are invoked as well.

--- a/yarpl/include/yarpl/single/Single.h
+++ b/yarpl/include/yarpl/single/Single.h
@@ -14,7 +14,7 @@ namespace yarpl {
 namespace single {
 
 template <typename T>
-class Single : public virtual Refcounted {
+class Single : public virtual Refcounted, public yarpl::enable_get_ref {
  public:
   virtual void subscribe(Reference<SingleObserver<T>>) = 0;
 
@@ -146,7 +146,7 @@ template <typename Function>
 auto Single<T>::map(Function function) {
   using D = typename std::result_of<Function(T)>::type;
   return make_ref<MapOperator<T, D, Function>, Single<D>>(
-      get_ref<Single<T>>(this), std::move(function));
+      this->ref_from_this(this), std::move(function));
 }
 
 } // single

--- a/yarpl/include/yarpl/single/SingleObserver.h
+++ b/yarpl/include/yarpl/single/SingleObserver.h
@@ -13,7 +13,7 @@ namespace yarpl {
 namespace single {
 
 template <typename T>
-class SingleObserver : public virtual Refcounted {
+class SingleObserver : public virtual Refcounted, public yarpl::enable_get_ref {
  public:
   // Note: If any of the following methods is overridden in a subclass, the new
   // methods SHOULD ensure that these are invoked as well.

--- a/yarpl/include/yarpl/single/SingleOperator.h
+++ b/yarpl/include/yarpl/single/SingleOperator.h
@@ -58,7 +58,7 @@ class SingleOperator : public Single<D> {
     void onSubscribe(
         Reference<::yarpl::single::SingleSubscription> subscription) override {
       upstreamSubscription_ = std::move(subscription);
-      observer_->onSubscribe(get_ref(this));
+      observer_->onSubscribe(this->ref_from_this(this));
     }
 
     void onError(folly::exception_wrapper error) override {
@@ -109,7 +109,7 @@ class MapOperator : public SingleOperator<U, D> {
   void subscribe(Reference<SingleObserver<D>> observer) override {
     Super::upstream_->subscribe(
         // Note: implicit cast to a reference to a observer.
-        make_ref<MapSubscription>(get_ref(this), std::move(observer)));
+        make_ref<MapSubscription>(this->ref_from_this(this), std::move(observer)));
   }
 
  private:

--- a/yarpl/test/Observable_test.cpp
+++ b/yarpl/test/Observable_test.cpp
@@ -555,7 +555,7 @@ class InfiniteAsyncTestOperator
   Reference<Subscription> subscribe(
       Reference<Observer<int>> observer) override {
     auto subscription = make_ref<TestSubscription>(
-        get_ref(this), std::move(observer), checkpoint_);
+        this->ref_from_this(this), std::move(observer), checkpoint_);
     Super::upstream_->subscribe(
         // Note: implicit cast to a reference to a observer.
         subscription);

--- a/yarpl/test/RefcountedTest.cpp
+++ b/yarpl/test/RefcountedTest.cpp
@@ -47,15 +47,21 @@ TEST(RefcountedTest, ReferenceCountingWorks) {
 }
 
 
-class MyRefInside : public virtual Refcounted {
+class MyRefInside : public virtual Refcounted, public yarpl::enable_get_ref {
 public:
   MyRefInside() {
-    auto r = get_ref(this);
+    auto r = this->ref_from_this(this);
+  }
+
+  auto a_const_method() const {
+    return ref_from_this(this);
   }
 };
 
 TEST(RefcountedTest, CanCallGetRefInCtor) {
-  make_ref<MyRefInside>();
+  auto r = make_ref<MyRefInside>();
+  auto r2 = r->a_const_method();
+  EXPECT_EQ(r, r2);
 }
 
 } // yarpl

--- a/yarpl/test/yarpl/test_utils/Mocks.h
+++ b/yarpl/test/yarpl/test_utils/Mocks.h
@@ -50,7 +50,7 @@ class MockSubscriber : public flowable::Subscriber<T> {
   void onSubscribe(
       yarpl::Reference<flowable::Subscription> subscription) override {
     subscription_ = subscription;
-    auto this_ = get_ref(this);
+    auto this_ = this->ref_from_this(this);
     onSubscribe_(subscription);
 
     if (initial_ > 0) {
@@ -59,7 +59,7 @@ class MockSubscriber : public flowable::Subscriber<T> {
   }
 
   void onNext(T element) override {
-    auto this_ = get_ref(this);
+    auto this_ = this->ref_from_this(this);
     onNext_(element);
 
     --waitedFrameCount_;
@@ -67,7 +67,7 @@ class MockSubscriber : public flowable::Subscriber<T> {
   }
 
   void onComplete() override {
-    auto this_ = get_ref(this);
+    auto this_ = this->ref_from_this(this);
     onComplete_();
     subscription_.reset();
     terminated_ = true;
@@ -75,7 +75,7 @@ class MockSubscriber : public flowable::Subscriber<T> {
   }
 
   void onError(folly::exception_wrapper ex) override {
-    auto this_ = get_ref(this);
+    auto this_ = this->ref_from_this(this);
     onError_(std::move(ex));
     terminated_ = true;
     terminalEventCV_.notify_all();


### PR DESCRIPTION
because let's not keep around a confusing API which may, hypothetically, lead to a memory leak 