### PR TITLE
onComplete() should not be called after sync call to cancel()

### DIFF
--- a/rsocket/statemachine/StreamRequester.cpp
+++ b/rsocket/statemachine/StreamRequester.cpp
@@ -50,9 +50,9 @@ void StreamRequester::cancel() noexcept {
   VLOG(5) << "StreamRequester::cancel(requested_=" << requested_ << ")";
   if (requested_) {
     cancelStream();
+    cancelConsumer();
   }
   closeStream(StreamCompletionSignal::CANCEL);
-  completeConsumer();
 }
 
 void StreamRequester::endStream(StreamCompletionSignal signal) {

--- a/test/RequestStreamTest_concurrency.cpp
+++ b/test/RequestStreamTest_concurrency.cpp
@@ -122,18 +122,12 @@ TEST(RequestStreamTest, OperationsAfterCancel) {
         batons.onCancelSent.post();
         CHECK_WAIT(batons.onCancelReceivedToclient);
         CHECK_WAIT(batons.onSecondPayloadSent);
+        batons.clientFinished.post();
       }));
 
   // shouldn't recieve 'bar', we canceled syncronously with the Subscriber
   // had 'cancel' been called in a different thread with no synchronization,
   // the client's Subscriber _could_ have received 'bar'
-
-  EXPECT_CALL(*subscriber_mock, onComplete_())
-      .InSequence(client_seq)
-      .WillOnce(Invoke([&]() {
-        LOCKSTEP_DEBUG("CLIENT: got onComplete()");
-        batons.clientFinished.post();
-      }));
 
   LOCKSTEP_DEBUG("RUNNER: doing requestStream()");
   requester->requestStream(Payload("initial"))

--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -127,18 +127,17 @@ class FlowableOperator : public Flowable<D> {
     void terminateImpl(
         TerminateState state,
         folly::exception_wrapper ex = folly::exception_wrapper{nullptr}) {
-      if (isTerminated()) {
-        return;
-      }
+      auto self = this->ref_from_this(this);
 
-      if (auto upstream = std::move(upstream_)) {
-        if (state.up) {
+      if (state.up) {
+        if (auto upstream = std::move(upstream_)) {
           upstream->cancel();
         }
+        subscriber_.reset();
       }
 
-      if (auto subscriber = std::move(subscriber_)) {
-        if (state.down) {
+      if (state.down) {
+        if (auto subscriber = std::move(subscriber_)) {
           if (ex) {
             subscriber->onError(std::move(ex));
           } else {

--- a/yarpl/test/FlowableTest.cpp
+++ b/yarpl/test/FlowableTest.cpp
@@ -553,7 +553,7 @@ TEST(FlowableTest, SubscribeMultipleTimes) {
     return std::make_tuple(req, true);
   });
 
-  auto setup_mock = [](auto request_num, auto& resps) {
+  auto setup_mock = [](auto request_num, auto& resps, bool isCanceled = false) {
     auto mock = make_ref<StrictMockSubscriber>(request_num);
 
     Sequence seq;
@@ -562,7 +562,9 @@ TEST(FlowableTest, SubscribeMultipleTimes) {
         .InSequence(seq)
         .WillRepeatedly(
             Invoke([&resps](int64_t value) { resps.push_back(value); }));
-    EXPECT_CALL(*mock, onComplete_()).InSequence(seq);
+    if (!isCanceled) {
+      EXPECT_CALL(*mock, onComplete_()).InSequence(seq);
+    }
     return mock;
   };
 
@@ -570,7 +572,7 @@ TEST(FlowableTest, SubscribeMultipleTimes) {
   auto mock1 = setup_mock(5, results[0]);
   auto mock2 = setup_mock(5, results[1]);
   auto mock3 = setup_mock(5, results[2]);
-  auto mock4 = setup_mock(5, results[3]);
+  auto mock4 = setup_mock(5, results[3], true);
   auto mock5 = setup_mock(5, results[4]);
 
   // map on the same flowable twice


### PR DESCRIPTION
and fixes a use after free when FlowableOperator is terminated 