### PR TITLE
fix undefined use-after-move ordering bug

### DIFF
--- a/rsocket/RSocketClient.cpp
+++ b/rsocket/RSocketClient.cpp
@@ -95,7 +95,8 @@ folly::Future<folly::Unit> RSocketClient::resume() {
     auto frameTransport =
         yarpl::make_ref<FrameTransport>(std::move(framedConnection));
 
-    connection.eventBase.runInEventBaseThread([
+    auto& eb = connection.eventBase;
+    eb.runInEventBaseThread([
       this,
       frameTransport = std::move(frameTransport),
       resumeCallback = std::move(resumeCallback),


### PR DESCRIPTION
`connection.eventBase` might be evaluated _after_ the move of `connection` into the lambda. 