### PR TITLE
Multiple bug fixes and associated stress test

### DIFF
--- a/examples/resumption/Resumption_Server.cpp
+++ b/examples/resumption/Resumption_Server.cpp
@@ -23,10 +23,7 @@ class HelloStreamRequestResponder : public RSocketResponder {
     auto requestString = request.moveDataToString();
     return Flowables::range(1, 1000)->map([name = std::move(requestString)](
         int64_t v) {
-      std::stringstream ss;
-      ss << "Hello " << name << " " << v << "!";
-      std::string s = ss.str();
-      return Payload(s, "metadata");
+      return Payload(folly::to<std::string>(v), "metadata");
     });
   }
 };

--- a/rsocket/RSocketClient.cpp
+++ b/rsocket/RSocketClient.cpp
@@ -36,7 +36,7 @@ RSocketClient::RSocketClient(
       token_(std::move(token)) {}
 
 RSocketClient::~RSocketClient() {
-  VLOG(4) << "RSocketClient destroyed ..";
+  VLOG(3) << "RSocketClient destroyed ..";
   disconnect().get();
 }
 

--- a/rsocket/framing/Frame.cpp
+++ b/rsocket/framing/Frame.cpp
@@ -217,9 +217,9 @@ std::ostream& operator<<(std::ostream& os, const Frame_ERROR& frame) {
 
   std::ostream& operator<<(std::ostream& os, const Frame_RESUME& frame) {
     return os << frame.header_ << ", ("
-              << "token"
-              << ", @server " << frame.lastReceivedServerPosition_
-              << ", @client " << frame.clientPosition_ << ")";
+              << "token " << frame.token_ << ", @server "
+              << frame.lastReceivedServerPosition_ << ", @client "
+              << frame.clientPosition_ << ")";
   }
 
   std::ostream& operator<<(std::ostream& os, const Frame_RESUME_OK& frame) {

--- a/rsocket/framing/FrameTransportImpl.cpp
+++ b/rsocket/framing/FrameTransportImpl.cpp
@@ -20,7 +20,7 @@ FrameTransportImpl::FrameTransportImpl(
 }
 
 FrameTransportImpl::~FrameTransportImpl() {
-  VLOG(1) << "~FrameTransport";
+  VLOG(1) << "~FrameTransport (" << this << ")";
 }
 
 void FrameTransportImpl::connect() {
@@ -130,12 +130,12 @@ void FrameTransportImpl::terminateProcessor(folly::exception_wrapper ex) {
 }
 
 void FrameTransportImpl::onComplete() {
-  VLOG(6) << "onComplete";
+  VLOG(3) << "FrameTransport received onComplete";
   terminateProcessor(folly::exception_wrapper());
 }
 
 void FrameTransportImpl::onError(folly::exception_wrapper ex) {
-  VLOG(6) << "onError" << ex;
+  VLOG(3) << "FrameTransport received onError: " << ex.what();
   terminateProcessor(std::move(ex));
 }
 
@@ -145,7 +145,7 @@ void FrameTransportImpl::request(int64_t n) {
 }
 
 void FrameTransportImpl::cancel() {
-  VLOG(6) << "cancel";
+  VLOG(3) << "FrameTransport received cancel";
   terminateProcessor(folly::exception_wrapper());
 }
 

--- a/test/RSocketTests.cpp
+++ b/test/RSocketTests.cpp
@@ -33,7 +33,8 @@ std::unique_ptr<RSocketServer> makeServer(
 std::unique_ptr<RSocketServer> makeResumableServer(
     std::shared_ptr<RSocketServiceHandler> serviceHandler) {
   TcpConnectionAcceptor::Options opts;
-  opts.threads = 3;
+  opts.threads = 10;
+  opts.backlog = 200;
   opts.address = folly::SocketAddress("::", 0);
   auto rs = RSocket::createServer(
       std::make_unique<TcpConnectionAcceptor>(std::move(opts)));


### PR DESCRIPTION
We can now run resumption test with multiple clients against a single server.  It defaults to 5 clients running against a multi-threaded (10 threads) server.  Each client creates 3 streams at various points of time and cold-resumes twice during its lifetime.

I stress tested on my laptop by running 125 clients simultaneously (after that it hits system limits).  I ran 1000 iterations of the setup.

I kept repeating the experiments till there were no issues.

The bug fix descriptions are inline