### PR TITLE
Make RSocketConnectionManager unit testable and add unit tests for it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,7 @@ add_library(
   rsocket/internal/ScheduledSingleObserver.h
   rsocket/internal/ScheduledSingleSubscription.cpp
   rsocket/internal/ScheduledSingleSubscription.h
+  rsocket/internal/ManageableConnection.h
   rsocket/internal/RSocketConnectionManager.cpp
   rsocket/internal/RSocketConnectionManager.h
   rsocket/internal/SwappableEventBase.cpp
@@ -422,13 +423,15 @@ add_executable(
   test/test_utils/GenericRequestResponseHandler.h
   test/test_utils/MockDuplexConnection.h
   test/test_utils/MockKeepaliveTimer.h
+  test/test_utils/MockManageableConnection.h
   test/test_utils/MockRequestHandler.h
   test/test_utils/MockStats.h
   test/test_utils/ColdResumeManager.cpp
   test/test_utils/ColdResumeManager.h
   test/transport/DuplexConnectionTest.cpp
   test/transport/DuplexConnectionTest.h
-  test/transport/TcpDuplexConnectionTest.cpp)
+  test/transport/TcpDuplexConnectionTest.cpp
+  test/RSocketConnectionManagerTest.cpp)
 
 target_link_libraries(
   tests

--- a/rsocket/internal/ManageableConnection.h
+++ b/rsocket/internal/ManageableConnection.h
@@ -1,0 +1,53 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+#pragma once
+
+#include <folly/ExceptionWrapper.h>
+#include <folly/futures/SharedPromise.h>
+#include <folly/io/async/EventBase.h>
+
+namespace rsocket {
+
+class MockManageableConnection;
+enum class StreamCompletionSignal;
+
+/// Utility class that enables RSocketConnectionManager to handle
+/// lifetime of RSocketStateMachine objects.
+class ManageableConnection {
+public:
+  virtual ~ManageableConnection() {
+    if (!closePromise_.isFulfilled()) {
+      // don't let any object indefinitely wait for the close event.
+      closePromise_.setValue();
+    }
+  }
+
+  /// Listen for the close event.
+  ///
+  /// The proposed usage is utilizing `via` function and appending
+  /// more functionality with `then` function.
+  ///
+  /// \return a Future to bind to.
+  folly::Future<folly::Unit> listenCloseEvent() {
+    return closePromise_.getFuture();
+  }
+
+  /// Terminates underlying connection.
+  ///
+  /// This may synchronously deliver terminal signals to all
+  /// StreamAutomatonBase attached to this ConnectionAutomaton.
+  virtual void close(folly::exception_wrapper,
+                     StreamCompletionSignal) = 0;
+
+protected:
+  void onClose(folly::exception_wrapper) {
+    // ignore the exception
+    closePromise_.setValue();
+  }
+
+private:
+  folly::SharedPromise<folly::Unit> closePromise_;
+
+  friend MockManageableConnection;
+};
+
+} // namespace rsocket

--- a/rsocket/internal/RSocketConnectionManager.h
+++ b/rsocket/internal/RSocketConnectionManager.h
@@ -16,22 +16,22 @@ class EventBase;
 
 namespace rsocket {
 
-class RSocketStateMachine;
+class ManageableConnection;
 
 class RSocketConnectionManager {
  public:
   ~RSocketConnectionManager();
 
   void manageConnection(
-      std::shared_ptr<rsocket::RSocketStateMachine>,
+      std::shared_ptr<ManageableConnection>,
       folly::EventBase&);
 
  private:
   using StateMachineMap = std::unordered_map<
-      std::shared_ptr<rsocket::RSocketStateMachine>,
+      std::shared_ptr<ManageableConnection>,
       folly::EventBase&>;
 
-  void removeConnection(const std::shared_ptr<rsocket::RSocketStateMachine>&);
+  void removeConnection(const std::shared_ptr<ManageableConnection>&);
 
   folly::Synchronized<StateMachineMap, std::mutex> sockets_;
 

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -17,6 +17,7 @@
 #include "rsocket/framing/FrameSerializer.h"
 #include "rsocket/framing/FrameTransport.h"
 #include "rsocket/internal/ClientResumeStatusCallback.h"
+#include "rsocket/internal/ManageableConnection.h"
 #include "rsocket/internal/ScheduledSubscriber.h"
 #include "rsocket/internal/WarmResumeManager.h"
 #include "rsocket/statemachine/ChannelResponder.h"
@@ -199,6 +200,8 @@ void RSocketStateMachine::close(
   if (connectionEvents) {
     connectionEvents->onClosed(ex);
   }
+
+  ManageableConnection::onClose(ex);
 }
 
 void RSocketStateMachine::closeFrameTransport(

--- a/rsocket/statemachine/RSocketStateMachine.h
+++ b/rsocket/statemachine/RSocketStateMachine.h
@@ -12,6 +12,7 @@
 #include "rsocket/ResumeManager.h"
 #include "rsocket/framing/FrameProcessor.h"
 #include "rsocket/internal/Common.h"
+#include "rsocket/internal/ManageableConnection.h"
 #include "rsocket/statemachine/StreamState.h"
 #include "rsocket/statemachine/StreamsFactory.h"
 #include "rsocket/statemachine/StreamsWriter.h"
@@ -58,6 +59,7 @@ class FrameSink {
 class RSocketStateMachine final
     : public FrameSink,
       public FrameProcessor,
+      public ManageableConnection,
       public StreamsWriter,
       public std::enable_shared_from_this<RSocketStateMachine> {
  public:
@@ -93,7 +95,7 @@ class RSocketStateMachine final
   ///
   /// This may synchronously deliver terminal signals to all
   /// StreamAutomatonBase attached to this ConnectionAutomaton.
-  void close(folly::exception_wrapper, StreamCompletionSignal);
+  void close(folly::exception_wrapper, StreamCompletionSignal) override;
 
   /// Terminate underlying connection and connect new connection
   void reconnect(
@@ -207,10 +209,6 @@ class RSocketStateMachine final
 
   RSocketStats& stats() {
     return *stats_;
-  }
-
-  std::shared_ptr<RSocketConnectionEvents>& connectionEvents() {
-    return connectionEvents_;
   }
 
  private:

--- a/test/RSocketConnectionManagerTest.cpp
+++ b/test/RSocketConnectionManagerTest.cpp
@@ -1,0 +1,64 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <gtest/gtest.h>
+
+#include <folly/io/async/EventBase.h>
+#include <rsocket/internal/Common.h>
+#include <rsocket/internal/RSocketConnectionManager.h>
+#include <test/test_utils/MockManageableConnection.h>
+
+using namespace rsocket;
+using namespace testing;
+
+TEST(RSocketConnectionManagerTest, None) {
+  RSocketConnectionManager conMgr;
+  StrictMock<MockManageableConnection> con;
+}
+
+TEST(RSocketConnectionManagerTest, TerminateConnectionManager) {
+  auto spCon = std::make_shared<StrictMock<MockManageableConnection>>();
+  EXPECT_CALL(*spCon, onClose_(_));
+  EXPECT_CALL(*spCon, close_(_, StreamCompletionSignal::SOCKET_CLOSED));
+  folly::EventBase evb;
+  {
+    RSocketConnectionManager conMgr;
+    conMgr.manageConnection(spCon, evb);
+  }
+}
+
+TEST(RSocketConnectionManagerTest, TerminateConnectionWithDestruction) {
+  folly::EventBase evb;
+  {
+    RSocketConnectionManager conMgr;
+    {
+      auto spCon = std::make_shared<StrictMock<MockManageableConnection>>();
+      EXPECT_CALL(*spCon, onClose_(_));
+      EXPECT_CALL(*spCon, close_(_, StreamCompletionSignal::SOCKET_CLOSED));
+      conMgr.manageConnection(spCon, evb);
+    }
+  }
+}
+
+TEST(RSocketConnectionManagerTest, NonManagedConnection) {
+  auto spCon = std::make_shared<StrictMock<MockManageableConnection>>();
+  // no one is calling close_ or onClose_
+}
+
+TEST(RSocketConnectionManagerTest, NonManagedConnectionClosesItself) {
+  auto spCon = std::make_shared<StrictMock<MockManageableConnection>>();
+  EXPECT_CALL(*spCon, onClose_(_));
+  EXPECT_CALL(*spCon, close_(_, StreamCompletionSignal::CANCEL));
+  spCon->close(folly::exception_wrapper(), StreamCompletionSignal::CANCEL);
+}
+
+TEST(RSocketConnectionManagerTest, ManagedConnectionClosesItself) {
+  RSocketConnectionManager conMgr;
+  folly::EventBase evb;
+  {
+    auto spCon = std::make_shared<StrictMock<MockManageableConnection>>();
+    EXPECT_CALL(*spCon, onClose_(_));
+    EXPECT_CALL(*spCon, close_(_, StreamCompletionSignal::CANCEL));
+    conMgr.manageConnection(spCon, evb);
+    spCon->close(folly::exception_wrapper(), StreamCompletionSignal::CANCEL);
+  }
+}

--- a/test/test_utils/MockManageableConnection.h
+++ b/test/test_utils/MockManageableConnection.h
@@ -1,0 +1,39 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <rsocket/internal/ManageableConnection.h>
+
+namespace rsocket {
+
+class MockManageableConnection : public rsocket::ManageableConnection {
+public:
+  MOCK_METHOD0(listenCloseEvent_, folly::Future<folly::Unit>());
+  MOCK_METHOD1(onClose_, void(folly::exception_wrapper));
+  MOCK_METHOD2(close_, void(folly::exception_wrapper, StreamCompletionSignal));
+
+  folly::Future<folly::Unit> listenCloseEvent() noexcept {
+    listenCloseEvent_();
+    return closePromise_.getFuture();
+  }
+
+  /// Terminates underlying connection.
+  ///
+  /// This may synchronously deliver terminal signals to all
+  /// StreamAutomatonBase attached to this ConnectionAutomaton.
+  void close(folly::exception_wrapper ex,
+             StreamCompletionSignal scs) noexcept override {
+    close_(ex, scs);
+    onClose(ex);
+  }
+
+protected:
+  void onClose(folly::exception_wrapper ex) noexcept {
+    onClose_(ex);
+    closePromise_.setValue();
+  }
+};
+
+} // namespace rsocket


### PR DESCRIPTION
I have removed the hack of returning ConnectionEvents with ConnectionEventsWrapper in RSocketConnectionManager.

I have made the RSocketConnectionManager be easy to unit test.

I have added some tests to verify the functionality.