### PR TITLE
Clean up a bit of RSocketStateMachine's API

### DIFF
--- a/rsocket/RSocketClient.cpp
+++ b/rsocket/RSocketClient.cpp
@@ -107,7 +107,7 @@ folly::Future<folly::Unit> RSocketClient::resume() {
         createState(connection.eventBase);
       }
 
-      stateMachine_->tryClientResume(
+      stateMachine_->resumeClient(
           token_,
           std::move(frameTransport),
           std::move(resumeCallback),
@@ -153,7 +153,7 @@ void RSocketClient::fromConnection(
     framedConnection = std::make_unique<FramedDuplexConnection>(
         std::move(connection), setupParameters.protocolVersion);
   }
-  stateMachine_->connectClientSendSetup(
+  stateMachine_->connectClient(
       std::move(framedConnection), std::move(setupParameters));
 }
 

--- a/rsocket/RSocketRequester.cpp
+++ b/rsocket/RSocketRequester.cpp
@@ -142,7 +142,7 @@ yarpl::Reference<yarpl::single::Single<void>> RSocketRequester::fireAndForget(
     ]() mutable {
       // TODO pass in SingleSubscriber for underlying layers to
       // call onSuccess/onError once put on network
-      srs->requestFireAndForget(std::move(request));
+      srs->fireAndForget(std::move(request));
       // right now just immediately call onSuccess
       subscriber->onSubscribe(yarpl::single::SingleSubscriptions::empty());
       subscriber->onSuccess();

--- a/rsocket/internal/Common.h
+++ b/rsocket/internal/Common.h
@@ -50,7 +50,7 @@ enum class StreamCompletionSignal {
   SOCKET_CLOSED,
 };
 
-enum class RSocketMode { SERVER, CLIENT };
+enum class RSocketMode : uint8_t { SERVER, CLIENT };
 
 std::ostream& operator<<(std::ostream&, RSocketMode);
 

--- a/rsocket/statemachine/StreamsFactory.cpp
+++ b/rsocket/statemachine/StreamsFactory.cpp
@@ -45,7 +45,7 @@ static void subscribeToErrorSingle(
 Reference<yarpl::flowable::Subscriber<Payload>>
 StreamsFactory::createChannelRequester(
     Reference<yarpl::flowable::Subscriber<Payload>> responseSink) {
-  if (connection_.isDisconnectedOrClosed()) {
+  if (connection_.isDisconnected()) {
     subscribeToErrorFlowable(std::move(responseSink));
     return nullptr;
   }
@@ -61,7 +61,7 @@ StreamsFactory::createChannelRequester(
 void StreamsFactory::createStreamRequester(
     Payload request,
     Reference<yarpl::flowable::Subscriber<Payload>> responseSink) {
-  if (connection_.isDisconnectedOrClosed()) {
+  if (connection_.isDisconnected()) {
     subscribeToErrorFlowable(std::move(responseSink));
     return;
   }
@@ -77,7 +77,7 @@ void StreamsFactory::createStreamRequester(
     Reference<yarpl::flowable::Subscriber<Payload>> responseSink,
     StreamId streamId,
     size_t n) {
-  if (connection_.isDisconnectedOrClosed()) {
+  if (connection_.isDisconnected()) {
     subscribeToErrorFlowable(std::move(responseSink));
     return;
   }
@@ -93,7 +93,7 @@ void StreamsFactory::createStreamRequester(
 void StreamsFactory::createRequestResponseRequester(
     Payload payload,
     Reference<yarpl::single::SingleObserver<Payload>> responseSink) {
-  if (connection_.isDisconnectedOrClosed()) {
+  if (connection_.isDisconnected()) {
     subscribeToErrorSingle(std::move(responseSink));
     return;
   }


### PR DESCRIPTION
* Rename connectClientSendSetup() to connectClient() and tryClientResume() to
  resumeClient(), to match the existing connectServer() and resumeServer().

* Rename isDisconnectedOrClosed() to isDisconnected().  A closed connection
  is disconnected after all.

* Remove the remoteResumeable_ field.  It's exactly the same as the isResumable_
  field.

* Remove uses of CHECK around the private connect() helper.  Throw exceptions
  instead.

* Rename requestFireAndForget() to fireAndForget() to match
  metadataPush().

* Shrink the RSocketMode field to 1 byte, make it const.

* Move a ton of public helper methods to private, as they're not used outside of
  RSocketStateMachine.

* Header comments all around.