### PR TITLE
Handle exceptions thrown from map operators

### DIFF
--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -199,8 +199,13 @@ class MapOperator : public ObservableOperator<U, D, MapOperator<U, D, F>> {
         : SuperSub(std::move(observable), std::move(observer)) {}
 
     void onNext(U value) override {
-      auto& map = SuperSub::getObservableOperator();
-      SuperSub::observerOnNext(map->function_(std::move(value)));
+      try {
+        auto& map = this->getObservableOperator();
+        this->observerOnNext(map->function_(std::move(value)));
+      } catch (const std::exception& exn) {
+        folly::exception_wrapper ew{std::current_exception(), exn};
+        this->terminateErr(std::move(ew));
+      }
     }
   };
 

--- a/yarpl/test/Single_test.cpp
+++ b/yarpl/test/Single_test.cpp
@@ -69,3 +69,17 @@ TEST(Single, SingleMap) {
   to->awaitTerminalEvent();
   to->assertOnSuccessValue("hello");
 }
+
+TEST(Single, MapWithException) {
+  auto single = Singles::just<int>(3)->map([](int n) {
+    if (n > 2) {
+      throw std::runtime_error{"Too big!"};
+    }
+    return n;
+  });
+
+  auto observer = yarpl::make_ref<SingleTestObserver<int>>();
+  single->subscribe(observer);
+
+  observer->assertOnErrorMessage("Too big!");
+}


### PR DESCRIPTION
If the function passed to a map operator throws, then we should cancel the
subscription, and pass the exception as the onError to the downstream (unless
this is a Single, where we shouldn't cancel the subscription).

Improves the SingleOperator termination semantics, which haven't kept up with
ObservableOperator and FlowableOperator.