### PR TITLE
RSocketConnectionManager: If client is already disconnected, no need to use evb_ to close the connection

### DIFF
--- a/rsocket/internal/ManageableConnection.h
+++ b/rsocket/internal/ManageableConnection.h
@@ -27,7 +27,7 @@ public:
   /// more functionality with `then` function.
   ///
   /// \return a Future to bind to.
-  folly::Future<folly::Unit> listenCloseEvent() {
+  virtual folly::Future<folly::Unit> listenCloseEvent() {
     return closePromise_.getFuture();
   }
 
@@ -38,8 +38,15 @@ public:
   virtual void close(folly::exception_wrapper,
                      StreamCompletionSignal) = 0;
 
+  /// If the connection is already disconnected, then there is
+  /// no need to close it in the given eventbase, we can call
+  /// close() function inline.
+  /// As the eventbase might be deleted when the application code
+  /// disconnects, we can save ourselves for that case too.
+  virtual bool isDisconnectedOrClosed() const = 0;
+
 protected:
-  void onClose(folly::exception_wrapper) {
+  virtual void onClose(folly::exception_wrapper) {
     // ignore the exception
     closePromise_.setValue();
   }

--- a/rsocket/statemachine/RSocketStateMachine.h
+++ b/rsocket/statemachine/RSocketStateMachine.h
@@ -186,7 +186,7 @@ class RSocketStateMachine final
       ResumePosition clientPosition);
 
   uint32_t getKeepaliveTime() const;
-  bool isDisconnectedOrClosed() const;
+  bool isDisconnectedOrClosed() const override;
   bool isClosed() const;
 
   StreamsFactory& streamsFactory() {


### PR DESCRIPTION
Users of our RSocketClient might only call `disconnect` method and they assume that its now fine to get rid of the corresponding eventBase that we used to add the StateMachine to the ConnectionManager.

Disconnect method already closes the connection. So we don't need to call the `close` method of the RSocketStateMachine within the `evb` if the connection is already disconnected.
This eliminates the possibility of trying to use the deleted `evb`.

So, either close() or disconnect() is called, it should be fine to have `evb`, out of the scope/deleted when the ConnectionManager is being destroyed.