### PR TITLE
Make FrameHeader's fields public, put it in it's own header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,8 @@ add_library(
   rsocket/framing/Frame.h
   rsocket/framing/FrameFlags.cpp
   rsocket/framing/FrameFlags.h
+  rsocket/framing/FrameHeader.cpp
+  rsocket/framing/FrameHeader.h
   rsocket/framing/FrameProcessor.h
   rsocket/framing/FrameSerializer.cpp
   rsocket/framing/FrameSerializer.h

--- a/rsocket/framing/Frame.cpp
+++ b/rsocket/framing/Frame.cpp
@@ -16,80 +16,6 @@ const uint32_t Frame_LEASE::kMaxNumRequests;
 const uint32_t Frame_SETUP::kMaxKeepaliveTime;
 const uint32_t Frame_SETUP::kMaxLifetime;
 
-static std::ostream&
-writeFlags(std::ostream& os, FrameFlags frameFlags, FrameType frameType) {
-  constexpr const char* kEmpty = "0x00";
-  constexpr const char* kMetadata = "METADATA";
-  constexpr const char* kResumeEnable = "RESUME_ENABLE";
-  constexpr const char* kLease = "LEASE";
-  constexpr const char* kKeepAliveRespond = "KEEPALIVE_RESPOND";
-  constexpr const char* kFollows = "FOLLOWS";
-  constexpr const char* kComplete = "COMPLETE";
-  constexpr const char* kNext = "NEXT";
-
-  static std::map<FrameType, std::vector<std::pair<FrameFlags, std::string>>>
-      flagToNameMap{{FrameType::REQUEST_N, {}},
-                    {FrameType::REQUEST_RESPONSE,
-                     {{FrameFlags::METADATA, kMetadata},
-                      {FrameFlags::FOLLOWS, kFollows}}},
-                    {FrameType::REQUEST_FNF,
-                     {{FrameFlags::METADATA, kMetadata},
-                      {FrameFlags::FOLLOWS, kFollows}}},
-                    {FrameType::METADATA_PUSH, {}},
-                    {FrameType::CANCEL, {}},
-                    {FrameType::PAYLOAD,
-                     {{FrameFlags::METADATA, kMetadata},
-                      {FrameFlags::FOLLOWS, kFollows},
-                      {FrameFlags::COMPLETE, kComplete},
-                      {FrameFlags::NEXT, kNext}}},
-                    {FrameType::ERROR, {{FrameFlags::METADATA, kMetadata}}},
-                    {FrameType::KEEPALIVE,
-                     {{FrameFlags::KEEPALIVE_RESPOND, kKeepAliveRespond}}},
-                    {FrameType::SETUP,
-                     {{FrameFlags::METADATA, kMetadata},
-                      {FrameFlags::RESUME_ENABLE, kResumeEnable},
-                      {FrameFlags::LEASE, kLease}}},
-                    {FrameType::LEASE, {{FrameFlags::METADATA, kMetadata}}},
-                    {FrameType::RESUME, {}},
-                    {FrameType::REQUEST_CHANNEL,
-                     {{FrameFlags::METADATA, kMetadata},
-                      {FrameFlags::FOLLOWS, kFollows},
-                      {FrameFlags::COMPLETE, kComplete}}},
-                    {FrameType::REQUEST_STREAM,
-                     {{FrameFlags::METADATA, kMetadata},
-                      {FrameFlags::FOLLOWS, kFollows}}}};
-
-  FrameFlags foundFlags = FrameFlags::EMPTY;
-
-  // Search the corresponding string value for each flag, insert the missing
-  // ones as empty
-  const std::vector<std::pair<FrameFlags, std::string>>& allowedFlags =
-      flagToNameMap[frameType];
-
-  std::string delimiter = "";
-  for (const auto& pair : allowedFlags) {
-    if (!!(frameFlags & pair.first)) {
-      os << delimiter << pair.second;
-      delimiter = "|";
-      foundFlags |= pair.first;
-    }
-  }
-
-  if (foundFlags != frameFlags) {
-    os << frameFlags;
-  } else if (delimiter.empty()) {
-    os << kEmpty;
-  }
-  return os;
-}
-
-std::ostream& operator<<(std::ostream& os, const FrameHeader& header) {
-  os << header.type_ << "[";
-  return writeFlags(os, header.flags_, header.type_) << ", " << header.streamId_ << "]";
-}
-
-/// @}
-
 std::ostream& operator<<(std::ostream& os, const Frame_REQUEST_Base& frame) {
   return os << frame.header_ << "(" << frame.requestN_ << ", "
             << frame.payload_;
@@ -165,16 +91,12 @@ Frame_ERROR Frame_ERROR::invalid(StreamId stream, std::string message) {
   return streamErr(ErrorCode::INVALID, std::move(message), stream);
 }
 
-Frame_ERROR Frame_ERROR::connectionErr(
-    ErrorCode err,
-    std::string message) {
+Frame_ERROR Frame_ERROR::connectionErr(ErrorCode err, std::string message) {
   return Frame_ERROR{0, err, Payload{std::move(message)}};
 }
 
-Frame_ERROR Frame_ERROR::streamErr(
-    ErrorCode err,
-    std::string message,
-    StreamId stream) {
+Frame_ERROR
+Frame_ERROR::streamErr(ErrorCode err, std::string message, StreamId stream) {
   if (stream == 0) {
     throw std::invalid_argument{"Can't make stream error for stream zero"};
   }
@@ -184,78 +106,74 @@ Frame_ERROR Frame_ERROR::streamErr(
 std::ostream& operator<<(std::ostream& os, const Frame_ERROR& frame) {
   return os << frame.header_ << ", " << frame.errorCode_ << ", "
             << frame.payload_;
-  }
+}
 
-  std::ostream& operator<<(std::ostream& os, const Frame_KEEPALIVE& frame) {
-    return os << frame.header_ << "(<"
-              << (frame.data_ ? frame.data_->computeChainDataLength() : 0)
-              << ">)";
-  }
+std::ostream& operator<<(std::ostream& os, const Frame_KEEPALIVE& frame) {
+  return os << frame.header_ << "(<"
+            << (frame.data_ ? frame.data_->computeChainDataLength() : 0)
+            << ">)";
+}
 
-  std::ostream& operator<<(std::ostream& os, const Frame_SETUP& frame) {
-    return os << frame.header_ << ", Version: " << frame.versionMajor_ << "."
-        << frame.versionMinor_ << ", "
-        << "Token: " << frame.token_ << ", " << frame.payload_;
-  }
+std::ostream& operator<<(std::ostream& os, const Frame_SETUP& frame) {
+  return os << frame.header_ << ", Version: " << frame.versionMajor_ << "."
+            << frame.versionMinor_ << ", "
+            << "Token: " << frame.token_ << ", " << frame.payload_;
+}
 
-  void Frame_SETUP::moveToSetupPayload(SetupParameters & setupPayload) {
-    setupPayload.metadataMimeType = std::move(metadataMimeType_);
-    setupPayload.dataMimeType = std::move(dataMimeType_);
-    setupPayload.payload = std::move(payload_);
-    setupPayload.token = std::move(token_);
-    setupPayload.resumable = !!(header_.flags_ & FrameFlags::RESUME_ENABLE);
-    setupPayload.protocolVersion =
-        ProtocolVersion(versionMajor_, versionMinor_);
-  }
+void Frame_SETUP::moveToSetupPayload(SetupParameters& setupPayload) {
+  setupPayload.metadataMimeType = std::move(metadataMimeType_);
+  setupPayload.dataMimeType = std::move(dataMimeType_);
+  setupPayload.payload = std::move(payload_);
+  setupPayload.token = std::move(token_);
+  setupPayload.resumable = !!(header_.flags & FrameFlags::RESUME_ENABLE);
+  setupPayload.protocolVersion = ProtocolVersion(versionMajor_, versionMinor_);
+}
 
-  std::ostream& operator<<(std::ostream& os, const Frame_LEASE& frame) {
-    return os << frame.header_ << ", ("
-              << (frame.metadata_ ? frame.metadata_->computeChainDataLength()
-                                  : 0)
-              << ")";
-  }
+std::ostream& operator<<(std::ostream& os, const Frame_LEASE& frame) {
+  return os << frame.header_ << ", ("
+            << (frame.metadata_ ? frame.metadata_->computeChainDataLength() : 0)
+            << ")";
+}
 
-  std::ostream& operator<<(std::ostream& os, const Frame_RESUME& frame) {
-    return os << frame.header_ << ", ("
-              << "token " << frame.token_ << ", @server "
-              << frame.lastReceivedServerPosition_ << ", @client "
-              << frame.clientPosition_ << ")";
-  }
+std::ostream& operator<<(std::ostream& os, const Frame_RESUME& frame) {
+  return os << frame.header_ << ", ("
+            << "token " << frame.token_ << ", @server "
+            << frame.lastReceivedServerPosition_ << ", @client "
+            << frame.clientPosition_ << ")";
+}
 
-  std::ostream& operator<<(std::ostream& os, const Frame_RESUME_OK& frame) {
-    return os << frame.header_ << ", (@" << frame.position_ << ")";
-  }
+std::ostream& operator<<(std::ostream& os, const Frame_RESUME_OK& frame) {
+  return os << frame.header_ << ", (@" << frame.position_ << ")";
+}
 
-  std::ostream& operator<<(
-      std::ostream& os, const Frame_REQUEST_CHANNEL& frame) {
-    return os << frame.header_ << ", " << frame.payload_;
-  }
+std::ostream& operator<<(std::ostream& os, const Frame_REQUEST_CHANNEL& frame) {
+  return os << frame.header_ << ", " << frame.payload_;
+}
 
-  std::ostream& operator<<(
-      std::ostream& os, const Frame_REQUEST_STREAM& frame) {
-    return os << frame.header_ << ", initialRequestN=" << frame.requestN_
-              << ", " << frame.payload_;
-  }
+std::ostream& operator<<(std::ostream& os, const Frame_REQUEST_STREAM& frame) {
+  return os << frame.header_ << ", initialRequestN=" << frame.requestN_ << ", "
+            << frame.payload_;
+}
 
-  StreamType getStreamType(FrameType frameType) {
-    if (frameType == FrameType::REQUEST_STREAM) {
-      return StreamType::STREAM;
-    } else if (frameType == FrameType::REQUEST_CHANNEL) {
-      return StreamType::CHANNEL;
-    } else if (frameType == FrameType::REQUEST_RESPONSE) {
-      return StreamType::REQUEST_RESPONSE;
-    } else if (frameType == FrameType::REQUEST_FNF) {
-      return StreamType::FNF;
-    } else {
-      LOG(FATAL) << "Unknown open stream frame : " << frameType;
-    }
+StreamType getStreamType(FrameType frameType) {
+  if (frameType == FrameType::REQUEST_STREAM) {
+    return StreamType::STREAM;
+  } else if (frameType == FrameType::REQUEST_CHANNEL) {
+    return StreamType::CHANNEL;
+  } else if (frameType == FrameType::REQUEST_RESPONSE) {
+    return StreamType::REQUEST_RESPONSE;
+  } else if (frameType == FrameType::REQUEST_FNF) {
+    return StreamType::FNF;
+  } else {
+    LOG(FATAL) << "Unknown open stream frame : " << frameType;
   }
+}
 
-  bool isNewStreamFrame(FrameType frameType) {
-    return frameType == FrameType::REQUEST_CHANNEL ||
-        frameType == FrameType::REQUEST_STREAM ||
-        frameType == FrameType::REQUEST_RESPONSE ||
-        frameType == FrameType::REQUEST_FNF;
-  }
+bool isNewStreamFrame(FrameType frameType) {
+  return frameType == FrameType::REQUEST_CHANNEL ||
+      frameType == FrameType::REQUEST_STREAM ||
+      frameType == FrameType::REQUEST_RESPONSE ||
+      frameType == FrameType::REQUEST_FNF;
+}
 
 } // namespace rsocket

--- a/rsocket/framing/FrameHeader.cpp
+++ b/rsocket/framing/FrameHeader.cpp
@@ -1,0 +1,83 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "rsocket/framing/FrameHeader.h"
+
+#include <map>
+#include <ostream>
+#include <vector>
+
+namespace rsocket {
+
+namespace {
+
+constexpr auto kEmpty = "0x00";
+constexpr auto kMetadata = "METADATA";
+constexpr auto kResumeEnable = "RESUME_ENABLE";
+constexpr auto kLease = "LEASE";
+constexpr auto kKeepAliveRespond = "KEEPALIVE_RESPOND";
+constexpr auto kFollows = "FOLLOWS";
+constexpr auto kComplete = "COMPLETE";
+constexpr auto kNext = "NEXT";
+
+std::map<FrameType, std::vector<std::pair<FrameFlags, std::string>>>
+    flagToNameMap{
+        {FrameType::REQUEST_N, {}},
+        {FrameType::REQUEST_RESPONSE,
+         {{FrameFlags::METADATA, kMetadata}, {FrameFlags::FOLLOWS, kFollows}}},
+        {FrameType::REQUEST_FNF,
+         {{FrameFlags::METADATA, kMetadata}, {FrameFlags::FOLLOWS, kFollows}}},
+        {FrameType::METADATA_PUSH, {}},
+        {FrameType::CANCEL, {}},
+        {FrameType::PAYLOAD,
+         {{FrameFlags::METADATA, kMetadata},
+          {FrameFlags::FOLLOWS, kFollows},
+          {FrameFlags::COMPLETE, kComplete},
+          {FrameFlags::NEXT, kNext}}},
+        {FrameType::ERROR, {{FrameFlags::METADATA, kMetadata}}},
+        {FrameType::KEEPALIVE,
+         {{FrameFlags::KEEPALIVE_RESPOND, kKeepAliveRespond}}},
+        {FrameType::SETUP,
+         {{FrameFlags::METADATA, kMetadata},
+          {FrameFlags::RESUME_ENABLE, kResumeEnable},
+          {FrameFlags::LEASE, kLease}}},
+        {FrameType::LEASE, {{FrameFlags::METADATA, kMetadata}}},
+        {FrameType::RESUME, {}},
+        {FrameType::REQUEST_CHANNEL,
+         {{FrameFlags::METADATA, kMetadata},
+          {FrameFlags::FOLLOWS, kFollows},
+          {FrameFlags::COMPLETE, kComplete}}},
+        {FrameType::REQUEST_STREAM,
+         {{FrameFlags::METADATA, kMetadata}, {FrameFlags::FOLLOWS, kFollows}}}};
+
+std::ostream&
+writeFlags(std::ostream& os, FrameFlags frameFlags, FrameType frameType) {
+  FrameFlags foundFlags = FrameFlags::EMPTY;
+
+  // Search the corresponding string value for each flag, insert the missing
+  // ones as empty
+  auto const& allowedFlags = flagToNameMap[frameType];
+
+  std::string delimiter = "";
+  for (const auto& pair : allowedFlags) {
+    if (!!(frameFlags & pair.first)) {
+      os << delimiter << pair.second;
+      delimiter = "|";
+      foundFlags |= pair.first;
+    }
+  }
+
+  if (foundFlags != frameFlags) {
+    os << frameFlags;
+  } else if (delimiter.empty()) {
+    os << kEmpty;
+  }
+  return os;
+}
+}
+
+std::ostream& operator<<(std::ostream& os, const FrameHeader& header) {
+  os << header.type << "[";
+  return writeFlags(os, header.flags, header.type)
+      << ", " << header.streamId << "]";
+}
+}

--- a/rsocket/framing/FrameHeader.h
+++ b/rsocket/framing/FrameHeader.h
@@ -1,0 +1,34 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include <iosfwd>
+
+#include "rsocket/framing/FrameFlags.h"
+#include "rsocket/framing/FrameType.h"
+#include "rsocket/internal/Common.h"
+
+namespace rsocket {
+
+class FrameHeader {
+ public:
+  FrameHeader() {}
+
+  FrameHeader(FrameType ty, FrameFlags fflags, StreamId stream)
+      : type{ty}, flags{fflags}, streamId{stream} {}
+
+  bool flagsComplete() const {
+    return !!(flags & FrameFlags::COMPLETE);
+  }
+
+  bool flagsNext() const {
+    return !!(flags & FrameFlags::NEXT);
+  }
+
+  FrameType type{FrameType::RESERVED};
+  FrameFlags flags{FrameFlags::EMPTY};
+  StreamId streamId{0};
+};
+
+std::ostream& operator<<(std::ostream&, const FrameHeader&);
+}

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -425,14 +425,14 @@ void RSocketStateMachine::handleConnectionFrame(
       VLOG(3) << mode_ << " In: " << frame;
       resumeManager_->resetUpToPosition(frame.position_);
       if (mode_ == RSocketMode::SERVER) {
-        if (!!(frame.header_.flags_ & FrameFlags::KEEPALIVE_RESPOND)) {
+        if (!!(frame.header_.flags & FrameFlags::KEEPALIVE_RESPOND)) {
           sendKeepalive(FrameFlags::EMPTY, std::move(frame.data_));
         } else {
           closeWithError(
               Frame_ERROR::connectionError("keepalive without flag"));
         }
       } else {
-        if (!!(frame.header_.flags_ & FrameFlags::KEEPALIVE_RESPOND)) {
+        if (!!(frame.header_.flags & FrameFlags::KEEPALIVE_RESPOND)) {
           closeWithError(Frame_ERROR::connectionError(
               "client received keepalive with respond flag"));
         } else if (keepaliveTimer_) {

--- a/test/framing/FrameTest.cpp
+++ b/test/framing/FrameTest.cpp
@@ -44,9 +44,9 @@ void expectHeader(
     FrameFlags flags,
     StreamId streamId,
     const Frame& frame) {
-  EXPECT_EQ(type, frame.header_.type_);
-  EXPECT_EQ(streamId, frame.header_.streamId_);
-  EXPECT_EQ(flags, frame.header_.flags_);
+  EXPECT_EQ(type, frame.header_.type);
+  EXPECT_EQ(streamId, frame.header_.streamId);
+  EXPECT_EQ(flags, frame.header_.flags);
 }
 
 TEST(FrameTest, Frame_REQUEST_STREAM) {


### PR DESCRIPTION
Part of making Frame.{cpp,h} smaller.

Also get rid of the NDEBUG case of not setting the FrameType in the default
constructor.  This won't affect performance.