### PR TITLE
Another fix to unknown clients writing on connections

### DIFF
--- a/rsocket/framing/FramedReader.cpp
+++ b/rsocket/framing/FramedReader.cpp
@@ -142,7 +142,9 @@ void FramedReader::parseFrames() {
 void FramedReader::onComplete() noexcept {
   completed_ = true;
   payloadQueue_.move(); // equivalent to clear(), releases the buffers
-  DuplexConnection::Subscriber::onComplete();
+  if (DuplexConnection::Subscriber::subscription()) {
+    DuplexConnection::Subscriber::onComplete();
+  }
   if (auto subscriber = std::move(frames_)) {
     // after this call the instance can be destroyed!
     subscriber->onComplete();
@@ -153,7 +155,7 @@ void FramedReader::onError(folly::exception_wrapper ex) noexcept {
   completed_ = true;
   payloadQueue_.move(); // equivalent to clear(), releases the buffers
   if (DuplexConnection::Subscriber::subscription()) {
-    DuplexConnection::Subscriber::onError(folly::exception_wrapper());
+    DuplexConnection::Subscriber::onError({});
   }
   if (auto subscriber = std::move(frames_)) {
     // after this call the instance can be destroyed!


### PR DESCRIPTION
Easy repro, run any rsocket server (I used `example_resumption_server`), connect
to it with `nc` and type a bunch of gibberish.  Added a test that does the
equivalent, and fails before this change.