### PR TITLE
Refactor and test FramedReader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,36 +396,37 @@ install(DIRECTORY yarpl/include/yarpl DESTINATION include FILES_MATCHING PATTERN
 
 add_executable(
   tests
+  test/ColdResumptionTest.cpp
+  test/ConnectionEventsTest.cpp
   test/PayloadTest.cpp
   test/RSocketClientServerTest.cpp
-  test/RSocketTests.h
-  test/RSocketTests.cpp
-  test/RequestChannelTest.cpp
   test/RSocketClientTest.cpp
+  test/RSocketTests.cpp
+  test/RSocketTests.h
+  test/RequestChannelTest.cpp
   test/RequestResponseTest.cpp
   test/RequestStreamTest.cpp
   test/RequestStreamTest_concurrency.cpp
-  test/WarmResumptionTest.cpp
-  test/ColdResumptionTest.cpp
-  test/ConnectionEventsTest.cpp
   test/Test.cpp
+  test/WarmResumptionTest.cpp
   test/framing/FrameTest.cpp
   test/framing/FrameTransportTest.cpp
-  test/handlers/HelloStreamRequestHandler.cpp
-  test/handlers/HelloStreamRequestHandler.h
+  test/framing/FramedReaderTest.cpp
   test/handlers/HelloServiceHandler.cpp
   test/handlers/HelloServiceHandler.h
+  test/handlers/HelloStreamRequestHandler.cpp
+  test/handlers/HelloStreamRequestHandler.h
   test/internal/AllowanceSemaphoreTest.cpp
   test/internal/FollyKeepaliveTimerTest.cpp
-  test/internal/SwappableEventBaseTest.cpp
   test/internal/SetupResumeAcceptorTest.cpp
+  test/internal/SwappableEventBaseTest.cpp
+  test/test_utils/ColdResumeManager.cpp
+  test/test_utils/ColdResumeManager.h
   test/test_utils/GenericRequestResponseHandler.h
   test/test_utils/MockDuplexConnection.h
   test/test_utils/MockKeepaliveTimer.h
   test/test_utils/MockRequestHandler.h
   test/test_utils/MockStats.h
-  test/test_utils/ColdResumeManager.cpp
-  test/test_utils/ColdResumeManager.h
   test/transport/DuplexConnectionTest.cpp
   test/transport/DuplexConnectionTest.h
   test/transport/TcpDuplexConnectionTest.cpp)

--- a/test/framing/FramedReaderTest.cpp
+++ b/test/framing/FramedReaderTest.cpp
@@ -1,0 +1,55 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <gtest/gtest.h>
+
+#include "rsocket/framing/FramedReader.h"
+#include "test/test_utils/MockDuplexConnection.h"
+
+using namespace rsocket;
+using namespace testing;
+using namespace yarpl::mocks;
+
+TEST(FramedReader, TinyFrame) {
+  auto version = std::make_shared<ProtocolVersion>(ProtocolVersion::Latest);
+  auto reader = yarpl::make_ref<FramedReader>(version);
+
+  // Not using hex string-literal as std::string ctor hits '\x00' and stops
+  // reading.
+  auto buf = folly::IOBuf::createCombined(4);
+  buf->append(4);
+  buf->writableData()[0] = '\x00';
+  buf->writableData()[1] = '\x00';
+  buf->writableData()[2] = '\x00';
+  buf->writableData()[3] = '\x02';
+
+  reader->onSubscribe(yarpl::flowable::Subscription::empty());
+  reader->onNext(std::move(buf));
+
+  auto subscriber = yarpl::make_ref<
+      StrictMock<MockSubscriber<std::unique_ptr<folly::IOBuf>>>>();
+  EXPECT_CALL(*subscriber, onSubscribe_(_));
+  EXPECT_CALL(*subscriber, onError_(_));
+
+  reader->setInput(subscriber);
+  subscriber->awaitTerminalEvent();
+  reader->onComplete();
+}
+
+TEST(FramedReader, CantDetectVersion) {
+  auto version = std::make_shared<ProtocolVersion>(ProtocolVersion::Unknown);
+  auto reader = yarpl::make_ref<FramedReader>(version);
+
+  auto buf = folly::IOBuf::copyBuffer("ABCDEFGHIJKLMNOP");
+
+  reader->onSubscribe(yarpl::flowable::Subscription::empty());
+  reader->onNext(std::move(buf));
+
+  auto subscriber = yarpl::make_ref<
+      StrictMock<MockSubscriber<std::unique_ptr<folly::IOBuf>>>>();
+  EXPECT_CALL(*subscriber, onSubscribe_(_));
+  EXPECT_CALL(*subscriber, onError_(_));
+
+  reader->setInput(subscriber);
+  subscriber->awaitTerminalEvent();
+  reader->onComplete();
+}


### PR DESCRIPTION
This is usually the first point of failure in crashes, and it's a nightmare to
understand.  Move out the functions that do things with the frame size and the
version (those can be shared with FramedWriter later too), add tests for error
cases.