### PR TITLE
Add fire-and-forget benchmark

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -15,11 +15,15 @@ endfunction()
 benchmark(baselines_tcp BaselinesTcp.cpp)
 benchmark(baselines_async_socket BaselinesAsyncSocket.cpp)
 
+benchmark(fire-forget-throughput-tcp FireForgetThroughputTcp.cpp)
 benchmark(req-response-throughput-tcp RequestResponseThroughputTcp.cpp)
 benchmark(stream-throughput-tcp StreamThroughputTcp.cpp)
+
 benchmark(stream-throughput-mem StreamThroughputMemory.cpp)
 
 add_test(NAME RequestResponseThroughputTcpTest COMMAND req-response-throughput-tcp --items 100000)
 add_test(NAME StreamThroughputTcpTest COMMAND stream-throughput-tcp --items 100000)
+add_test(NAME FireForgetThroughputTcpTest COMMAND fire-forget-throughput-tcp --items 100000)
+
 #TODO(lehecka):enable test
 #add_test(NAME StreamThroughputMemoryTest COMMAND stream-throughput-mem --items 100000)

--- a/benchmarks/StreamThroughputMemory.cpp
+++ b/benchmarks/StreamThroughputMemory.cpp
@@ -150,6 +150,8 @@ std::shared_ptr<RSocketClient> makeClient() {
 }
 
 BENCHMARK(StreamThroughput, n) {
+  (void)n;
+
   std::shared_ptr<RSocketClient> client;
   yarpl::Reference<BoundedSubscriber> subscriber;
 

--- a/benchmarks/StreamThroughputTcp.cpp
+++ b/benchmarks/StreamThroughputTcp.cpp
@@ -3,17 +3,11 @@
 #include "benchmarks/Fixture.h"
 #include "benchmarks/Throughput.h"
 
-#include <deque>
-
 #include <folly/Baton.h>
 #include <folly/Benchmark.h>
-#include <folly/io/async/ScopedEventBaseThread.h>
 #include <folly/portability/GFlags.h>
 
 #include "rsocket/RSocket.h"
-#include "rsocket/transports/tcp/TcpConnectionAcceptor.h"
-#include "rsocket/transports/tcp/TcpConnectionFactory.h"
-#include "yarpl/Flowable.h"
 
 using namespace rsocket;
 
@@ -29,6 +23,8 @@ DEFINE_int32(items, 1000000, "number of items in stream, per client");
 DEFINE_int32(streams, 1, "number of streams, per client");
 
 BENCHMARK(StreamThroughput, n) {
+  (void)n;
+
   std::unique_ptr<Fixture> fixture;
   Fixture::Options opts;
 


### PR DESCRIPTION
Pretty similar to the request-response one, except this one puts the latch on
the server's responder.

Adds `(void)n;` statements to benchmarks so the compiler shuts up about unused
variables.  Note: We can remove the `n` argument entirely from the macro, but
that'll just make the compiler cry about macros being called with the wrong
number of arguments.