### PR TITLE
BaseSubscriber

### DIFF
--- a/benchmarks/Throughput.h
+++ b/benchmarks/Throughput.h
@@ -41,8 +41,10 @@ class BoundedSubscriber : public yarpl::flowable::LegacySubscriber<Payload> {
 
   void onSubscribe(
       yarpl::Reference<yarpl::flowable::Subscription> subscription) override {
-    yarpl::flowable::LegacySubscriber<Payload>::onSubscribe(std::move(subscription));
-    yarpl::flowable::LegacySubscriber<Payload>::subscription()->request(requested_);
+    yarpl::flowable::LegacySubscriber<Payload>::onSubscribe(
+        std::move(subscription));
+    yarpl::flowable::LegacySubscriber<Payload>::subscription()->request(
+        requested_);
   }
 
   void onNext(Payload) override {

--- a/benchmarks/Throughput.h
+++ b/benchmarks/Throughput.h
@@ -34,15 +34,15 @@ class FixedResponder : public RSocketResponder {
 
 /// Subscriber that requests N items and cancels the subscription once all of
 /// them arrive.  Signals a latch when it terminates.
-class BoundedSubscriber : public yarpl::flowable::Subscriber<Payload> {
+class BoundedSubscriber : public yarpl::flowable::LegacySubscriber<Payload> {
  public:
   BoundedSubscriber(Latch& latch, size_t requested)
       : latch_{latch}, requested_{requested} {}
 
   void onSubscribe(
       yarpl::Reference<yarpl::flowable::Subscription> subscription) override {
-    yarpl::flowable::Subscriber<Payload>::onSubscribe(std::move(subscription));
-    yarpl::flowable::Subscriber<Payload>::subscription()->request(requested_);
+    yarpl::flowable::LegacySubscriber<Payload>::onSubscribe(std::move(subscription));
+    yarpl::flowable::LegacySubscriber<Payload>::subscription()->request(requested_);
   }
 
   void onNext(Payload) override {
@@ -51,19 +51,19 @@ class BoundedSubscriber : public yarpl::flowable::Subscriber<Payload> {
       latch_.post();
 
       // After this cancel we could be destroyed.
-      yarpl::flowable::Subscriber<Payload>::subscription()->cancel();
+      yarpl::flowable::LegacySubscriber<Payload>::subscription()->cancel();
     }
   }
 
   void onComplete() override {
-    yarpl::flowable::Subscriber<Payload>::onComplete();
+    yarpl::flowable::LegacySubscriber<Payload>::onComplete();
     if (!terminated_.exchange(true)) {
       latch_.post();
     }
   }
 
   void onError(folly::exception_wrapper) override {
-    yarpl::flowable::Subscriber<Payload>::onError({});
+    yarpl::flowable::LegacySubscriber<Payload>::onError({});
     if (!terminated_.exchange(true)) {
       latch_.post();
     }

--- a/benchmarks/Throughput.h
+++ b/benchmarks/Throughput.h
@@ -34,16 +34,16 @@ class FixedResponder : public RSocketResponder {
 
 /// Subscriber that requests N items and cancels the subscription once all of
 /// them arrive.  Signals a latch when it terminates.
-class BoundedSubscriber : public yarpl::flowable::LegacySubscriber<Payload> {
+class BoundedSubscriber : public yarpl::flowable::InternalSubscriber<Payload> {
  public:
   BoundedSubscriber(Latch& latch, size_t requested)
       : latch_{latch}, requested_{requested} {}
 
   void onSubscribe(
       yarpl::Reference<yarpl::flowable::Subscription> subscription) override {
-    yarpl::flowable::LegacySubscriber<Payload>::onSubscribe(
+    yarpl::flowable::InternalSubscriber<Payload>::onSubscribe(
         std::move(subscription));
-    yarpl::flowable::LegacySubscriber<Payload>::subscription()->request(
+    yarpl::flowable::InternalSubscriber<Payload>::subscription()->request(
         requested_);
   }
 
@@ -53,19 +53,19 @@ class BoundedSubscriber : public yarpl::flowable::LegacySubscriber<Payload> {
       latch_.post();
 
       // After this cancel we could be destroyed.
-      yarpl::flowable::LegacySubscriber<Payload>::subscription()->cancel();
+      yarpl::flowable::InternalSubscriber<Payload>::subscription()->cancel();
     }
   }
 
   void onComplete() override {
-    yarpl::flowable::LegacySubscriber<Payload>::onComplete();
+    yarpl::flowable::InternalSubscriber<Payload>::onComplete();
     if (!terminated_.exchange(true)) {
       latch_.post();
     }
   }
 
   void onError(folly::exception_wrapper) override {
-    yarpl::flowable::LegacySubscriber<Payload>::onError({});
+    yarpl::flowable::InternalSubscriber<Payload>::onError({});
     if (!terminated_.exchange(true)) {
       latch_.post();
     }

--- a/examples/resumption/ColdResumption_Client.cpp
+++ b/examples/resumption/ColdResumption_Client.cpp
@@ -22,7 +22,8 @@ typedef std::map<std::string, Reference<Subscriber<Payload>>> HelloSubscribers;
 
 namespace {
 
-class HelloSubscriber : public virtual Refcounted, public LegacySubscriber<Payload> {
+class HelloSubscriber : public virtual Refcounted,
+                        public LegacySubscriber<Payload> {
  public:
   void request(int n) {
     while (!LegacySubscriber<Payload>::subscription()) {

--- a/examples/resumption/ColdResumption_Client.cpp
+++ b/examples/resumption/ColdResumption_Client.cpp
@@ -23,13 +23,13 @@ typedef std::map<std::string, Reference<Subscriber<Payload>>> HelloSubscribers;
 namespace {
 
 class HelloSubscriber : public virtual Refcounted,
-                        public LegacySubscriber<Payload> {
+                        public InternalSubscriber<Payload> {
  public:
   void request(int n) {
-    while (!LegacySubscriber<Payload>::subscription()) {
+    while (!InternalSubscriber<Payload>::subscription()) {
       std::this_thread::yield();
     }
-    LegacySubscriber<Payload>::subscription()->request(n);
+    InternalSubscriber<Payload>::subscription()->request(n);
   }
 
   int rcvdCount() const {
@@ -38,7 +38,7 @@ class HelloSubscriber : public virtual Refcounted,
 
  protected:
   void onSubscribe(Reference<Subscription> subscription) noexcept override {
-    LegacySubscriber<rsocket::Payload>::onSubscribe(subscription);
+    InternalSubscriber<rsocket::Payload>::onSubscribe(subscription);
   }
 
   void onNext(Payload) noexcept override {

--- a/examples/resumption/ColdResumption_Client.cpp
+++ b/examples/resumption/ColdResumption_Client.cpp
@@ -22,13 +22,13 @@ typedef std::map<std::string, Reference<Subscriber<Payload>>> HelloSubscribers;
 
 namespace {
 
-class HelloSubscriber : public virtual Refcounted, public Subscriber<Payload> {
+class HelloSubscriber : public virtual Refcounted, public LegacySubscriber<Payload> {
  public:
   void request(int n) {
-    while (!Subscriber<Payload>::subscription()) {
+    while (!LegacySubscriber<Payload>::subscription()) {
       std::this_thread::yield();
     }
-    Subscriber<Payload>::subscription()->request(n);
+    LegacySubscriber<Payload>::subscription()->request(n);
   }
 
   int rcvdCount() const {
@@ -37,7 +37,7 @@ class HelloSubscriber : public virtual Refcounted, public Subscriber<Payload> {
 
  protected:
   void onSubscribe(Reference<Subscription> subscription) noexcept override {
-    Subscriber<rsocket::Payload>::onSubscribe(subscription);
+    LegacySubscriber<rsocket::Payload>::onSubscribe(subscription);
   }
 
   void onNext(Payload) noexcept override {

--- a/examples/resumption/WarmResumption_Client.cpp
+++ b/examples/resumption/WarmResumption_Client.cpp
@@ -22,7 +22,7 @@ DEFINE_int32(port, 9898, "host:port to connect to");
 namespace {
 
 class HelloSubscriber : public virtual yarpl::Refcounted,
-                        public yarpl::flowable::Subscriber<Payload> {
+                        public yarpl::flowable::LegacySubscriber<Payload> {
  public:
   void request(int n) {
     LOG(INFO) << "... requesting " << n;

--- a/examples/resumption/WarmResumption_Client.cpp
+++ b/examples/resumption/WarmResumption_Client.cpp
@@ -22,7 +22,7 @@ DEFINE_int32(port, 9898, "host:port to connect to");
 namespace {
 
 class HelloSubscriber : public virtual yarpl::Refcounted,
-                        public yarpl::flowable::LegacySubscriber<Payload> {
+                        public yarpl::flowable::InternalSubscriber<Payload> {
  public:
   void request(int n) {
     LOG(INFO) << "... requesting " << n;

--- a/examples/util/ExampleSubscriber.h
+++ b/examples/util/ExampleSubscriber.h
@@ -16,7 +16,7 @@
  */
 namespace rsocket_example {
 class ExampleSubscriber
-    : public yarpl::flowable::LegacySubscriber<rsocket::Payload> {
+    : public yarpl::flowable::InternalSubscriber<rsocket::Payload> {
  public:
   ~ExampleSubscriber();
   ExampleSubscriber(int initialRequest, int numToTake);

--- a/examples/util/ExampleSubscriber.h
+++ b/examples/util/ExampleSubscriber.h
@@ -15,7 +15,8 @@
  * Request 5 items to begin with, then 3 more after each receipt of 3.
  */
 namespace rsocket_example {
-class ExampleSubscriber : public yarpl::flowable::LegacySubscriber<rsocket::Payload> {
+class ExampleSubscriber
+    : public yarpl::flowable::LegacySubscriber<rsocket::Payload> {
  public:
   ~ExampleSubscriber();
   ExampleSubscriber(int initialRequest, int numToTake);

--- a/examples/util/ExampleSubscriber.h
+++ b/examples/util/ExampleSubscriber.h
@@ -15,7 +15,7 @@
  * Request 5 items to begin with, then 3 more after each receipt of 3.
  */
 namespace rsocket_example {
-class ExampleSubscriber : public yarpl::flowable::Subscriber<rsocket::Payload> {
+class ExampleSubscriber : public yarpl::flowable::LegacySubscriber<rsocket::Payload> {
  public:
   ~ExampleSubscriber();
   ExampleSubscriber(int initialRequest, int numToTake);

--- a/rsocket/DuplexConnection.h
+++ b/rsocket/DuplexConnection.h
@@ -29,7 +29,8 @@ namespace rsocket {
 /// before the connection is destroyed.
 class DuplexConnection {
  public:
-  using LegacySubscriber = yarpl::flowable::LegacySubscriber<std::unique_ptr<folly::IOBuf>>;
+  using LegacySubscriber =
+      yarpl::flowable::LegacySubscriber<std::unique_ptr<folly::IOBuf>>;
   using Subscriber = yarpl::flowable::Subscriber<std::unique_ptr<folly::IOBuf>>;
 
   virtual ~DuplexConnection() = default;

--- a/rsocket/DuplexConnection.h
+++ b/rsocket/DuplexConnection.h
@@ -29,6 +29,7 @@ namespace rsocket {
 /// before the connection is destroyed.
 class DuplexConnection {
  public:
+  using LegacySubscriber = yarpl::flowable::LegacySubscriber<std::unique_ptr<folly::IOBuf>>;
   using Subscriber = yarpl::flowable::Subscriber<std::unique_ptr<folly::IOBuf>>;
 
   virtual ~DuplexConnection() = default;

--- a/rsocket/DuplexConnection.h
+++ b/rsocket/DuplexConnection.h
@@ -29,8 +29,8 @@ namespace rsocket {
 /// before the connection is destroyed.
 class DuplexConnection {
  public:
-  using LegacySubscriber =
-      yarpl::flowable::LegacySubscriber<std::unique_ptr<folly::IOBuf>>;
+  using InternalSubscriber =
+      yarpl::flowable::InternalSubscriber<std::unique_ptr<folly::IOBuf>>;
   using Subscriber = yarpl::flowable::Subscriber<std::unique_ptr<folly::IOBuf>>;
 
   virtual ~DuplexConnection() = default;

--- a/rsocket/RSocketResponder.cpp
+++ b/rsocket/RSocketResponder.cpp
@@ -45,7 +45,7 @@ RSocketResponder::handleRequestChannelCore(
     const yarpl::Reference<yarpl::flowable::Subscriber<Payload>>&
         response) noexcept {
   class EagerSubscriberBridge
-      : public yarpl::flowable::Subscriber<rsocket::Payload> {
+      : public yarpl::flowable::LegacySubscriber<rsocket::Payload> {
    public:
     void onSubscribe(yarpl::Reference<yarpl::flowable::Subscription>
                          subscription) noexcept override {

--- a/rsocket/RSocketResponder.cpp
+++ b/rsocket/RSocketResponder.cpp
@@ -45,7 +45,7 @@ RSocketResponder::handleRequestChannelCore(
     const yarpl::Reference<yarpl::flowable::Subscriber<Payload>>&
         response) noexcept {
   class EagerSubscriberBridge
-      : public yarpl::flowable::LegacySubscriber<rsocket::Payload> {
+      : public yarpl::flowable::InternalSubscriber<rsocket::Payload> {
    public:
     void onSubscribe(yarpl::Reference<yarpl::flowable::Subscription>
                          subscription) noexcept override {

--- a/rsocket/framing/FramedReader.cpp
+++ b/rsocket/framing/FramedReader.cpp
@@ -67,7 +67,7 @@ size_t FramedReader::readFrameLength() const {
 }
 
 void FramedReader::onSubscribe(yarpl::Reference<Subscription> subscription) {
-  DuplexConnection::LegacySubscriber::onSubscribe(subscription);
+  DuplexConnection::InternalSubscriber::onSubscribe(subscription);
   subscription->request(std::numeric_limits<int64_t>::max());
 }
 
@@ -131,7 +131,7 @@ void FramedReader::parseFrames() {
 
 void FramedReader::onComplete() {
   payloadQueue_.move();
-  DuplexConnection::LegacySubscriber::onComplete();
+  DuplexConnection::InternalSubscriber::onComplete();
   if (auto subscriber = std::move(inner_)) {
     // After this call the instance can be destroyed!
     subscriber->onComplete();
@@ -140,7 +140,7 @@ void FramedReader::onComplete() {
 
 void FramedReader::onError(folly::exception_wrapper ex) {
   payloadQueue_.move();
-  DuplexConnection::LegacySubscriber::onError({});
+  DuplexConnection::InternalSubscriber::onError({});
   if (auto subscriber = std::move(inner_)) {
     // After this call the instance can be destroyed!
     subscriber->onError(std::move(ex));
@@ -205,8 +205,8 @@ void FramedReader::error(std::string errorMsg) {
   VLOG(1) << "error: " << errorMsg;
 
   payloadQueue_.move();
-  if (DuplexConnection::LegacySubscriber::subscription()) {
-    DuplexConnection::LegacySubscriber::subscription()->cancel();
+  if (DuplexConnection::InternalSubscriber::subscription()) {
+    DuplexConnection::InternalSubscriber::subscription()->cancel();
   }
   if (auto subscriber = std::move(inner_)) {
     // After this call the instance can be destroyed!

--- a/rsocket/framing/FramedReader.cpp
+++ b/rsocket/framing/FramedReader.cpp
@@ -67,7 +67,7 @@ size_t FramedReader::readFrameLength() const {
 }
 
 void FramedReader::onSubscribe(yarpl::Reference<Subscription> subscription) {
-  DuplexConnection::Subscriber::onSubscribe(subscription);
+  DuplexConnection::LegacySubscriber::onSubscribe(subscription);
   subscription->request(std::numeric_limits<int64_t>::max());
 }
 
@@ -131,7 +131,7 @@ void FramedReader::parseFrames() {
 
 void FramedReader::onComplete() {
   payloadQueue_.move();
-  DuplexConnection::Subscriber::onComplete();
+  DuplexConnection::LegacySubscriber::onComplete();
   if (auto subscriber = std::move(inner_)) {
     // After this call the instance can be destroyed!
     subscriber->onComplete();
@@ -140,7 +140,7 @@ void FramedReader::onComplete() {
 
 void FramedReader::onError(folly::exception_wrapper ex) {
   payloadQueue_.move();
-  DuplexConnection::Subscriber::onError({});
+  DuplexConnection::LegacySubscriber::onError({});
   if (auto subscriber = std::move(inner_)) {
     // After this call the instance can be destroyed!
     subscriber->onError(std::move(ex));
@@ -205,8 +205,8 @@ void FramedReader::error(std::string errorMsg) {
   VLOG(1) << "error: " << errorMsg;
 
   payloadQueue_.move();
-  if (DuplexConnection::Subscriber::subscription()) {
-    DuplexConnection::Subscriber::subscription()->cancel();
+  if (DuplexConnection::LegacySubscriber::subscription()) {
+    DuplexConnection::LegacySubscriber::subscription()->cancel();
   }
   if (auto subscriber = std::move(inner_)) {
     // After this call the instance can be destroyed!

--- a/rsocket/framing/FramedReader.h
+++ b/rsocket/framing/FramedReader.h
@@ -11,7 +11,7 @@
 
 namespace rsocket {
 
-class FramedReader : public DuplexConnection::LegacySubscriber,
+class FramedReader : public DuplexConnection::InternalSubscriber,
                      public yarpl::flowable::Subscription {
  public:
   explicit FramedReader(std::shared_ptr<ProtocolVersion> version)

--- a/rsocket/framing/FramedReader.h
+++ b/rsocket/framing/FramedReader.h
@@ -11,7 +11,7 @@
 
 namespace rsocket {
 
-class FramedReader : public DuplexConnection::Subscriber,
+class FramedReader : public DuplexConnection::LegacySubscriber,
                      public yarpl::flowable::Subscription {
  public:
   explicit FramedReader(std::shared_ptr<ProtocolVersion> version)

--- a/rsocket/framing/FramedWriter.cpp
+++ b/rsocket/framing/FramedWriter.cpp
@@ -50,7 +50,7 @@ size_t FramedWriter::getPayloadLength(size_t payloadLength) const {
 }
 
 void FramedWriter::onSubscribe(yarpl::Reference<Subscription> subscription) {
-  DuplexConnection::Subscriber::onSubscribe(subscription);
+  DuplexConnection::LegacySubscriber::onSubscribe(subscription);
   stream_->onSubscribe(std::move(subscription));
 }
 
@@ -112,17 +112,17 @@ void FramedWriter::onNextMultiple(
 void FramedWriter::error(std::string errorMsg) {
   VLOG(1) << "error: " << errorMsg;
   onError(std::runtime_error(std::move(errorMsg)));
-  DuplexConnection::Subscriber::subscription()->cancel();
+  DuplexConnection::LegacySubscriber::subscription()->cancel();
 }
 
 void FramedWriter::onComplete() {
-  DuplexConnection::Subscriber::onComplete();
+  DuplexConnection::LegacySubscriber::onComplete();
   stream_->onComplete();
   stream_ = nullptr;
 }
 
 void FramedWriter::onError(folly::exception_wrapper ex) {
-  DuplexConnection::Subscriber::onError(ex);
+  DuplexConnection::LegacySubscriber::onError(ex);
   stream_->onError(std::move(ex));
   stream_ = nullptr;
 }

--- a/rsocket/framing/FramedWriter.cpp
+++ b/rsocket/framing/FramedWriter.cpp
@@ -50,7 +50,7 @@ size_t FramedWriter::getPayloadLength(size_t payloadLength) const {
 }
 
 void FramedWriter::onSubscribe(yarpl::Reference<Subscription> subscription) {
-  DuplexConnection::LegacySubscriber::onSubscribe(subscription);
+  DuplexConnection::InternalSubscriber::onSubscribe(subscription);
   stream_->onSubscribe(std::move(subscription));
 }
 
@@ -112,17 +112,17 @@ void FramedWriter::onNextMultiple(
 void FramedWriter::error(std::string errorMsg) {
   VLOG(1) << "error: " << errorMsg;
   onError(std::runtime_error(std::move(errorMsg)));
-  DuplexConnection::LegacySubscriber::subscription()->cancel();
+  DuplexConnection::InternalSubscriber::subscription()->cancel();
 }
 
 void FramedWriter::onComplete() {
-  DuplexConnection::LegacySubscriber::onComplete();
+  DuplexConnection::InternalSubscriber::onComplete();
   stream_->onComplete();
   stream_ = nullptr;
 }
 
 void FramedWriter::onError(folly::exception_wrapper ex) {
-  DuplexConnection::LegacySubscriber::onError(ex);
+  DuplexConnection::InternalSubscriber::onError(ex);
   stream_->onError(std::move(ex));
   stream_ = nullptr;
 }

--- a/rsocket/framing/FramedWriter.h
+++ b/rsocket/framing/FramedWriter.h
@@ -12,7 +12,7 @@ namespace rsocket {
 
 struct ProtocolVersion;
 
-class FramedWriter : public DuplexConnection::Subscriber {
+class FramedWriter : public DuplexConnection::LegacySubscriber {
  public:
   explicit FramedWriter(
       yarpl::Reference<DuplexConnection::Subscriber> stream,

--- a/rsocket/framing/FramedWriter.h
+++ b/rsocket/framing/FramedWriter.h
@@ -12,7 +12,7 @@ namespace rsocket {
 
 struct ProtocolVersion;
 
-class FramedWriter : public DuplexConnection::LegacySubscriber {
+class FramedWriter : public DuplexConnection::InternalSubscriber {
  public:
   explicit FramedWriter(
       yarpl::Reference<DuplexConnection::Subscriber> stream,

--- a/rsocket/internal/ScheduledSubscriber.h
+++ b/rsocket/internal/ScheduledSubscriber.h
@@ -18,7 +18,7 @@ namespace rsocket {
 // right EventBase.
 //
 
-template<typename T>
+template <typename T>
 class ScheduledSubscriber : public yarpl::flowable::LegacySubscriber<T> {
  public:
   ScheduledSubscriber(
@@ -87,8 +87,9 @@ class ScheduledSubscriber : public yarpl::flowable::LegacySubscriber<T> {
 // wrapped in the ScheduledSubscription since the application code calls
 // request and cancel from any thread.
 //
-template<typename T>
-class ScheduledSubscriptionSubscriber : public yarpl::flowable::LegacySubscriber<T> {
+template <typename T>
+class ScheduledSubscriptionSubscriber
+    : public yarpl::flowable::LegacySubscriber<T> {
  public:
   ScheduledSubscriptionSubscriber(
       yarpl::Reference<yarpl::flowable::Subscriber<T>> inner,

--- a/rsocket/internal/ScheduledSubscriber.h
+++ b/rsocket/internal/ScheduledSubscriber.h
@@ -19,7 +19,7 @@ namespace rsocket {
 //
 
 template<typename T>
-class ScheduledSubscriber : public yarpl::flowable::Subscriber<T> {
+class ScheduledSubscriber : public yarpl::flowable::LegacySubscriber<T> {
  public:
   ScheduledSubscriber(
       yarpl::Reference<yarpl::flowable::Subscriber<T>> inner,
@@ -88,7 +88,7 @@ class ScheduledSubscriber : public yarpl::flowable::Subscriber<T> {
 // request and cancel from any thread.
 //
 template<typename T>
-class ScheduledSubscriptionSubscriber : public yarpl::flowable::Subscriber<T> {
+class ScheduledSubscriptionSubscriber : public yarpl::flowable::LegacySubscriber<T> {
  public:
   ScheduledSubscriptionSubscriber(
       yarpl::Reference<yarpl::flowable::Subscriber<T>> inner,

--- a/rsocket/internal/ScheduledSubscriber.h
+++ b/rsocket/internal/ScheduledSubscriber.h
@@ -19,7 +19,7 @@ namespace rsocket {
 //
 
 template <typename T>
-class ScheduledSubscriber : public yarpl::flowable::LegacySubscriber<T> {
+class ScheduledSubscriber : public yarpl::flowable::InternalSubscriber<T> {
  public:
   ScheduledSubscriber(
       yarpl::Reference<yarpl::flowable::Subscriber<T>> inner,
@@ -89,7 +89,7 @@ class ScheduledSubscriber : public yarpl::flowable::LegacySubscriber<T> {
 //
 template <typename T>
 class ScheduledSubscriptionSubscriber
-    : public yarpl::flowable::LegacySubscriber<T> {
+    : public yarpl::flowable::InternalSubscriber<T> {
  public:
   ScheduledSubscriptionSubscriber(
       yarpl::Reference<yarpl::flowable::Subscriber<T>> inner,

--- a/rsocket/internal/SetupResumeAcceptor.cpp
+++ b/rsocket/internal/SetupResumeAcceptor.cpp
@@ -44,7 +44,7 @@ void closeWithError(
 
 /// Subscriber that owns a connection, sets itself as that connection's input,
 /// and reads out a single frame before cancelling.
-class OneFrameSubscriber : public DuplexConnection::Subscriber {
+class OneFrameSubscriber : public DuplexConnection::InternalSubscriber {
  public:
   OneFrameSubscriber(
       SetupResumeAcceptor& acceptor,
@@ -65,7 +65,7 @@ class OneFrameSubscriber : public DuplexConnection::Subscriber {
   }
 
   void onSubscribe(yarpl::Reference<yarpl::flowable::Subscription> sub) override {
-    DuplexConnection::Subscriber::onSubscribe(sub);
+    DuplexConnection::InternalSubscriber::onSubscribe(sub);
     sub->request(std::numeric_limits<int32_t>::max());
   }
 
@@ -75,7 +75,7 @@ class OneFrameSubscriber : public DuplexConnection::Subscriber {
     auto self = ref_from_this(this);
     acceptor_.remove(self);
 
-    if (auto sub = DuplexConnection::Subscriber::subscription()) {
+    if (auto sub = DuplexConnection::InternalSubscriber::subscription()) {
       sub->cancel();
     }
 
@@ -88,13 +88,13 @@ class OneFrameSubscriber : public DuplexConnection::Subscriber {
 
   void onComplete() override {
     auto self = ref_from_this(this);
-    DuplexConnection::Subscriber::onComplete();
+    DuplexConnection::InternalSubscriber::onComplete();
     acceptor_.remove(self);
   }
 
   void onError(folly::exception_wrapper ew) override {
     auto self = ref_from_this(this);
-    DuplexConnection::Subscriber::onError(std::move(ew));
+    DuplexConnection::InternalSubscriber::onError(std::move(ew));
     acceptor_.remove(self);
   }
 

--- a/rsocket/statemachine/ChannelRequester.h
+++ b/rsocket/statemachine/ChannelRequester.h
@@ -12,7 +12,7 @@ namespace rsocket {
 /// Implementation of stream stateMachine that represents a Channel requester.
 class ChannelRequester : public ConsumerBase,
                          public PublisherBase,
-                         public yarpl::flowable::LegacySubscriber<Payload> {
+                         public yarpl::flowable::InternalSubscriber<Payload> {
  public:
   ChannelRequester(std::shared_ptr<StreamsWriter> writer, StreamId streamId)
       : ConsumerBase(std::move(writer), streamId),

--- a/rsocket/statemachine/ChannelRequester.h
+++ b/rsocket/statemachine/ChannelRequester.h
@@ -12,7 +12,7 @@ namespace rsocket {
 /// Implementation of stream stateMachine that represents a Channel requester.
 class ChannelRequester : public ConsumerBase,
                          public PublisherBase,
-                         public yarpl::flowable::Subscriber<Payload> {
+                         public yarpl::flowable::LegacySubscriber<Payload> {
  public:
   ChannelRequester(std::shared_ptr<StreamsWriter> writer, StreamId streamId)
       : ConsumerBase(std::move(writer), streamId),

--- a/rsocket/statemachine/ChannelResponder.h
+++ b/rsocket/statemachine/ChannelResponder.h
@@ -13,7 +13,7 @@ namespace rsocket {
 /// Implementation of stream stateMachine that represents a Channel responder.
 class ChannelResponder : public ConsumerBase,
                          public PublisherBase,
-                         public yarpl::flowable::Subscriber<Payload> {
+                         public yarpl::flowable::LegacySubscriber<Payload> {
  public:
   ChannelResponder(
       std::shared_ptr<StreamsWriter> writer,

--- a/rsocket/statemachine/ChannelResponder.h
+++ b/rsocket/statemachine/ChannelResponder.h
@@ -13,7 +13,7 @@ namespace rsocket {
 /// Implementation of stream stateMachine that represents a Channel responder.
 class ChannelResponder : public ConsumerBase,
                          public PublisherBase,
-                         public yarpl::flowable::LegacySubscriber<Payload> {
+                         public yarpl::flowable::InternalSubscriber<Payload> {
  public:
   ChannelResponder(
       std::shared_ptr<StreamsWriter> writer,

--- a/rsocket/statemachine/StreamResponder.h
+++ b/rsocket/statemachine/StreamResponder.h
@@ -11,7 +11,7 @@ namespace rsocket {
 /// Implementation of stream stateMachine that represents a Stream responder
 class StreamResponder : public StreamStateMachineBase,
                         public PublisherBase,
-                        public yarpl::flowable::LegacySubscriber<Payload> {
+                        public yarpl::flowable::InternalSubscriber<Payload> {
  public:
   StreamResponder(
       std::shared_ptr<StreamsWriter> writer,

--- a/rsocket/statemachine/StreamResponder.h
+++ b/rsocket/statemachine/StreamResponder.h
@@ -11,7 +11,7 @@ namespace rsocket {
 /// Implementation of stream stateMachine that represents a Stream responder
 class StreamResponder : public StreamStateMachineBase,
                         public PublisherBase,
-                        public yarpl::flowable::Subscriber<Payload> {
+                        public yarpl::flowable::LegacySubscriber<Payload> {
  public:
   StreamResponder(
       std::shared_ptr<StreamsWriter> writer,

--- a/test/ColdResumptionTest.cpp
+++ b/test/ColdResumptionTest.cpp
@@ -21,13 +21,13 @@ using namespace yarpl::flowable;
 typedef std::map<std::string, Reference<Subscriber<Payload>>> HelloSubscribers;
 
 namespace {
-class HelloSubscriber : public Subscriber<Payload> {
+class HelloSubscriber : public LegacySubscriber<Payload> {
  public:
   explicit HelloSubscriber(size_t latestValue) : latestValue_(latestValue) {}
 
   void request(int n) {
     subscribedBaton_.wait();
-    Subscriber<Payload>::subscription()->request(n);
+    LegacySubscriber<Payload>::subscription()->request(n);
   }
 
   void awaitLatestValue(size_t value) {
@@ -51,7 +51,7 @@ class HelloSubscriber : public Subscriber<Payload> {
 
  protected:
   void onSubscribe(Reference<Subscription> subscription) noexcept override {
-    Subscriber<rsocket::Payload>::onSubscribe(subscription);
+    LegacySubscriber<rsocket::Payload>::onSubscribe(subscription);
     subscribedBaton_.post();
   }
 

--- a/test/ColdResumptionTest.cpp
+++ b/test/ColdResumptionTest.cpp
@@ -21,13 +21,13 @@ using namespace yarpl::flowable;
 typedef std::map<std::string, Reference<Subscriber<Payload>>> HelloSubscribers;
 
 namespace {
-class HelloSubscriber : public LegacySubscriber<Payload> {
+class HelloSubscriber : public InternalSubscriber<Payload> {
  public:
   explicit HelloSubscriber(size_t latestValue) : latestValue_(latestValue) {}
 
   void request(int n) {
     subscribedBaton_.wait();
-    LegacySubscriber<Payload>::subscription()->request(n);
+    InternalSubscriber<Payload>::subscription()->request(n);
   }
 
   void awaitLatestValue(size_t value) {
@@ -51,7 +51,7 @@ class HelloSubscriber : public LegacySubscriber<Payload> {
 
  protected:
   void onSubscribe(Reference<Subscription> subscription) noexcept override {
-    LegacySubscriber<rsocket::Payload>::onSubscribe(subscription);
+    InternalSubscriber<rsocket::Payload>::onSubscribe(subscription);
     subscribedBaton_.post();
   }
 

--- a/test/fuzzers/frame_fuzzer.cpp
+++ b/test/fuzzers/frame_fuzzer.cpp
@@ -31,7 +31,7 @@ struct FuzzerConnectionAcceptor : rsocket::ConnectionAcceptor {
 struct FuzzerDuplexConnection : rsocket::DuplexConnection {
   using Subscriber = rsocket::DuplexConnection::Subscriber;
 
-  struct SinkSubscriber : LegacySubscriber {
+  struct SinkSubscriber : InternalSubscriber {
     std::vector<std::unique_ptr<folly::IOBuf>> sent_buffers;
 
     void onNext(std::unique_ptr<folly::IOBuf> buf) {

--- a/test/fuzzers/frame_fuzzer.cpp
+++ b/test/fuzzers/frame_fuzzer.cpp
@@ -31,7 +31,7 @@ struct FuzzerConnectionAcceptor : rsocket::ConnectionAcceptor {
 struct FuzzerDuplexConnection : rsocket::DuplexConnection {
   using Subscriber = rsocket::DuplexConnection::Subscriber;
 
-  struct SinkSubscriber : Subscriber {
+  struct SinkSubscriber : LegacySubscriber {
     std::vector<std::unique_ptr<folly::IOBuf>> sent_buffers;
 
     void onNext(std::unique_ptr<folly::IOBuf> buf) {

--- a/test/test_utils/MockDuplexConnection.h
+++ b/test/test_utils/MockDuplexConnection.h
@@ -11,8 +11,8 @@ namespace rsocket {
 
 class MockDuplexConnection : public DuplexConnection {
 public:
- using LegacySubscriber =
-     yarpl::flowable::LegacySubscriber<std::unique_ptr<folly::IOBuf>>;
+ using InternalSubscriber =
+     yarpl::flowable::InternalSubscriber<std::unique_ptr<folly::IOBuf>>;
  using Subscriber = yarpl::flowable::Subscriber<std::unique_ptr<folly::IOBuf>>;
 
  MockDuplexConnection() {

--- a/test/test_utils/MockDuplexConnection.h
+++ b/test/test_utils/MockDuplexConnection.h
@@ -11,14 +11,15 @@ namespace rsocket {
 
 class MockDuplexConnection : public DuplexConnection {
 public:
-  using LegacySubscriber = yarpl::flowable::LegacySubscriber<std::unique_ptr<folly::IOBuf>>;
-  using Subscriber = yarpl::flowable::Subscriber<std::unique_ptr<folly::IOBuf>>;
+ using LegacySubscriber =
+     yarpl::flowable::LegacySubscriber<std::unique_ptr<folly::IOBuf>>;
+ using Subscriber = yarpl::flowable::Subscriber<std::unique_ptr<folly::IOBuf>>;
 
-  MockDuplexConnection() {
-    ON_CALL(*this, getOutput_()).WillByDefault(testing::Invoke([] {
-      return yarpl::make_ref<
-          yarpl::mocks::MockSubscriber<std::unique_ptr<folly::IOBuf>>>();
-    }));
+ MockDuplexConnection() {
+   ON_CALL(*this, getOutput_()).WillByDefault(testing::Invoke([] {
+     return yarpl::make_ref<
+         yarpl::mocks::MockSubscriber<std::unique_ptr<folly::IOBuf>>>();
+   }));
   }
 
   /// Creates a DuplexConnection that always runs `in` on the input

--- a/test/test_utils/MockDuplexConnection.h
+++ b/test/test_utils/MockDuplexConnection.h
@@ -11,6 +11,7 @@ namespace rsocket {
 
 class MockDuplexConnection : public DuplexConnection {
 public:
+  using LegacySubscriber = yarpl::flowable::LegacySubscriber<std::unique_ptr<folly::IOBuf>>;
   using Subscriber = yarpl::flowable::Subscriber<std::unique_ptr<folly::IOBuf>>;
 
   MockDuplexConnection() {

--- a/test/test_utils/PrintSubscriber.h
+++ b/test/test_utils/PrintSubscriber.h
@@ -6,7 +6,7 @@
 #include "yarpl/flowable/Subscriber.h"
 
 namespace rsocket {
-class PrintSubscriber : public yarpl::flowable::LegacySubscriber<Payload> {
+class PrintSubscriber : public yarpl::flowable::InternalSubscriber<Payload> {
  public:
   ~PrintSubscriber();
 

--- a/test/test_utils/PrintSubscriber.h
+++ b/test/test_utils/PrintSubscriber.h
@@ -6,7 +6,7 @@
 #include "yarpl/flowable/Subscriber.h"
 
 namespace rsocket {
-class PrintSubscriber : public yarpl::flowable::Subscriber<Payload> {
+class PrintSubscriber : public yarpl::flowable::LegacySubscriber<Payload> {
  public:
   ~PrintSubscriber();
 

--- a/yarpl/CMakeLists.txt
+++ b/yarpl/CMakeLists.txt
@@ -125,6 +125,7 @@ add_executable(
   test/ReferenceTest.cpp
   test/SubscribeObserveOnTests.cpp
   test/Single_test.cpp
+  test/FlowableSubscriberTest.cpp
   test/credits-test.cpp
   test/yarpl-tests.cpp)
 

--- a/yarpl/include/yarpl/flowable/CancelingSubscriber.h
+++ b/yarpl/include/yarpl/flowable/CancelingSubscriber.h
@@ -13,7 +13,7 @@ namespace flowable {
  * A Subscriber that always cancels the subscription passed to it.
  */
 template <typename T>
-class CancelingSubscriber final : public Subscriber<T> {
+class CancelingSubscriber final : public LegacySubscriber<T> {
  public:
   void onSubscribe(
       yarpl::Reference<yarpl::flowable::Subscription> sub) override {

--- a/yarpl/include/yarpl/flowable/CancelingSubscriber.h
+++ b/yarpl/include/yarpl/flowable/CancelingSubscriber.h
@@ -13,7 +13,7 @@ namespace flowable {
  * A Subscriber that always cancels the subscription passed to it.
  */
 template <typename T>
-class CancelingSubscriber final : public LegacySubscriber<T> {
+class CancelingSubscriber final : public InternalSubscriber<T> {
  public:
   void onSubscribe(
       yarpl::Reference<yarpl::flowable::Subscription> sub) override {

--- a/yarpl/include/yarpl/flowable/EmitterFlowable.h
+++ b/yarpl/include/yarpl/flowable/EmitterFlowable.h
@@ -31,7 +31,7 @@ class EmiterBase : public virtual Refcounted {
  * of a request(n) call.
  */
 template <typename T>
-class EmiterSubscription : public Subscription, public LegacySubscriber<T> {
+class EmiterSubscription : public Subscription, public InternalSubscriber<T> {
   constexpr static auto kCanceled = credits::kCanceled;
   constexpr static auto kNoFlowControl = credits::kNoFlowControl;
 

--- a/yarpl/include/yarpl/flowable/EmitterFlowable.h
+++ b/yarpl/include/yarpl/flowable/EmitterFlowable.h
@@ -31,7 +31,7 @@ class EmiterBase : public virtual Refcounted {
  * of a request(n) call.
  */
 template <typename T>
-class EmiterSubscription : public Subscription, public Subscriber<T> {
+class EmiterSubscription : public Subscription, public LegacySubscriber<T> {
   constexpr static auto kCanceled = credits::kCanceled;
   constexpr static auto kNoFlowControl = credits::kNoFlowControl;
 

--- a/yarpl/include/yarpl/flowable/FlowableObserveOnOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableObserveOnOperator.h
@@ -39,7 +39,7 @@ class ObserveOnOperatorSubscription : public yarpl::flowable::Subscription,
 };
 
 template <typename T>
-class ObserveOnOperatorSubscriber : public yarpl::flowable::Subscriber<T> {
+class ObserveOnOperatorSubscriber : public yarpl::flowable::LegacySubscriber<T> {
  public:
   ObserveOnOperatorSubscriber(
       Reference<Subscriber<T>> inner,

--- a/yarpl/include/yarpl/flowable/FlowableObserveOnOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableObserveOnOperator.h
@@ -39,7 +39,8 @@ class ObserveOnOperatorSubscription : public yarpl::flowable::Subscription,
 };
 
 template <typename T>
-class ObserveOnOperatorSubscriber : public yarpl::flowable::LegacySubscriber<T> {
+class ObserveOnOperatorSubscriber
+    : public yarpl::flowable::LegacySubscriber<T> {
  public:
   ObserveOnOperatorSubscriber(
       Reference<Subscriber<T>> inner,

--- a/yarpl/include/yarpl/flowable/FlowableObserveOnOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableObserveOnOperator.h
@@ -40,7 +40,7 @@ class ObserveOnOperatorSubscription : public yarpl::flowable::Subscription,
 
 template <typename T>
 class ObserveOnOperatorSubscriber
-    : public yarpl::flowable::LegacySubscriber<T> {
+    : public yarpl::flowable::InternalSubscriber<T> {
  public:
   ObserveOnOperatorSubscriber(
       Reference<Subscriber<T>> inner,

--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -36,7 +36,7 @@ class FlowableOperator : public Flowable<D> {
   /// subscriber for the previous stage; as a subscription for the next one, the
   /// user-supplied subscriber being the last of the pipeline stages.
   class Subscription : public yarpl::flowable::Subscription,
-                       public Subscriber<U> {
+                       public LegacySubscriber<U> {
    protected:
     Subscription(
         Reference<Operator> flowable,

--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -36,7 +36,7 @@ class FlowableOperator : public Flowable<D> {
   /// subscriber for the previous stage; as a subscription for the next one, the
   /// user-supplied subscriber being the last of the pipeline stages.
   class Subscription : public yarpl::flowable::Subscription,
-                       public LegacySubscriber<U> {
+                       public InternalSubscriber<U> {
    protected:
     Subscription(
         Reference<Operator> flowable,

--- a/yarpl/include/yarpl/flowable/Subscriber.h
+++ b/yarpl/include/yarpl/flowable/Subscriber.h
@@ -22,6 +22,7 @@ class Subscriber : public virtual Refcounted, public yarpl::enable_get_ref {
 };
 
 // codemod all things that inherit from Subscriber to inherit from
+// InternalSubscriber
 template <typename T>
 class InternalSubscriber : public Subscriber<T> {
  public:

--- a/yarpl/include/yarpl/flowable/Subscriber.h
+++ b/yarpl/include/yarpl/flowable/Subscriber.h
@@ -57,7 +57,7 @@ class InternalSubscriber : public Subscriber<T> {
 
 // T : Type of Flowable that this Subscriber operates on
 //
-// keep_reference_to_this : SafeSubscriber will keep a live reference to
+// keep_reference_to_this : BaseSubscriber will keep a live reference to
 // itself on the stack while in a signaling or requesting method, in case
 // the derived class causes all other references to itself to be dropped.
 //
@@ -65,7 +65,7 @@ class InternalSubscriber : public Subscriber<T> {
 // use `keep_reference_to_this = false` as an optimization to
 // prevent an atomic inc/dec pair
 template <typename T>
-class SafeSubscriber : public Subscriber<T> {
+class BaseSubscriber : public Subscriber<T> {
  public:
   // Note: If any of the following methods is overridden in a subclass, the new
   // methods SHOULD ensure that these are invoked as well.

--- a/yarpl/include/yarpl/flowable/Subscriber.h
+++ b/yarpl/include/yarpl/flowable/Subscriber.h
@@ -15,40 +15,95 @@ namespace flowable {
 template <typename T>
 class Subscriber : public virtual Refcounted, public yarpl::enable_get_ref {
  public:
+  virtual void onSubscribe(Reference<Subscription>) = 0;
+  virtual void onComplete() = 0;
+  virtual void onError(folly::exception_wrapper) = 0;
+  virtual void onNext(T) = 0;
+};
+
+// codemod all things that inherit from Subscriber to inherit from LegacySubscriber
+template <typename T>
+class LegacySubscriber : public Subscriber<T> {
+ public:
   // Note: If any of the following methods is overridden in a subclass, the new
   // methods SHOULD ensure that these are invoked as well.
-  virtual void onSubscribe(Reference<Subscription> subscription) {
+  void onSubscribe(Reference<Subscription> subscription) override {
     DCHECK(subscription);
-
-    if (subscription_) {
-      subscription->cancel();
-      return;
-    }
-
+    CHECK(!subscription_);
     subscription_ = std::move(subscription);
   }
 
   // No further calls to the subscription after this method is invoked.
-  virtual void onComplete() {
+  void onComplete() override {
     DCHECK(subscription_) << "Calling onComplete() without a subscription";
     subscription_.reset();
   }
 
   // No further calls to the subscription after this method is invoked.
-  virtual void onError(folly::exception_wrapper) {
+  void onError(folly::exception_wrapper) override {
     DCHECK(subscription_) << "Calling onError() without a subscription";
     subscription_.reset();
   }
 
-  virtual void onNext(T) = 0;
-
  protected:
-  Subscription* subscription() {
-    return subscription_.operator->();
+  Reference<Subscription> subscription() {
+    return subscription_;
   }
 
  private:
   Reference<Subscription> subscription_;
 };
-}
-}
+
+template <typename T>
+class SafeSubscriber : public Subscriber<T> {
+ public:
+  // Note: If any of the following methods is overridden in a subclass, the new
+  // methods SHOULD ensure that these are invoked as well.
+  void onSubscribe(Reference<Subscription> subscription) final override {
+    DCHECK(subscription);
+    CHECK(!subscription_);
+    subscription_ = std::move(subscription);
+    onSubscribeImpl();
+  }
+
+  // No further calls to the subscription after this method is invoked.
+  void onComplete() final override {
+    DCHECK(subscription_) << "Calling onComplete() without a subscription";
+    subscription_.reset();
+    onCompleteImpl();
+  }
+
+  // No further calls to the subscription after this method is invoked.
+  void onError(folly::exception_wrapper e) final override {
+    DCHECK(subscription_) << "Calling onError() without a subscription";
+    subscription_.reset();
+    onErrorImpl(std::move(e));
+  }
+
+  void onNext(T t) final override {
+    onNextImpl(std::move(t));
+  }
+
+  virtual void onSubscribeImpl() = 0;
+  virtual void onCompleteImpl() = 0;
+  virtual void onNextImpl(T) = 0;
+  virtual void onErrorImpl(folly::exception_wrapper) = 0;
+
+ protected:
+  Reference<Subscription> subscription() {
+    return subscription_;
+  }
+
+ private:
+  Reference<Subscription> subscription_;
+};
+
+template <typename T>
+class SafeDefaultSubscriber : public SafeSubscriber<T> {
+  void onSubscribeImpl() override {}
+  void onNextImpl(T) override {}
+  void onCompleteImpl() override {}
+  void onErrorImpl(folly::exception_wrapper) override {}
+};
+
+} } /* namespace yarpl::flowable */

--- a/yarpl/include/yarpl/flowable/Subscriber.h
+++ b/yarpl/include/yarpl/flowable/Subscriber.h
@@ -22,7 +22,6 @@ class Subscriber : public virtual Refcounted, public yarpl::enable_get_ref {
 };
 
 // codemod all things that inherit from Subscriber to inherit from
-// InternalSubscriber
 template <typename T>
 class InternalSubscriber : public Subscriber<T> {
  public:

--- a/yarpl/include/yarpl/flowable/TestSubscriber.h
+++ b/yarpl/include/yarpl/flowable/TestSubscriber.h
@@ -26,7 +26,7 @@ namespace flowable {
  * ts->assert...
  */
 template <typename T>
-class TestSubscriber : public LegacySubscriber<T> {
+class TestSubscriber : public InternalSubscriber<T> {
  public:
   static_assert(
       std::is_copy_constructible<T>::value,

--- a/yarpl/include/yarpl/flowable/TestSubscriber.h
+++ b/yarpl/include/yarpl/flowable/TestSubscriber.h
@@ -26,7 +26,7 @@ namespace flowable {
  * ts->assert...
  */
 template <typename T>
-class TestSubscriber : public Subscriber<T> {
+class TestSubscriber : public LegacySubscriber<T> {
  public:
   static_assert(
       std::is_copy_constructible<T>::value,

--- a/yarpl/test/FlowableSubscriberTest.cpp
+++ b/yarpl/test/FlowableSubscriberTest.cpp
@@ -1,0 +1,41 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "yarpl/flowable/Subscriber.h"
+#include "yarpl/test_utils/Mocks.h"
+
+using namespace yarpl;
+using namespace yarpl::flowable;
+using namespace yarpl::mocks;
+using namespace testing;
+
+namespace {
+
+TEST(FlowableSubscriberTest, TestBasicFunctionality) {
+  Sequence subscriber_seq;
+  auto subscriber = yarpl::make_ref<StrictMock<MockSafeSubscriber<int>>>();
+
+  EXPECT_CALL(*subscriber, onSubscribeImpl())
+    .Times(1)
+    .InSequence(subscriber_seq)
+    .WillOnce(Invoke([&] {
+      subscriber->request(3);
+    }));
+  EXPECT_CALL(*subscriber, onNextImpl(5))
+    .Times(1)
+    .InSequence(subscriber_seq);
+  EXPECT_CALL(*subscriber, onCompleteImpl())
+    .Times(1)
+    .InSequence(subscriber_seq);
+
+  auto subscription = yarpl::make_ref<StrictMock<MockSubscription>>();
+  EXPECT_CALL(*subscription, request_(3))
+    .Times(1)
+    .WillOnce(InvokeWithoutArgs([&] {
+      subscriber->onNext(5);
+      subscriber->onComplete();
+    }));
+
+  subscriber->onSubscribe(subscription);
+}
+
+}

--- a/yarpl/test/FlowableSubscriberTest.cpp
+++ b/yarpl/test/FlowableSubscriberTest.cpp
@@ -12,7 +12,7 @@ namespace {
 
 TEST(FlowableSubscriberTest, TestBasicFunctionality) {
   Sequence subscriber_seq;
-  auto subscriber = yarpl::make_ref<StrictMock<MockSafeSubscriber<int>>>();
+  auto subscriber = yarpl::make_ref<StrictMock<MockBaseSubscriber<int>>>();
 
   EXPECT_CALL(*subscriber, onSubscribeImpl())
     .Times(1)

--- a/yarpl/test/FlowableTest.cpp
+++ b/yarpl/test/FlowableTest.cpp
@@ -20,13 +20,13 @@ namespace {
  * Used in place of TestSubscriber where we have move-only types.
  */
 template <typename T>
-class CollectingSubscriber : public Subscriber<T> {
+class CollectingSubscriber : public LegacySubscriber<T> {
  public:
   explicit CollectingSubscriber(int64_t requestCount = 100)
       : requestCount_(requestCount) {}
 
   void onSubscribe(Reference<Subscription> subscription) override {
-    Subscriber<T>::onSubscribe(subscription);
+    LegacySubscriber<T>::onSubscribe(subscription);
     subscription->request(requestCount_);
   }
 
@@ -35,12 +35,12 @@ class CollectingSubscriber : public Subscriber<T> {
   }
 
   void onComplete() override {
-    Subscriber<T>::onComplete();
+    LegacySubscriber<T>::onComplete();
     complete_ = true;
   }
 
   void onError(folly::exception_wrapper ex) override {
-    Subscriber<T>::onError(ex);
+    LegacySubscriber<T>::onError(ex);
     error_ = true;
     errorMsg_ = ex.get_exception()->what();
   }
@@ -62,7 +62,7 @@ class CollectingSubscriber : public Subscriber<T> {
   }
 
   void cancelSubscription() {
-    Subscriber<T>::subscription()->cancel();
+    LegacySubscriber<T>::subscription()->cancel();
   }
 
  private:
@@ -404,13 +404,13 @@ TEST(FlowableTest, FlowableCompleteInTheMiddle) {
   EXPECT_EQ(std::size_t{1}, subscriber->values().size());
 }
 
-class RangeCheckingSubscriber : public Subscriber<int32_t> {
+class RangeCheckingSubscriber : public LegacySubscriber<int32_t> {
  public:
   explicit RangeCheckingSubscriber(int32_t total, folly::Baton<>& b)
       : total_(total), onComplete_(b) {}
 
   void onSubscribe(Reference<Subscription> subscription) override {
-    Subscriber<int32_t>::onSubscribe(subscription);
+    LegacySubscriber<int32_t>::onSubscribe(subscription);
     subscription->request(total_);
   }
 
@@ -424,7 +424,7 @@ class RangeCheckingSubscriber : public Subscriber<int32_t> {
   }
 
   void onComplete() override {
-    Subscriber<int32_t>::onComplete();
+    LegacySubscriber<int32_t>::onComplete();
     EXPECT_EQ(total_, current_);
     onComplete_.post();
   }
@@ -464,7 +464,7 @@ TEST(FlowableTest, FlowableFromDifferentThreads) {
 }
 } // namespace
 
-class ErrorRangeCheckingSubscriber : public Subscriber<int32_t> {
+class ErrorRangeCheckingSubscriber : public LegacySubscriber<int32_t> {
  public:
   explicit ErrorRangeCheckingSubscriber(
       int32_t expect,
@@ -477,7 +477,7 @@ class ErrorRangeCheckingSubscriber : public Subscriber<int32_t> {
         expectedErr_(expected_err) {}
 
   void onSubscribe(Reference<Subscription> subscription) override {
-    Subscriber<int32_t>::onSubscribe(subscription);
+    LegacySubscriber<int32_t>::onSubscribe(subscription);
     subscription->request(request_);
   }
 
@@ -495,7 +495,7 @@ class ErrorRangeCheckingSubscriber : public Subscriber<int32_t> {
   }
 
   void onComplete() override {
-    Subscriber<int32_t>::onComplete();
+    LegacySubscriber<int32_t>::onComplete();
     FAIL() << "shouldn't ever onComplete";
   }
 

--- a/yarpl/test/FlowableTest.cpp
+++ b/yarpl/test/FlowableTest.cpp
@@ -20,13 +20,13 @@ namespace {
  * Used in place of TestSubscriber where we have move-only types.
  */
 template <typename T>
-class CollectingSubscriber : public LegacySubscriber<T> {
+class CollectingSubscriber : public InternalSubscriber<T> {
  public:
   explicit CollectingSubscriber(int64_t requestCount = 100)
       : requestCount_(requestCount) {}
 
   void onSubscribe(Reference<Subscription> subscription) override {
-    LegacySubscriber<T>::onSubscribe(subscription);
+    InternalSubscriber<T>::onSubscribe(subscription);
     subscription->request(requestCount_);
   }
 
@@ -35,12 +35,12 @@ class CollectingSubscriber : public LegacySubscriber<T> {
   }
 
   void onComplete() override {
-    LegacySubscriber<T>::onComplete();
+    InternalSubscriber<T>::onComplete();
     complete_ = true;
   }
 
   void onError(folly::exception_wrapper ex) override {
-    LegacySubscriber<T>::onError(ex);
+    InternalSubscriber<T>::onError(ex);
     error_ = true;
     errorMsg_ = ex.get_exception()->what();
   }
@@ -62,7 +62,7 @@ class CollectingSubscriber : public LegacySubscriber<T> {
   }
 
   void cancelSubscription() {
-    LegacySubscriber<T>::subscription()->cancel();
+    InternalSubscriber<T>::subscription()->cancel();
   }
 
  private:
@@ -404,13 +404,13 @@ TEST(FlowableTest, FlowableCompleteInTheMiddle) {
   EXPECT_EQ(std::size_t{1}, subscriber->values().size());
 }
 
-class RangeCheckingSubscriber : public LegacySubscriber<int32_t> {
+class RangeCheckingSubscriber : public InternalSubscriber<int32_t> {
  public:
   explicit RangeCheckingSubscriber(int32_t total, folly::Baton<>& b)
       : total_(total), onComplete_(b) {}
 
   void onSubscribe(Reference<Subscription> subscription) override {
-    LegacySubscriber<int32_t>::onSubscribe(subscription);
+    InternalSubscriber<int32_t>::onSubscribe(subscription);
     subscription->request(total_);
   }
 
@@ -424,7 +424,7 @@ class RangeCheckingSubscriber : public LegacySubscriber<int32_t> {
   }
 
   void onComplete() override {
-    LegacySubscriber<int32_t>::onComplete();
+    InternalSubscriber<int32_t>::onComplete();
     EXPECT_EQ(total_, current_);
     onComplete_.post();
   }
@@ -464,7 +464,7 @@ TEST(FlowableTest, FlowableFromDifferentThreads) {
 }
 } // namespace
 
-class ErrorRangeCheckingSubscriber : public LegacySubscriber<int32_t> {
+class ErrorRangeCheckingSubscriber : public InternalSubscriber<int32_t> {
  public:
   explicit ErrorRangeCheckingSubscriber(
       int32_t expect,
@@ -477,7 +477,7 @@ class ErrorRangeCheckingSubscriber : public LegacySubscriber<int32_t> {
         expectedErr_(expected_err) {}
 
   void onSubscribe(Reference<Subscription> subscription) override {
-    LegacySubscriber<int32_t>::onSubscribe(subscription);
+    InternalSubscriber<int32_t>::onSubscribe(subscription);
     subscription->request(request_);
   }
 
@@ -495,7 +495,7 @@ class ErrorRangeCheckingSubscriber : public LegacySubscriber<int32_t> {
   }
 
   void onComplete() override {
-    LegacySubscriber<int32_t>::onComplete();
+    InternalSubscriber<int32_t>::onComplete();
     FAIL() << "shouldn't ever onComplete";
   }
 

--- a/yarpl/test/ReferenceTest.cpp
+++ b/yarpl/test/ReferenceTest.cpp
@@ -11,12 +11,13 @@
 using yarpl::Refcounted;
 using yarpl::Reference;
 using yarpl::AtomicReference;
+using yarpl::flowable::LegacySubscriber;
 using yarpl::flowable::Subscriber;
 
 namespace {
 
 template <class T>
-class MySubscriber : public Subscriber<T> {
+class MySubscriber : public LegacySubscriber<T> {
   void onNext(T) override {}
 };
 }

--- a/yarpl/test/ReferenceTest.cpp
+++ b/yarpl/test/ReferenceTest.cpp
@@ -11,13 +11,13 @@
 using yarpl::Refcounted;
 using yarpl::Reference;
 using yarpl::AtomicReference;
-using yarpl::flowable::LegacySubscriber;
+using yarpl::flowable::InternalSubscriber;
 using yarpl::flowable::Subscriber;
 
 namespace {
 
 template <class T>
-class MySubscriber : public LegacySubscriber<T> {
+class MySubscriber : public InternalSubscriber<T> {
   void onNext(T) override {}
 };
 }

--- a/yarpl/test/SubscribeObserveOnTests.cpp
+++ b/yarpl/test/SubscribeObserveOnTests.cpp
@@ -145,7 +145,7 @@ TEST(ObserveSubscribeTests, BothObserveAndSubscribeOn) {
 }
 
 namespace {
-class EarlyCancelSubscriber : public yarpl::flowable::Subscriber<int64_t> {
+class EarlyCancelSubscriber : public yarpl::flowable::LegacySubscriber<int64_t> {
  public:
   EarlyCancelSubscriber(
       folly::EventBase& on_base,
@@ -153,7 +153,7 @@ class EarlyCancelSubscriber : public yarpl::flowable::Subscriber<int64_t> {
       : on_base_(on_base), subscriber_complete_(subscriber_complete) {}
 
   void onSubscribe(Reference<yarpl::flowable::Subscription> s) override {
-    Subscriber::onSubscribe(s);
+    LegacySubscriber::onSubscribe(s);
     s->request(5);
   }
 

--- a/yarpl/test/SubscribeObserveOnTests.cpp
+++ b/yarpl/test/SubscribeObserveOnTests.cpp
@@ -146,7 +146,7 @@ TEST(ObserveSubscribeTests, BothObserveAndSubscribeOn) {
 
 namespace {
 class EarlyCancelSubscriber
-    : public yarpl::flowable::LegacySubscriber<int64_t> {
+    : public yarpl::flowable::InternalSubscriber<int64_t> {
  public:
   EarlyCancelSubscriber(
       folly::EventBase& on_base,
@@ -154,7 +154,7 @@ class EarlyCancelSubscriber
       : on_base_(on_base), subscriber_complete_(subscriber_complete) {}
 
   void onSubscribe(Reference<yarpl::flowable::Subscription> s) override {
-    LegacySubscriber::onSubscribe(s);
+    InternalSubscriber::onSubscribe(s);
     s->request(5);
   }
 

--- a/yarpl/test/SubscribeObserveOnTests.cpp
+++ b/yarpl/test/SubscribeObserveOnTests.cpp
@@ -145,7 +145,8 @@ TEST(ObserveSubscribeTests, BothObserveAndSubscribeOn) {
 }
 
 namespace {
-class EarlyCancelSubscriber : public yarpl::flowable::LegacySubscriber<int64_t> {
+class EarlyCancelSubscriber
+    : public yarpl::flowable::LegacySubscriber<int64_t> {
  public:
   EarlyCancelSubscriber(
       folly::EventBase& on_base,

--- a/yarpl/test/yarpl/test_utils/Mocks.h
+++ b/yarpl/test/yarpl/test_utils/Mocks.h
@@ -35,7 +35,7 @@ class MockFlowable : public flowable::Flowable<T> {
 /// For the same reason putting mock instance in a smart pointer is a poor idea.
 /// Can only be instanciated for CopyAssignable E type.
 template <typename T>
-class MockSubscriber : public flowable::Subscriber<T> {
+class MockSubscriber : public flowable::LegacySubscriber<T> {
  public:
   MOCK_METHOD1(
       onSubscribe_,

--- a/yarpl/test/yarpl/test_utils/Mocks.h
+++ b/yarpl/test/yarpl/test_utils/Mocks.h
@@ -35,7 +35,7 @@ class MockFlowable : public flowable::Flowable<T> {
 /// For the same reason putting mock instance in a smart pointer is a poor idea.
 /// Can only be instanciated for CopyAssignable E type.
 template <typename T>
-class MockSubscriber : public flowable::LegacySubscriber<T> {
+class MockSubscriber : public flowable::InternalSubscriber<T> {
  public:
   MOCK_METHOD1(
       onSubscribe_,

--- a/yarpl/test/yarpl/test_utils/Mocks.h
+++ b/yarpl/test/yarpl/test_utils/Mocks.h
@@ -135,22 +135,22 @@ class MockSubscription : public flowable::Subscription {
   MOCK_METHOD0(cancel_, void());
 
   void request(int64_t n) override {
-    if (!requested_) {
-      requested_ = true;
-      EXPECT_CALL(checkpoint_, Call()).Times(1);
-    }
-
     request_(n);
   }
 
   void cancel() override {
     cancel_();
-    checkpoint_.Call();
   }
-
- protected:
-  bool requested_{false};
-  testing::MockFunction<void()> checkpoint_;
 };
 }
+
+template <typename T>
+class MockSafeSubscriber : public flowable::SafeSubscriber<T> {
+public:
+  MOCK_METHOD0_T(onSubscribeImpl, void());
+  MOCK_METHOD1_T(onNextImpl, void(T));
+  MOCK_METHOD0_T(onCompleteImpl, void());
+  MOCK_METHOD1_T(onErrorImpl, void(folly::exception_wrapper));
+};
+
 } // namespace yarpl::mocks

--- a/yarpl/test/yarpl/test_utils/Mocks.h
+++ b/yarpl/test/yarpl/test_utils/Mocks.h
@@ -145,7 +145,7 @@ class MockSubscription : public flowable::Subscription {
 }
 
 template <typename T>
-class MockSafeSubscriber : public flowable::SafeSubscriber<T> {
+class MockBaseSubscriber : public flowable::BaseSubscriber<T> {
 public:
   MOCK_METHOD0_T(onSubscribeImpl, void());
   MOCK_METHOD1_T(onNextImpl, void(T));


### PR DESCRIPTION
codemods to migrate most name changes:

```
codemod --accept-all -d . --extensions h,cpp 'public (yarpl::flowable::?)Subscriber' 'public \1InternalSubscriber'
codemod --accept-all -d . --extensions h,cpp 'public (flowable::?)Subscriber'        'public \1InternalSubscriber'
codemod --accept-all -d . --extensions h,cpp 'public Subscriber'                     'public InternalSubscriber'
codemod --accept-all -d . --extensions h,cpp '\bSubscriber<(.+)>::subscription'      'InternalSubscriber<\1>::subscription'
codemod --accept-all -d . --extensions h,cpp 'using (.+?)\bSubscriber;'              'using \1InternalSubscriber;'
codemod --accept-all -d . --extensions h,cpp '\bSubscriber<(.+)>::on(\w+)\('         'InternalSubscriber<\1>::on\2('
codemod --accept-all -d . --extensions h,cpp '\bSubscriber::(\w+)\('                 'InternalSubscriber::\1('
```

Changes to Subscriber
======

Makes Subscriber a pure interface to implement; renames `Subscriber -> InternalSubscriber`, adds `BaseSubscriber` which manages its `Subscription` on behalf of the subclass, and provides guarentees about signaling methods not being called after a synchronized call to cancel(). Also guarentees that cancel() and request() are nilpotent after a call to cancel(). 

`InternalSubscriber` exists as a drop-in for what used to be `Subscriber` to allow code to be incrementally changed to use `BaseSubscriber`. Above codemods will handle 98% of cases where `Subscriber` is currently used. Eventually `InternalSubscriber` can be deprecated and removed (or usage can be reduced and moved over to BaseSubscriber).

`BaseSubscriber` checks that a `Subscriber` hasn't been subscribed to multiple times (the spec is inconsistent about if this should be allowed; for now this is conservative, but the constraint can be relaxed later if need be).

New Subscriber implementations should inherit from `BaseSubscriber`, and implement: 
 * `onSubscribeImpl()` (note that it does not take a `Reference<Subscription>`)
 * `onNextImpl(T)`
 * `onCompleteImpl()`
 * `onErrorImpl(folly::exception_wrapper)`
* (optional) `onTerminateImpl()`

Subclass accesses the associated subscription via methods `request(n)` and `cancel()` on the subscriber itself. 

Why make `Subscriber` a pure interface and remove `Subscription` state?
 - Most subclasses of Subscriber add their own `Subscription` member and manage it rather than calling `Subscriber::subscription()` to get a reference to it
 - Most subclasses of Subscriber don't properly call their superclass methods, and miss out on `D?CHECK`s and reference clearing in the parent (which may lead to missed bugs and leaks)
 - The ideal would be all implementations of Subscriber can inherit a set of checks guaranteed to run
 - `BaseSubscriber` can be safely (and in a non-breaking way) extended with additional callbacks such as `onTerminate()` 
 - `BaseSubscriber` can provide a wrapping `Subscription` which provides stronger, weaker, more flexible threading guarantees based on what the application requires 
 - Forcing implementation of `onComplete`/`onError` makes a missed callback or missed `override` obvious; you're not going to be able to instantiate a subclass unless you know you've implemented all required callbacks.
 - `onTerminateImpl()` adds a singular location to put teardown code, and when cancel() and request() are called from the same thread as the one calling signaling methods, is guarenteed to be the last signaling method to run.

Changes to Reference/Refcounted: #767