### PR TITLE
yarpl refcount debugging helpers

### DIFF
--- a/yarpl/CMakeLists.txt
+++ b/yarpl/CMakeLists.txt
@@ -26,6 +26,11 @@ if(APPLE AND ${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
   add_compile_options("-fno-sanitize=address,undefined")
 endif()
 
+option(YARPL_REFCOUNT_DEBUGGING "Enable refcount debugging/leak checking in Yarpl" OFF)
+if(YARPL_REFCOUNT_DEBUGGING)
+  add_compile_options(-DYARPL_REFCOUNT_DEBUGGING)
+endif()
+
 # Using NDEBUG in Release builds.
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG")
 
@@ -44,6 +49,7 @@ add_library(
         include/yarpl/Scheduler.h
         include/yarpl/Disposable.h
         include/yarpl/Refcounted.h
+        src/yarpl/Refcounted.cpp
         # Flowable public API
         include/yarpl/Flowable.h
         include/yarpl/flowable/EmitterFlowable.h

--- a/yarpl/src/yarpl/Refcounted.cpp
+++ b/yarpl/src/yarpl/Refcounted.cpp
@@ -1,0 +1,111 @@
+#include "yarpl/Refcounted.h"
+
+#include "folly/Synchronized.h"
+
+#include <algorithm>
+#include <iomanip>
+
+namespace yarpl {
+namespace detail {
+
+using sync_map_type = folly::Synchronized<refcount_map_type>;
+using refcount_pair = std::pair<std::string, int64_t>;
+
+#ifdef YARPL_REFCOUNT_DEBUGGING
+
+// number of objects currently live of this type
+sync_map_type live_refcounted_map;
+
+// number of objects ever created of this type
+sync_map_type total_refcounted_map;
+
+static void inc_in_map(std::string const& typestring, sync_map_type& the_map) {
+  auto map = the_map.wlock();
+  auto it = map->find(typestring);
+  if (it == map->end()) {
+    map->emplace(typestring, 1);
+    it = map->find(typestring);
+  }
+  else {
+    it->second = it->second + 1;
+  }
+
+  VLOG(6) << "increment " << typestring << " to " << it->second;
+}
+
+static void dec_in_map(std::string const& typestring, sync_map_type& the_map) {
+  auto map = the_map.wlock();
+  auto it = map->find(typestring);
+  if (it == map->end()) {
+    VLOG(6) << "didn't find " << typestring << " in the map";
+    return;
+  }
+  else {
+    if (it->second >= 1) {
+      it->second = it->second - 1;
+    }
+    else {
+      VLOG(6) << "deallocating " << typestring << " past zero?";
+      return;
+    }
+  }
+
+  VLOG(6) << "decrement " << typestring << " to " << it->second;
+}
+
+void inc_live(std::string const& typestring) { inc_in_map(typestring, live_refcounted_map); }
+void dec_live(std::string const& typestring) { dec_in_map(typestring, live_refcounted_map); }
+
+void inc_created(std::string const& typestring) { inc_in_map(typestring, total_refcounted_map); }
+
+template <typename ComparePred>
+void debug_refcounts_map(std::ostream& o, sync_map_type const& the_map, ComparePred& pred) {
+  // truncate demangled typename
+  auto const max_type_len = 50;
+  // only print the first 'n' entries
+  auto max_entries = 50;
+
+  auto the_map_locked = the_map.rlock();
+  std::vector<refcount_pair> entries(the_map_locked->begin(), the_map_locked->end());
+  std::sort(entries.begin(), entries.end(), pred);
+
+  for(auto& pair : entries) {
+    if (!max_entries--) break;
+
+    auto s = pair.first;
+    if (s.size() > max_type_len) {
+      s = s.substr(0, max_type_len);
+    }
+    o << std::left << std::setw (max_type_len) << s << " :: " << pair.second << std::endl;
+  }
+}
+
+void debug_refcounts(std::ostream& o) {
+  struct {
+    bool operator()(refcount_pair const& a, refcount_pair const& b) {
+      return a.second > b.second;
+    }
+  } max_refcount_pred;
+
+  o << "===============" << std::endl;
+  o << "LIVE REFCOUNTS: " << std::endl;
+  debug_refcounts_map(o, live_refcounted_map, max_refcount_pred);
+  o << "===============" << std::endl;
+  o << "===============" << std::endl;
+  o << "TOTAL REFCOUNTS: " << std::endl;
+  debug_refcounts_map(o, total_refcounted_map, max_refcount_pred);
+  o << "===============" << std::endl;
+}
+
+#else /* YARPL_REFCOUNT_DEBUGGING */
+
+void inc_created(std::string const&) { assert(false); }
+void inc_live(std::string const&) {  assert(false); }
+void dec_live(std::string const&) {  assert(false); }
+void debug_refcounts(std::ostream& o) {
+  o << "Compile with YARPL_REFCOUNT_DEBUGGING (-DYARPL_REFCOUNT_DEBUGGING=On) to get Refcounted allocation counts" << std::endl;
+}
+
+#endif
+
+} }

--- a/yarpl/test/yarpl-tests.cpp
+++ b/yarpl/test/yarpl-tests.cpp
@@ -4,9 +4,18 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include "yarpl/Refcounted.h"
+
 int main(int argc, char** argv) {
-  FLAGS_logtostderr = true;
-  ::testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv);
-  return RUN_ALL_TESTS();
+  int ret;
+  {
+    FLAGS_logtostderr = true;
+    ::testing::InitGoogleTest(&argc, argv);
+    folly::init(&argc, &argv);
+    ret = RUN_ALL_TESTS();
+  }
+
+  yarpl::detail::debug_refcounts(std::cerr);
+
+  return ret;
 }


### PR DESCRIPTION
`cmake ...etc... -DYARPL_REFCOUNT_DEBUGGING=On ../` to enable 

gives a nice summary of refcounted objects when `yarpl::detail::debug_refcounts(std::cerr)` is called: 

```
===============
LIVE REFCOUNTS:
yarpl::observable::FromPublisherOperator<int, yarp :: 0
yarpl::mocks::MockSubscriber<int>                  :: 0
yarpl::flowable::TakeOperator<std::__cxx11::basic_ :: 0
yarpl::observable::FromPublisherOperator<int, yarp :: 0
.... more types and their counts
===============
===============
TOTAL REFCOUNTS:
yarpl::observable::Subscription                    :: 35
yarpl::flowable::details::EmiterSubscription<long> :: 26
yarpl::flowable::details::EmitterWrapper<long, yar :: 21
yarpl::flowable::TestSubscriber<long>              :: 19
yarpl::observable::FromPublisherOperator<long, yar :: 17
... more types and their counts
===============