### PR TITLE
Channel tests

### DIFF
--- a/rsocket/statemachine/ConsumerBase.cpp
+++ b/rsocket/statemachine/ConsumerBase.cpp
@@ -31,6 +31,7 @@ void ConsumerBase::subscribe(
 // completeConsumer exists)
 void ConsumerBase::cancelConsumer() {
   state_ = State::CLOSED;
+  VLOG(5) << "ConsumerBase::cancelConsumer()";
   consumingSubscriber_ = nullptr;
 }
 
@@ -75,6 +76,7 @@ void ConsumerBase::processPayload(Payload&& payload, bool onNext) {
 
 void ConsumerBase::completeConsumer() {
   state_ = State::CLOSED;
+  VLOG(5) << "ConsumerBase::completeConsumer()";
   if (auto subscriber = std::move(consumingSubscriber_)) {
     subscriber->onComplete();
   }
@@ -82,6 +84,7 @@ void ConsumerBase::completeConsumer() {
 
 void ConsumerBase::errorConsumer(folly::exception_wrapper ex) {
   state_ = State::CLOSED;
+  VLOG(5) << "ConsumerBase::errorConsumer()";
   if (auto subscriber = std::move(consumingSubscriber_)) {
     subscriber->onError(std::move(ex));
   }
@@ -103,4 +106,4 @@ void ConsumerBase::handleFlowControlError() {
   }
   errorStream("flow control error");
 }
-}
+} // namespace rsocket

--- a/test/RequestChannelTest.cpp
+++ b/test/RequestChannelTest.cpp
@@ -88,6 +88,135 @@ TEST(RequestChannelTest, RequestOnDisconnectedClient) {
   ASSERT(did_call_on_error);
 }
 
+class ResponderLongOutPut : public rsocket::RSocketResponder {
+ public:
+  yarpl::Reference<Flowable<rsocket::Payload>> handleRequestChannel(
+      rsocket::Payload,
+      yarpl::Reference<Flowable<rsocket::Payload>> requestStream,
+      rsocket::StreamId) override {
+    auto ts = TestSubscriber<std::string>::create();
+    requestStream
+        ->map([](auto p) { LOG(INFO) << "received: " << p;
+          return p.moveDataToString(); })
+        ->subscribe(ts);
+
+    // output 1 - 100
+    return Flowables::range(1, 1000)->map([](
+        int64_t v) {
+      wait();
+      std::stringstream ss;
+      ss << "Server stream: " << v;
+      std::string s = ss.str();
+      return Payload(s, "metadata");
+    });
+  }
+};
+
+
+TEST(RequestChannelTest, CompleteRequesterResponderContinues) {
+  LOG(ERR) << "CompleteRequesterResponderContinues";
+  folly::ScopedEventBaseThread worker;
+  auto server = makeServer(std::make_shared<ResponderLongOutPut>());
+  auto client = makeClient(worker.getEventBase(), *server->listeningPort());
+  auto requester = client->getRequester();
+
+  auto ts = TestSubscriber<std::string>::create();
+
+  auto shortFlowable = Flowable<Payload>::create([](
+      Reference<Subscriber<Payload>> subscriber, int64_t) {
+    subscriber->onNext(Payload("some data", "meta"));
+    subscriber->onNext(Payload("more data", "meta"));
+    subscriber->onComplete();
+    LOG(INFO) << "client stream completed()";
+    return std::make_tuple(int64_t(1), true);
+  });
+
+  requester
+      ->requestChannel(
+          shortFlowable)
+      ->map([](auto p) { return p.moveDataToString(); })
+      ->subscribe(ts);
+  LOG(INFO) << "still waiting for server stream to end";
+  ts->awaitTerminalEvent();
+  LOG(INFO) << "server stream ended";
+  ts->assertSuccess();
+  ts->assertValueCount(1000);
+  ts->assertValueAt(0, "Server stream: 1");
+  ts->assertValueAt(999, "Server stream: 1000");
+}
+
+
+
+// Sandbox REMOVE BEFORE MAKING A PULL REQUEST
+
+class TestHandler2Way : public rsocket::RSocketResponder {
+ public:
+  /// Handles a new inbound Stream requested by the other end.
+  yarpl::Reference<Flowable<rsocket::Payload>> handleRequestChannel(
+      rsocket::Payload initialPayload,
+      yarpl::Reference<Flowable<rsocket::Payload>> requestStream,
+      rsocket::StreamId) override {
+    auto ts = TestSubscriber<std::string>::create();
+    requestStream
+        ->map([](auto p) { return p.moveDataToString(); })
+        ->subscribe(ts);
+    LOG(INFO) << initialPayload;
+    auto initialPayloadString = initialPayload.moveDataToString();
+    // say "Hello" to each name on the input stream
+    return Flowables::range(1, 10)->map([name = std::move(initialPayloadString)](
+        int64_t v) {
+      std::stringstream ss;
+      ss << "Hello " << name << " " << v << "!";
+      std::string s = ss.str();
+      return Payload(s, "metadata");
+    });
+  }
+};
+
+
+TEST(RequestChannelTest, ManualChannel) {
+  LOG(INFO) << "ManualChannel";
+  folly::ScopedEventBaseThread worker;
+  auto server = makeServer(std::make_shared<TestHandler2Way>());
+  auto client = makeClient(worker.getEventBase(), *server->listeningPort());
+  auto requester = client->getRequester();
+
+  auto ts = TestSubscriber<std::string>::create();
+
+  auto flow = Flowable<Payload>::create([](
+      Reference<Subscriber<Payload>> subscriber, int64_t) {
+    subscriber->onNext(Payload("1", "meta"));
+    subscriber->onNext(Payload("2", "meta"));
+    subscriber->onNext(Payload("3", "meta"));
+    subscriber->onNext(Payload("4", "meta"));
+    return std::make_tuple(int64_t(1), true);
+  });
+
+  requester
+      ->requestChannel(
+          flow)
+      ->map([](auto p) { return p.moveDataToString(); })
+      ->subscribe(ts);
+
+  ts->awaitTerminalEvent();
+  ts->assertSuccess();
+  ts->assertValueCount(2);
+  // assert that we echo back the 2nd and 3rd request values
+  // with the 1st initial payload prepended to each
+  ts->assertValueAt(0, "[/hello] Hello Bob!");
+  ts->assertValueAt(1, "[/hello] Hello Jane!");
+}
+
+auto flow = Flowable<Payload>::create([](
+        Reference<Subscriber<Payload>> subscriber, int64_t) {
+      subscriber->onNext(Payload("1", "meta"));
+      subscriber->onNext(Payload("2", "meta"));
+      subscriber->onNext(Payload("3", "meta"));
+      subscriber->onNext(Payload("4", "meta"));
+      return std::make_tuple(int64_t(1), true);
+    });
+
+
 // TODO complete from requester, responder continues
 // TODO complete from responder, requester continues
 // TODO cancel from requester, shuts down

--- a/yarpl/include/yarpl/flowable/TestSubscriber.h
+++ b/yarpl/include/yarpl/flowable/TestSubscriber.h
@@ -74,7 +74,6 @@ class TestSubscriber : public Subscriber<T> {
   }
 
   void onNext(T t) override {
-//    LOG(INFO) << t;
     if (delegate_) {
       values_.push_back(t);
       delegate_->onNext(std::move(t));

--- a/yarpl/include/yarpl/flowable/TestSubscriber.h
+++ b/yarpl/include/yarpl/flowable/TestSubscriber.h
@@ -74,6 +74,7 @@ class TestSubscriber : public Subscriber<T> {
   }
 
   void onNext(T t) override {
+//    LOG(INFO) << t;
     if (delegate_) {
       values_.push_back(t);
       delegate_->onNext(std::move(t));


### PR DESCRIPTION
The last 2 tests:
- failure on request, requester sees
- failure from requester ... what happens?

I'm not clear on what this exactly means.  I can have the requester stream send an onError, is that failure on request?  How does the requester "see" this?