### PR TITLE
Fix the crash when an unknown client connects to RSocketServer

### DIFF
--- a/rsocket/framing/FramedReader.cpp
+++ b/rsocket/framing/FramedReader.cpp
@@ -152,7 +152,9 @@ void FramedReader::onComplete() noexcept {
 void FramedReader::onError(folly::exception_wrapper ex) noexcept {
   completed_ = true;
   payloadQueue_.move(); // equivalent to clear(), releases the buffers
-  DuplexConnection::Subscriber::onError(folly::exception_wrapper());
+  if (DuplexConnection::Subscriber::subscription()) {
+    DuplexConnection::Subscriber::onError(folly::exception_wrapper());
+  }
   if (auto subscriber = std::move(frames_)) {
     // after this call the instance can be destroyed!
     subscriber->onError(std::move(ex));


### PR DESCRIPTION
When FramedReader does not accept a client, it causes onError call, which calls Subscriber::onError. In that function, it checks if there is any subscription or not.

In the unrecognized client case, there is no subscription available, so this call causes crash. So we need to check if the `subscription` is available before calling onError on the Subscriber class.