### PR TITLE
Resumption supported on multi-threaded server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,8 +329,8 @@ add_library(
   rsocket/framing/FrameProcessor.h
   rsocket/framing/FrameSerializer.cpp
   rsocket/framing/FrameSerializer.h
-  rsocket/framing/FrameTransport.cpp
-  rsocket/framing/FrameTransport.h
+  rsocket/framing/FrameTransportImpl.cpp
+  rsocket/framing/FrameTransportImpl.h
   rsocket/framing/FrameType.cpp
   rsocket/framing/FrameType.h
   rsocket/framing/FramedDuplexConnection.cpp
@@ -374,7 +374,12 @@ add_library(
   rsocket/RSocketServiceHandler.cpp
   rsocket/RSocketServiceHandler.h
   rsocket/RSocketServerState.h
-  rsocket/RSocketException.h)
+  rsocket/RSocketException.h
+  rsocket/framing/FrameTransport.h
+  rsocket/framing/ScheduledFrameTransport.h
+  rsocket/framing/ScheduledFrameTransport.cpp
+  rsocket/framing/ScheduledFrameProcessor.h
+  rsocket/framing/ScheduledFrameProcessor.cpp)
 
 target_include_directories(ReactiveSocket PUBLIC "${PROJECT_SOURCE_DIR}/yarpl/include")
 target_include_directories(ReactiveSocket PUBLIC "${PROJECT_SOURCE_DIR}/yarpl/src")

--- a/examples/resumption/Resumption_Server.cpp
+++ b/examples/resumption/Resumption_Server.cpp
@@ -67,7 +67,7 @@ int main(int argc, char* argv[]) {
 
   TcpConnectionAcceptor::Options opts;
   opts.address = folly::SocketAddress("::", FLAGS_port);
-  opts.threads = 1;
+  opts.threads = 3;
 
   auto rs = RSocket::createServer(
       std::make_unique<TcpConnectionAcceptor>(std::move(opts)));

--- a/rsocket/RSocketClient.cpp
+++ b/rsocket/RSocketClient.cpp
@@ -4,7 +4,7 @@
 #include "rsocket/RSocketRequester.h"
 #include "rsocket/RSocketResponder.h"
 #include "rsocket/RSocketStats.h"
-#include "rsocket/framing/FrameTransport.h"
+#include "rsocket/framing/FrameTransportImpl.h"
 #include "rsocket/framing/FramedDuplexConnection.h"
 #include "rsocket/internal/ClientResumeStatusCallback.h"
 #include "rsocket/internal/FollyKeepaliveTimer.h"
@@ -93,7 +93,7 @@ folly::Future<folly::Unit> RSocketClient::resume() {
           std::move(connection.connection), protocolVersion_);
     }
     auto frameTransport =
