### PR TITLE
RSocketClient::disconnect() should return a future

### DIFF
--- a/rsocket/RSocketClient.h
+++ b/rsocket/RSocketClient.h
@@ -27,10 +27,10 @@ class RSocketClient {
  public:
   ~RSocketClient();
 
-  RSocketClient(const RSocketClient&) = delete; // copy
-  RSocketClient(RSocketClient&&) = default; // move
-  RSocketClient& operator=(const RSocketClient&) = delete; // copy
-  RSocketClient& operator=(RSocketClient&&) = default; // move
+  RSocketClient(const RSocketClient&) = delete;
+  RSocketClient(RSocketClient&&) = default;
+  RSocketClient& operator=(const RSocketClient&) = delete;
+  RSocketClient& operator=(RSocketClient&&) = default;
 
   friend class RSocket;
 
@@ -44,8 +44,8 @@ class RSocketClient {
   // is raised.
   folly::Future<folly::Unit> resume();
 
-  // Disconnect the underlying transport
-  void disconnect(folly::exception_wrapper = folly::exception_wrapper{});
+  // Disconnect the underlying transport.
+  folly::Future<folly::Unit> disconnect(folly::exception_wrapper = {});
 
  private:
   // Private constructor.  RSocket class should be used to create instances

--- a/test/RSocketClientServerTest.cpp
+++ b/test/RSocketClientServerTest.cpp
@@ -50,7 +50,6 @@ TEST(RSocketClientServer, ConnectManyAsync) {
             workers[workerId].getEventBase(), *server->listeningPort())
             .then([&executed](std::shared_ptr<rsocket::RSocketClient> client) {
               auto requester = client->getRequester();
-              client->disconnect(folly::exception_wrapper());
               ++executed;
               return client;
             }).onError([&](folly::exception_wrapper ex) {

--- a/test/RSocketTests.cpp
+++ b/test/RSocketTests.cpp
@@ -97,12 +97,7 @@ std::shared_ptr<RSocketClient> makeDisconnectedClient(
       makeServer(std::make_shared<DisconnectedResponder>());
 
   auto client = makeClient(eventBase, *server->listeningPort());
-
-  client->disconnect();
-  folly::Baton<> wait_for_disconnect;
-  eventBase->runInEventBaseThread([&] { wait_for_disconnect.post(); });
-  // force all other operations to complete, including the disconnect
-  wait_for_disconnect.timed_wait(std::chrono::milliseconds(100));
+  client->disconnect().get();
   return client;
 }
 


### PR DESCRIPTION
Right now it does the disconnect asynchronously, with no good way to force it to
be synchronous.  Similarly, ~RSocketClient didn't call disconnect(), so it seems
like it would destroy the state machine on a different thread than the
ConnectionFactory worker thread.