### PR TITLE
A sample persistence to disk for cold resumption

### DIFF
--- a/rsocket/internal/WarmResumeManager.h
+++ b/rsocket/internal/WarmResumeManager.h
@@ -71,7 +71,7 @@ class WarmResumeManager : public ResumeManager {
     LOG(FATAL) << "Not Implemented for Warm Resumption";
   }
 
- private:
+ protected:
   void addFrame(const folly::IOBuf&, size_t);
   void evictFrame();
 

--- a/test/test_utils/ColdResumeManager.h
+++ b/test/test_utils/ColdResumeManager.h
@@ -17,8 +17,16 @@ class FrameTransport;
 // testing purposes)
 class ColdResumeManager : public WarmResumeManager {
  public:
-  explicit ColdResumeManager(std::shared_ptr<RSocketStats> stats)
-      : WarmResumeManager(std::move(stats)) {}
+  // If inputFile is provided, the ColdResumeManager will read state from the
+  // file, else it will start with a clean state.
+  // The constructor will throw if there is an error reading from the inputFile.
+  // If outputFile is provided, the ColdResumeManager will write to the
+  // outputFile upon destruction.
+  ColdResumeManager(
+      std::shared_ptr<RSocketStats> stats,
+      std::string inputFile = "",
+      std::string outputFile = "");
+
   ~ColdResumeManager();
 
   void trackReceivedFrame(
@@ -51,6 +59,7 @@ class ColdResumeManager : public WarmResumeManager {
 
  private:
   StreamResumeInfos streamResumeInfos_;
+  std::string outputFile_;
 
   // Largest used StreamId so far.
   StreamId largestUsedStreamId_{0};


### PR DESCRIPTION
Modify the existing ColdResumeManager to support persisting to file optionally.  

I opted to go with json for readability and easy debug-ability.  We can think of more optimal solutions once we get things rolling.  

The persisted content looks like this
```
{
  "Frames" : [
    {
      "0" : "\u0000\u0000\u0000\u0001\u0018\u0000\u0000\u0000\u0000\u0007First"
    },
    {
      "15" : "\u0000\u0000\u0000\u0001 \u0000\u0000\u0000\u0000\u0003"
    },
    {
      "25" : "\u0000\u0000\u0000\u0003\u0018\u0000\u0000\u0000\u0000\u0005Second"
    },
    {
      "41" : "\u0000\u0000\u0000\u0001 \u0000\u0000\u0000\u0000\u0004"
    }
  ],
  "ImpliedPosition" : 271,
  "StreamResumeInfos" : {
    "1" : {
      "StreamType" : 1,
      "StreamToken" : "First",
      "Requester" : 0,
      "ConsumerAllowance" : 4,
      "ProducerAllowance" : 0
    },
    "3" : {
      "StreamType" : 1,
      "StreamToken" : "Second",
      "Requester" : 0,
      "ConsumerAllowance" : 0,
      "ProducerAllowance" : 0
    }
  },
  "LargestUsedStreamId" : 3,
  "LastSentPosition" : 51,
  "FirstSentPosition" : 0
}
```