### PR TITLE
Execute inline if already in the same thread

### DIFF
--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -513,7 +513,7 @@ void RSocketStateMachine::handleConnectionFrame(
           resumeCallback_) {
         auto resumeCallback = std::move(resumeCallback_);
         resumeCallback->onResumeError(
-            ResumptionException(frame.payload_.cloneDataToString()));
+            ResumptionException(frame.payload_.moveDataToString()));
         // fall through
       }
 


### PR DESCRIPTION
The event base in the RSocketRequester and the event base of a class which initiates and uses it might be the same. So, whenever it calls requestXYZ, and whenever it subscribes to the flowable that is returned, they might be already at the same event base.

The issue with the current code is that:
 - Why don't we just execute the code, if we can, instead of adding it to a queue, possible performance improvement.
 - If the class that uses RSocketRequester registers a Baton and posts this baton when the subscribe() function completes, then we will have a deadlock situation. As the baton.wait() and the lambda that is added to the queue are to be in the same event base, the lambda will never be executed before the baton.wait() is satisfied.
With this update, we prevent such a possible deadlock situation.