### PR TITLE
Tests for creating Client & Server connections with existing sockets

### DIFF
--- a/test/RSocketClientServerTest.cpp
+++ b/test/RSocketClientServerTest.cpp
@@ -3,10 +3,14 @@
 #include "RSocketTests.h"
 
 #include <folly/Random.h>
+#include <folly/io/async/AsyncServerSocket.h>
+#include <folly/io/async/AsyncSocket.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <gtest/gtest.h>
+#include "rsocket/transports/tcp/TcpDuplexConnection.h"
 #include "test/handlers/HelloStreamRequestHandler.h"
 
+using namespace folly::io;
 using namespace rsocket;
 using namespace rsocket::tests;
 using namespace rsocket::tests::client_server;
@@ -114,3 +118,130 @@ TEST(RSocketClientServer, CloseServerWithConnections) {
 
   server.reset();
 }
+
+class SocketCallback : public folly::AsyncServerSocket::AcceptCallback {
+ public:
+  void connectionAccepted(
+      int fd,
+      const folly::SocketAddress& address) noexcept override {
+    VLOG(2) << "Accepting TCP connection from " << address << " on FD " << fd;
+
+    socketPromise.setValue(fd);
+  }
+
+  void acceptError(const std::exception& ex) noexcept override {
+    VLOG(2) << "TCP error: " << ex.what();
+
+    socketPromise.setException(ex);
+  }
+
+  folly::Future<int> getConnectedSocket() {
+    return socketPromise.getFuture();
+  }
+
+ protected:
+  folly::Promise<int> socketPromise;
+};
+
+class RSocketClientServerRaw : public ::testing::TestWithParam<bool> {};
+
+TEST_P(RSocketClientServerRaw, ServerWithNoAcceptor) {
+  // ConnectionAcceptor's should destroy the threads the last!
+  auto connectedClientThread = std::make_unique<folly::ScopedEventBaseThread>();
+  // Callbacks are also required to be destroyed the last!
+  auto callback = std::make_unique<SocketCallback>();
+  {
+    folly::ScopedEventBaseThread serverThread;
+    auto serverSocket = folly::AsyncServerSocket::UniquePtr(
+        new folly::AsyncServerSocket(serverThread.getEventBase()));
+
+    auto connectedClientEvb = connectedClientThread->getEventBase();
+    auto serverPort =
+        folly::via(
+            serverThread.getEventBase(),
+            [&serverSocket, &serverThread, &callback, connectedClientEvb]()
+                -> unsigned short {
+              serverSocket->bind(folly::SocketAddress("::", 0));
+              serverSocket->addAcceptCallback(
+                  callback.get(), connectedClientEvb);
+              serverSocket->listen(/*backlog=*/1);
+              serverSocket->startAccepting();
+              for (auto& i : serverSocket->getAddresses()) {
+                return i.getPort();
+              }
+              LOG(FATAL) << "Server could not be start";
+            })
+            .get();
+
+    // Thread should outlive the client.
+    auto clientThread = std::make_unique<folly::ScopedEventBaseThread>();
+    {
+      // Client connects to the server.
+      auto client = makeClient(clientThread->getEventBase(), serverPort);
+
+      // Server should have a connection now.
+      auto fd = callback->getConnectedSocket().get();
+
+      // Make a server with no Acceptor as we will already provide the
+      // connection!
+      auto server = makeServerWithNoAcceptor();
+
+      connectedClientEvb->runInEventBaseThreadAndWait([&server,
+                                                       &connectedClientEvb,
+                                                       fd]() {
+        folly::AsyncSocket::UniquePtr socket(
+            new folly::AsyncSocket(connectedClientEvb, fd));
+
+        auto connection =
+            std::make_unique<TcpDuplexConnection>(std::move(socket));
+
+        folly::EventBase dummyEventBase;
+        server->acceptConnection(
+            std::move(connection),
+            dummyEventBase,
+            RSocketServiceHandler::create([](const rsocket::SetupParameters&) {
+              return std::make_shared<HelloStreamRequestHandler>();
+            }));
+      });
+
+      auto disconnect = GetParam();
+      if (disconnect) {
+        client->disconnect().wait();
+      }
+    }
+
+    folly::Baton<> baton;
+    serverThread.getEventBase()->runInEventBaseThread(
+        [ serverSocket = std::move(serverSocket), &baton ]() {
+          serverSocket->stopAccepting();
+          baton.post();
+        });
+    baton.wait();
+  }
+}
+
+TEST_P(RSocketClientServerRaw, ClientFromExistingConnection) {
+  auto server = makeServer(std::make_shared<HelloStreamRequestHandler>());
+  // The eventBase should outlive the RSocketClient instance. Otherwise it
+  // causes leak that is caught on ASAN builds.
+  folly::EventBase evb;
+  {
+    std::unique_ptr<RSocketClient> client;
+    {
+      folly::SocketAddress address{"::1", *server->listeningPort()};
+      folly::AsyncSocket::UniquePtr socket(
+          new folly::AsyncSocket(&evb, address));
+      client = makeClientFromConnection(std::move(socket), evb);
+
+      bool disconnect = GetParam();
+      if (disconnect) {
+        client->disconnect().wait();
+      }
+    }
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(
+    Disconnect,
+    RSocketClientServerRaw,
+    ::testing::Values(true, false));

--- a/test/RSocketTests.h
+++ b/test/RSocketTests.h
@@ -23,6 +23,8 @@ std::unique_ptr<RSocketServer> makeServer(
 std::unique_ptr<RSocketServer> makeResumableServer(
     std::shared_ptr<RSocketServiceHandler> serviceHandler);
 
+std::unique_ptr<RSocketServer> makeServerWithNoAcceptor();
+
 std::unique_ptr<RSocketClient> makeClient(
     folly::EventBase* eventBase,
     uint16_t port);
@@ -46,6 +48,13 @@ std::unique_ptr<RSocketClient> makeColdResumableClient(
     std::shared_ptr<ResumeManager> resumeManager,
     std::shared_ptr<ColdResumeHandler> resumeHandler);
 
+std::unique_ptr<RSocketClient> makeClientFromConnection(
+    folly::AsyncSocket::UniquePtr socket,
+    folly::EventBase& eventBase);
+
+folly::Future<std::unique_ptr<RSocketClient>> makeClientFromConnectionAsync(
+    folly::AsyncSocket::UniquePtr socket,
+    folly::EventBase& eventBase);
 } // namespace client_server
 } // namespace tests
 } // namespace rsocket


### PR DESCRIPTION
The integration projects use existing sockets to create RSocket connections. I saw that unit testing for this functionality is lacked. So I have tried to add tests to this area.