### PR TITLE
Fix stream benchmark log

### DIFF
--- a/benchmarks/StreamThroughputTcp.cpp
+++ b/benchmarks/StreamThroughputTcp.cpp
@@ -50,8 +50,8 @@ BENCHMARK(StreamThroughput, n) {
     LOG(INFO) << "  Server with " << opts.serverThreads << " threads.";
     LOG(INFO) << "  " << opts.clients << " clients across "
               << fixture->workers.size() << " threads.";
-    LOG(INFO) << "  Each client running " << FLAGS_streams
-              << " streams that each get " << FLAGS_items << " items.";
+    LOG(INFO) << "  Running " << FLAGS_streams
+              << " streams of " << FLAGS_items << " items each.";
   }
 
   for (size_t i = 0; i < FLAGS_streams; ++i) {


### PR DESCRIPTION
It was saying we run `FLAGS_streams` streams per client.  We actually run
`FLAGS_streams` streams total, across all of our clients.  Fix it before people
get confused.