### PR TITLE
Cleaner termination semantics for FramedReader

### DIFF
--- a/rsocket/framing/FramedReader.h
+++ b/rsocket/framing/FramedReader.h
@@ -17,7 +17,11 @@ class FramedReader : public DuplexConnection::Subscriber,
   explicit FramedReader(std::shared_ptr<ProtocolVersion> version)
       : version_{std::move(version)} {}
 
+  /// Set the inner subscriber which will be getting full frame payloads.
   void setInput(yarpl::Reference<DuplexConnection::Subscriber>);
+
+  /// Cancel the subscription and error the inner subscriber.
+  void error(std::string);
 
   // Subscriber.
 
@@ -32,7 +36,6 @@ class FramedReader : public DuplexConnection::Subscriber,
   void cancel() override;
 
  private:
-  void error(std::string errorMsg);
   void parseFrames();
   bool ensureOrAutodetectProtocolVersion();
 


### PR DESCRIPTION
FramedReader is a Subscriber, so we should expect
FramedReader::on{Complete,Error}() to be called at most once, and after a call
to FramedReader::onSubscribe().

As such, we shouldn't call them from FramedReader::error(), that should have its
own logic to cancel the subscription safely and to error the inner subscriber
safely, while still being resilient to running
FramedReader::on{Complete,Error}() afterwards.  Added tests for this.

Connecting to RSocket server with `nc` and typing garbage still works properly.