-        yarpl::make_ref<FrameTransport>(std::move(framedConnection));
+        yarpl::make_ref<FrameTransportImpl>(std::move(framedConnection));
 
     auto& eb = connection.eventBase;
     eb.runInEventBaseThread([

--- a/rsocket/ResumeManager.h
+++ b/rsocket/ResumeManager.h
@@ -7,7 +7,7 @@
 #include <folly/Optional.h>
 
 #include "rsocket/framing/Frame.h"
-#include "rsocket/framing/FrameTransport.h"
+#include "rsocket/framing/FrameTransportImpl.h"
 
 namespace folly {
 class IOBuf;

--- a/rsocket/framing/FrameTransport.h
+++ b/rsocket/framing/FrameTransport.h
@@ -1,68 +1,17 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
-
 #pragma once
 
-#include <folly/ExceptionWrapper.h>
-#include "rsocket/DuplexConnection.h"
-#include "rsocket/internal/Common.h"
-#include "yarpl/flowable/Subscription.h"
+#include "yarpl/Refcounted.h"
+
+#include "rsocket/framing/FrameProcessor.h"
 
 namespace rsocket {
 
-class FrameProcessor;
-
-class FrameTransport final :
-    /// Registered as an input in the DuplexConnection.
-    public DuplexConnection::Subscriber,
-    /// Receives signals about connection writability.
-    public yarpl::flowable::Subscription {
+// Refer to FrameTransportImpl for documentation on the implementation
+class FrameTransport : public virtual yarpl::Refcounted {
  public:
-  explicit FrameTransport(std::unique_ptr<DuplexConnection> connection);
-  ~FrameTransport();
-
-  void setFrameProcessor(std::shared_ptr<FrameProcessor>);
-
-  /// Writes the frame directly to output. If the connection was closed it will
-  /// drop the frame.
-  void outputFrameOrDrop(std::unique_ptr<folly::IOBuf>);
-
-  /// Cancel the input, complete the output, and close the underlying
-  /// connection.
-  void close();
-
-  /// Cancel the input, error the output, and close the underlying connection.
-  /// This must be closed with a non-empty exception_wrapper.
-  void closeWithError(folly::exception_wrapper);
-
-  bool isClosed() const {
-    return !connection_;
-  }
-
- private:
-  void connect();
-
-  // Subscriber.
-
-  void onSubscribe(yarpl::Reference<yarpl::flowable::Subscription>) override;
-  void onNext(std::unique_ptr<folly::IOBuf>) override;
-  void onComplete() override;
-  void onError(folly::exception_wrapper) override;
-
-  // Subscription.
-
-  void request(int64_t) override;
-  void cancel() override;
-
-  /// Terminates the FrameProcessor.  Will queue up the exception if no
-  /// processor is set, overwriting any previously queued exception.
-  void terminateProcessor(folly::exception_wrapper);
-
-  void closeImpl(folly::exception_wrapper);
-
-  std::shared_ptr<FrameProcessor> frameProcessor_;
-  std::shared_ptr<DuplexConnection> connection_;
-
-  yarpl::Reference<DuplexConnection::Subscriber> connectionOutput_;
-  yarpl::Reference<yarpl::flowable::Subscription> connectionInputSub_;
+  virtual void setFrameProcessor(std::shared_ptr<FrameProcessor>) = 0;
+  virtual void outputFrameOrDrop(std::unique_ptr<folly::IOBuf>) = 0;
+  virtual void close() = 0;
+  virtual void closeWithError(folly::exception_wrapper) = 0;
 };
 }

--- a/rsocket/framing/FrameTransportImpl.h
+++ b/rsocket/framing/FrameTransportImpl.h
@@ -1,0 +1,71 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <folly/ExceptionWrapper.h>
+#include "rsocket/DuplexConnection.h"
+#include "rsocket/internal/Common.h"
+#include "yarpl/flowable/Subscription.h"
+
+#include "rsocket/framing/FrameTransport.h"
+
+namespace rsocket {
+
+class FrameProcessor;
+
+class FrameTransportImpl final
+    : public FrameTransport,
+      /// Registered as an input in the DuplexConnection.
+      public DuplexConnection::Subscriber,
+      /// Receives signals about connection writability.
+      public yarpl::flowable::Subscription {
+ public:
+  explicit FrameTransportImpl(std::unique_ptr<DuplexConnection> connection);
+  ~FrameTransportImpl();
+
+  void setFrameProcessor(std::shared_ptr<FrameProcessor>) override;
+
+  /// Writes the frame directly to output. If the connection was closed it will
+  /// drop the frame.
+  void outputFrameOrDrop(std::unique_ptr<folly::IOBuf>) override;
+
+  /// Cancel the input, complete the output, and close the underlying
+  /// connection.
+  void close() override;
+
+  /// Cancel the input, error the output, and close the underlying connection.
+  /// This must be closed with a non-empty exception_wrapper.
+  void closeWithError(folly::exception_wrapper) override;
+
+  bool isClosed() const {
+    return !connection_;
+  }
+
+ private:
+  void connect();
+
+  // Subscriber.
+
+  void onSubscribe(yarpl::Reference<yarpl::flowable::Subscription>) override;
+  void onNext(std::unique_ptr<folly::IOBuf>) override;
+  void onComplete() override;
+  void onError(folly::exception_wrapper) override;
+
+  // Subscription.
+
+  void request(int64_t) override;
+  void cancel() override;
+
+  /// Terminates the FrameProcessor.  Will queue up the exception if no
+  /// processor is set, overwriting any previously queued exception.
+  void terminateProcessor(folly::exception_wrapper);
+
+  void closeImpl(folly::exception_wrapper);
+
+  std::shared_ptr<FrameProcessor> frameProcessor_;
+  std::shared_ptr<DuplexConnection> connection_;
+
+  yarpl::Reference<DuplexConnection::Subscriber> connectionOutput_;
+  yarpl::Reference<yarpl::flowable::Subscription> connectionInputSub_;
+};
+}

--- a/rsocket/framing/ScheduledFrameProcessor.cpp
+++ b/rsocket/framing/ScheduledFrameProcessor.cpp
@@ -1,0 +1,33 @@
+#include "rsocket/framing/ScheduledFrameProcessor.h"
+
+#include <folly/ExceptionWrapper.h>
+#include <folly/io/IOBuf.h>
+
+namespace rsocket {
+
+ScheduledFrameProcessor::~ScheduledFrameProcessor() {
+  // ScheduledFrameProcessor could get destroyed before the scheduled events of
+  // the class get executed.  So preserve a copy of inner frameProcessor_ in
+  // the event queue.  Since the events in the queue are executed in order we
+  // are guaranteed to have the frameProcessor_ during all the other events
+  // which were added before the destruction of this class.
+  evb_->runInEventBaseThread([frameProcessor = frameProcessor_](){});
+}
+
+void ScheduledFrameProcessor::processFrame(
+    std::unique_ptr<folly::IOBuf> ioBuf) {
+  auto frameProcessorPtr = frameProcessor_.get();
+  evb_->runInEventBaseThread(
+      [ frameProcessorPtr, ioBuf = std::move(ioBuf) ]() mutable {
+        frameProcessorPtr->processFrame(std::move(ioBuf));
+      });
+}
+
+void ScheduledFrameProcessor::onTerminal(folly::exception_wrapper ex) {
+  auto frameProcessorPtr = frameProcessor_.get();
+  evb_->runInEventBaseThread(
+      [ ex = std::move(ex), frameProcessorPtr ]() mutable {
+        frameProcessorPtr->onTerminal(std::move(ex));
+      });
+}
+}

--- a/rsocket/framing/ScheduledFrameProcessor.h
+++ b/rsocket/framing/ScheduledFrameProcessor.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <folly/io/async/EventBase.h>
+
+#include "rsocket/framing/FrameProcessor.h"
+
+namespace rsocket {
+
+// This class is a wrapper around FrameProcessor which ensures all methods of
+// FrameProcessor get executed in a particular EventBase.
+//
+// This is currently used in the server where the resumed Transport of the
+// client is on a different EventBase compared to the EventBase on which the
+// original RSocketStateMachine was constructed for the client.  Here the
+// transport uses this class to schedule events of the RSocketStateMachine
+// (FrameProcessor) in the original EventBase.
+class ScheduledFrameProcessor : public FrameProcessor {
+ public:
+  ScheduledFrameProcessor(
+      std::shared_ptr<FrameProcessor> fp,
+      folly::EventBase* evb)
+      : frameProcessor_(std::move(fp)), evb_(evb) {}
+
+  ~ScheduledFrameProcessor();
+
+  void processFrame(std::unique_ptr<folly::IOBuf> ioBuf) override;
+  void onTerminal(folly::exception_wrapper ex) override;
+
+ private:
+  std::shared_ptr<FrameProcessor> frameProcessor_;
+  folly::EventBase* evb_;
+};
+
+} // rsocket

--- a/rsocket/framing/ScheduledFrameTransport.cpp
+++ b/rsocket/framing/ScheduledFrameTransport.cpp
@@ -1,0 +1,48 @@
+#include "rsocket/framing/ScheduledFrameTransport.h"
+
+#include <folly/io/IOBuf.h>
+
+namespace rsocket {
+
+ScheduledFrameTransport::~ScheduledFrameTransport() {
+  // ScheduledFrameTransport could get destroyed before the scheduled events of
+  // the class get executed.  So preserve a copy of inner frameProcessor_ in
+  // the event queue.  Since the events in the queue are executed in order we
+  // are guaranteed to have the frameTransport_ during all the other events
+  // which were added before the destruction of this class.
+  transportEvb_->runInEventBaseThread([frameTransport = frameTransport_](){});
+}
+
+void ScheduledFrameTransport::setFrameProcessor(
+    std::shared_ptr<FrameProcessor> fp) {
+  transportEvb_->runInEventBaseThread([ this, fp = std::move(fp) ]() mutable {
+    auto scheduledFP = std::make_shared<ScheduledFrameProcessor>(
+        std::move(fp), stateMachineEvb_);
+    frameTransport_->setFrameProcessor(std::move(scheduledFP));
+  });
+}
+
+void ScheduledFrameTransport::outputFrameOrDrop(
+    std::unique_ptr<folly::IOBuf> ioBuf) {
+  auto frameTransportPtr = frameTransport_.get();
+  transportEvb_->runInEventBaseThread(
+      [ frameTransportPtr, ioBuf = std::move(ioBuf) ]() mutable {
+        frameTransportPtr->outputFrameOrDrop(std::move(ioBuf));
+      });
+}
+
+void ScheduledFrameTransport::close() {
+  auto frameTransportPtr = frameTransport_.get();
+  transportEvb_->runInEventBaseThread(
+      [frameTransportPtr]() { frameTransportPtr->close(); });
+}
+
+void ScheduledFrameTransport::closeWithError(folly::exception_wrapper ex) {
+  auto frameTransportPtr = frameTransport_.get();
+  transportEvb_->runInEventBaseThread(
+      [ frameTransportPtr, ex = std::move(ex) ]() mutable {
+        frameTransportPtr->closeWithError(std::move(ex));
+      });
+}
+
+} // rsocket

--- a/rsocket/framing/ScheduledFrameTransport.h
+++ b/rsocket/framing/ScheduledFrameTransport.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <folly/io/async/EventBase.h>
+
+#include "rsocket/framing/FrameTransportImpl.h"
+#include "rsocket/framing/ScheduledFrameProcessor.h"
+
+namespace rsocket {
+
+// This class is a wrapper around FrameTransport which ensures all methods of
+// FrameTransport get executed in a particular EventBase.
+//
+// This is currently used in the server where the resumed Transport of the
+// client is on a different EventBase compared to the EventBase on which the
+// original RSocketStateMachine was constructed for the client.  Here the
+// RSocketStateMachine uses this class to schedule events of the Transport in
+// the new EventBase.
+class ScheduledFrameTransport : public FrameTransport {
+ public:
+  ScheduledFrameTransport(
+      yarpl::Reference<FrameTransport> frameTransport,
+      folly::EventBase* transportEvb,
+      folly::EventBase* stateMachineEvb)
+      : transportEvb_(transportEvb),
+        stateMachineEvb_(stateMachineEvb),
+        frameTransport_(std::move(frameTransport)) {}
+
+  ~ScheduledFrameTransport();
+
+  void setFrameProcessor(std::shared_ptr<FrameProcessor> fp) override;
+  void outputFrameOrDrop(std::unique_ptr<folly::IOBuf> ioBuf) override;
+  void close() override;
+  void closeWithError(folly::exception_wrapper ex) override;
+
+ private:
+  folly::EventBase* transportEvb_;
+  folly::EventBase* stateMachineEvb_;
+  yarpl::Reference<FrameTransport> frameTransport_;
+};
+}

--- a/rsocket/internal/SetupResumeAcceptor.cpp
+++ b/rsocket/internal/SetupResumeAcceptor.cpp
@@ -9,7 +9,7 @@
 #include "rsocket/framing/Frame.h"
 #include "rsocket/framing/FrameProcessor.h"
 #include "rsocket/framing/FrameSerializer.h"
-#include "rsocket/framing/FrameTransport.h"
+#include "rsocket/framing/FrameTransportImpl.h"
 
 namespace rsocket {
 
@@ -192,7 +192,7 @@ void SetupResumeAcceptor::accept(
     std::unique_ptr<DuplexConnection> connection,
     OnSetup onSetup,
     OnResume onResume) {
-  auto transport = yarpl::make_ref<FrameTransport>(std::move(connection));
+  auto transport = yarpl::make_ref<FrameTransportImpl>(std::move(connection));
   auto processor = std::make_shared<OneFrameProcessor>(
       *this, transport, std::move(onSetup), std::move(onResume));
   connections_.insert(transport);

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -15,7 +15,7 @@
 #include "rsocket/RSocketStats.h"
 #include "rsocket/framing/Frame.h"
 #include "rsocket/framing/FrameSerializer.h"
-#include "rsocket/framing/FrameTransport.h"
+#include "rsocket/framing/FrameTransportImpl.h"
 #include "rsocket/internal/ClientResumeStatusCallback.h"
 #include "rsocket/internal/ManageableConnection.h"
 #include "rsocket/internal/ScheduledSubscriber.h"
@@ -101,7 +101,6 @@ bool RSocketStateMachine::connect(
     ProtocolVersion protocolVersion) {
   CHECK(isDisconnectedOrClosed());
   CHECK(frameTransport);
-  CHECK(!frameTransport->isClosed());
   if (protocolVersion != ProtocolVersion::Unknown) {
     if (frameSerializer_) {
       if (frameSerializer_->protocolVersion() != protocolVersion) {
@@ -862,7 +861,8 @@ void RSocketStateMachine::connectClientSendSetup(
 
   setResumable(setupParams.resumable);
 
-  auto frameTransport = yarpl::make_ref<FrameTransport>(std::move(connection));
+  auto frameTransport =
+      yarpl::make_ref<FrameTransportImpl>(std::move(connection));
 
   auto protocolVersion = frameSerializer_->protocolVersion();
 

--- a/test/ColdResumptionTest.cpp
+++ b/test/ColdResumptionTest.cpp
@@ -29,7 +29,7 @@ class HelloSubscriber : public Subscriber<Payload> {
   }
 
   void awaitLatestValue(size_t value) {
-    auto count = 100;
+    auto count = 1000;
     while (value != latestValue_ && count > 0) {
       VLOG(1) << "Waiting " << count << " ticks for latest value...";
       std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/test/RSocketTests.cpp
+++ b/test/RSocketTests.cpp
@@ -33,7 +33,7 @@ std::unique_ptr<RSocketServer> makeServer(
 std::unique_ptr<RSocketServer> makeResumableServer(
     std::shared_ptr<RSocketServiceHandler> serviceHandler) {
   TcpConnectionAcceptor::Options opts;
-  opts.threads = 1;
+  opts.threads = 3;
   opts.address = folly::SocketAddress("::", 0);
   auto rs = RSocket::createServer(
       std::make_unique<TcpConnectionAcceptor>(std::move(opts)));

--- a/test/framing/FrameTransportTest.cpp
+++ b/test/framing/FrameTransportTest.cpp
@@ -2,7 +2,7 @@
 
 #include <gtest/gtest.h>
 
-#include "rsocket/framing/FrameTransport.h"
+#include "rsocket/framing/FrameTransportImpl.h"
 #include "test/test_utils/MockDuplexConnection.h"
 #include "test/test_utils/MockFrameProcessor.h"
 
@@ -28,7 +28,7 @@ TEST(FrameTransport, Close) {
         EXPECT_CALL(*output, onComplete_());
       });
 
-  auto transport = yarpl::make_ref<FrameTransport>(std::move(connection));
+  auto transport = yarpl::make_ref<FrameTransportImpl>(std::move(connection));
   transport->setFrameProcessor(
       std::make_shared<StrictMock<MockFrameProcessor>>());
   transport->close();
@@ -42,7 +42,7 @@ TEST(FrameTransport, CloseWithError) {
         EXPECT_CALL(*output, onError_(_));
       });
 
-  auto transport = yarpl::make_ref<FrameTransport>(std::move(connection));
+  auto transport = yarpl::make_ref<FrameTransportImpl>(std::move(connection));
   transport->setFrameProcessor(
       std::make_shared<StrictMock<MockFrameProcessor>>());
   transport->closeWithError(std::runtime_error("Uh oh"));
@@ -60,7 +60,7 @@ TEST(FrameTransport, SimpleNoQueue) {
         EXPECT_CALL(*output, onComplete_());
       });
 
-  auto transport = yarpl::make_ref<FrameTransport>(std::move(connection));
+  auto transport = yarpl::make_ref<FrameTransportImpl>(std::move(connection));
 
   transport->setFrameProcessor(
       std::make_shared<StrictMock<MockFrameProcessor>>());
@@ -87,7 +87,7 @@ TEST(FrameTransport, InputSendsError) {
         EXPECT_CALL(*output, onComplete_());
       });
 
-  auto transport = yarpl::make_ref<FrameTransport>(std::move(connection));
+  auto transport = yarpl::make_ref<FrameTransportImpl>(std::move(connection));
 
   auto processor = std::make_shared<StrictMock<MockFrameProcessor>>();
   EXPECT_CALL(*processor, onTerminal_(_));

--- a/test/internal/SetupResumeAcceptorTest.cpp
+++ b/test/internal/SetupResumeAcceptorTest.cpp
@@ -4,7 +4,7 @@
 
 #include <folly/io/async/EventBase.h>
 
-#include "rsocket/framing/FrameTransport.h"
+#include "rsocket/framing/FrameTransportImpl.h"
 #include "rsocket/internal/SetupResumeAcceptor.h"
 #include "test/test_utils/MockDuplexConnection.h"
 #include "test/test_utils/MockFrameProcessor.h"


### PR DESCRIPTION
Major changes in this PR are 
- `FrameTransport` is an interface which `FrameTransportImpl` and `ScheduledFrameTransport` implement.  `FrameTransportImpl` is the old `FrameTransport` (just renaming here).
- `RSocketStateMachine` uses the `FrameTransport` interface to interact with the transport
- `ScheduledFrameProcessor` has been introduced.
- If the resumed connection is on a different EventBase, we use `ScheduledFrameTransport` and `ScheduledFrameProcessor` to ensure the `RSocketStateMachine` continues to live on the old EventBase, but communicate with the transport on the new EventBase.
- Else, there is no thread hopping and regular FrameTransport and FrameProcessor (RSocketStateMachine) is used.

In the future, if/when we get rid of FrameTransport, we have to just give a different implementation of the FrameTransport interface.  The current PR is not bound to FrameTransport in anyway. 

I tested by increasing the number of threads in the resumption-server (both unittest and examples) and verified that the resumption succeeds when resumed on different EventBase.  AsyncServerSocket round-robins among the available worker threads, so this was pretty deterministic.   I will follow up with stress testing resumption