### PR TITLE
fix flowableoperator termination behavior

### DIFF
--- a/rsocket/statemachine/StreamRequester.cpp
+++ b/rsocket/statemachine/StreamRequester.cpp
@@ -49,8 +49,8 @@ void StreamRequester::request(int64_t n) noexcept {
 void StreamRequester::cancel() noexcept {
   VLOG(5) << "StreamRequester::cancel(requested_=" << requested_ << ")";
   if (requested_) {
-    cancelStream();
     cancelConsumer();
+    cancelStream();
   }
   closeStream(StreamCompletionSignal::CANCEL);
 }

--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -129,20 +129,17 @@ class FlowableOperator : public Flowable<D> {
         folly::exception_wrapper ex = folly::exception_wrapper{nullptr}) {
       auto self = this->ref_from_this(this);
 
-      if (state.up) {
-        if (auto upstream = std::move(upstream_)) {
-          upstream->cancel();
-        }
-        subscriber_.reset();
+      auto upstream = std::move(upstream_);
+      if(state.up && upstream) {
+        upstream->cancel();
       }
 
-      if (state.down) {
-        if (auto subscriber = std::move(subscriber_)) {
-          if (ex) {
-            subscriber->onError(std::move(ex));
-          } else {
-            subscriber->onComplete();
-          }
+      auto subscriber = std::move(subscriber_);
+      if(state.down && subscriber) {
+        if (ex) {
+          subscriber->onError(std::move(ex));
+        } else {
+          subscriber->onComplete();
         }
       }
     }

--- a/yarpl/test/FlowableTest.cpp
+++ b/yarpl/test/FlowableTest.cpp
@@ -553,7 +553,7 @@ TEST(FlowableTest, SubscribeMultipleTimes) {
     return std::make_tuple(req, true);
   });
 
-  auto setup_mock = [](auto request_num, auto& resps, bool isCanceled = false) {
+  auto setup_mock = [](auto request_num, auto& resps) {
     auto mock = make_ref<StrictMockSubscriber>(request_num);
 
     Sequence seq;
@@ -562,9 +562,7 @@ TEST(FlowableTest, SubscribeMultipleTimes) {
         .InSequence(seq)
         .WillRepeatedly(
             Invoke([&resps](int64_t value) { resps.push_back(value); }));
-    if (!isCanceled) {
-      EXPECT_CALL(*mock, onComplete_()).InSequence(seq);
-    }
+    EXPECT_CALL(*mock, onComplete_()).InSequence(seq);
     return mock;
   };
 
@@ -572,7 +570,7 @@ TEST(FlowableTest, SubscribeMultipleTimes) {
   auto mock1 = setup_mock(5, results[0]);
   auto mock2 = setup_mock(5, results[1]);
   auto mock3 = setup_mock(5, results[2]);
-  auto mock4 = setup_mock(5, results[3], true);
+  auto mock4 = setup_mock(5, results[3]);
   auto mock5 = setup_mock(5, results[4]);
 
   // map on the same flowable twice


### PR DESCRIPTION
syncs up changes made in the last import - namely an ordering of calls problem in StreamRequester and an incorrect lack of call to onComplete for the take operator. 