### PR TITLE
Bump the timeout on RSocketClientServer.ConnectManyAsync

### DIFF
--- a/test/RSocketClientServerTest.cpp
+++ b/test/RSocketClientServerTest.cpp
@@ -61,7 +61,7 @@ TEST(RSocketClientServer, ConnectManyAsync) {
   }
 
   CHECK_EQ(clients.size(), connectionCount);
-  auto results = folly::collectAll(clients).get(folly::Duration(5000));
+  auto results = folly::collectAll(clients).get(std::chrono::minutes{1});
   CHECK_EQ(results.size(), connectionCount);
 
   results.clear();


### PR DESCRIPTION
I routinely hit this timeout in optimized test runs (ironically).