### PR TITLE
Don't crash if user defined function throws at onNext

### DIFF
--- a/yarpl/include/yarpl/flowable/Subscribers.h
+++ b/yarpl/include/yarpl/flowable/Subscribers.h
@@ -83,6 +83,7 @@ class Subscribers {
         next_(std::move(value));
       } catch (const std::exception& exn) {
         userError_ = true;
+        Subscriber<T>::subscription()->cancel();
         onError(folly::exception_wrapper{std::current_exception(), exn});
         return;
       }

--- a/yarpl/include/yarpl/flowable/Subscribers.h
+++ b/yarpl/include/yarpl/flowable/Subscribers.h
@@ -113,7 +113,13 @@ class Subscribers {
 
     void onError(folly::exception_wrapper error) override {
       Subscriber<T>::onError(error);
-      error_(std::move(error));
+      try {
+        error_(std::move(error));
+      } catch (const std::exception& exn) {
+        auto ew = folly::exception_wrapper{std::current_exception(), exn};
+        DLOG(FATAL) << "'error' method should not throw: " << ew.what();
+        LOG(ERROR) << "'error' method should not throw: " << ew.what();
+      }
     }
 
    private:
@@ -137,7 +143,13 @@ class Subscribers {
     void onComplete() {
       if (!userError_) { // already errored?
         Subscriber<T>::onComplete();
-        complete_();
+        try {
+          complete_();
+        } catch (const std::exception& exn) {
+          auto ew = folly::exception_wrapper{std::current_exception(), exn};
+          DLOG(FATAL) << "'complete' method should not throw: " << ew.what();
+          LOG(ERROR) << "'complete' method should not throw: " << ew.what();
+        }
       }
     }
 

--- a/yarpl/test/FlowableTest.cpp
+++ b/yarpl/test/FlowableTest.cpp
@@ -593,5 +593,20 @@ TEST(FlowableTest, SubscribeMultipleTimes) {
   EXPECT_EQ(results[4], std::vector<int64_t>({1, 2, 3, 4, 5}));
 }
 
+TEST(FlowableTest, ConsumerThrows_OnNext) {
+  auto range = Flowables::range(1, 10);
+  bool onErrorIsCalled {false};
+
+  range->subscribe([](auto){
+    throw std::runtime_error("throw at consumption");
+  }, [&onErrorIsCalled](auto ex) {
+    onErrorIsCalled = true;
+  }, [](){
+    FAIL() << "onError should have been called";
+  });
+
+  EXPECT_TRUE(onErrorIsCalled);
+}
+
 } // flowable
 } // yarpl

--- a/yarpl/test/FlowableTest.cpp
+++ b/yarpl/test/FlowableTest.cpp
@@ -594,19 +594,41 @@ TEST(FlowableTest, SubscribeMultipleTimes) {
 }
 
 TEST(FlowableTest, ConsumerThrows_OnNext) {
-  auto range = Flowables::range(1, 10);
-  bool onErrorIsCalled {false};
+  bool onErrorIsCalled{false};
 
-  range->subscribe([](auto){
-    throw std::runtime_error("throw at consumption");
-  }, [&onErrorIsCalled](auto ex) {
-    onErrorIsCalled = true;
-  }, [](){
-    FAIL() << "onError should have been called";
-  });
+  Flowables::range(1, 10)->subscribe(
+      [](auto) { throw std::runtime_error("throw at consumption"); },
+      [&onErrorIsCalled](auto ex) { onErrorIsCalled = true; },
+      []() { FAIL() << "onError should have been called"; });
 
   EXPECT_TRUE(onErrorIsCalled);
 }
 
-} // flowable
-} // yarpl
+TEST(FlowableTest, ConsumerThrows_OnError) {
+  try {
+    Flowables::range(1, 10)->subscribe(
+        [](auto) { throw std::runtime_error("throw at consumption"); },
+        [](auto) { throw std::runtime_error("throw at onError"); },
+        []() { FAIL() << "onError should have been called"; });
+  } catch (const std::runtime_error& exn) {
+    FAIL() << "Error thrown in onError should have been caught.";
+  } catch (...) {
+    LOG(INFO) << "The app crashes in DEBUG mode to inform the implementor.";
+  }
+}
+
+TEST(FlowableTest, ConsumerThrows_OnComplete) {
+  try {
+    Flowables::range(1, 10)->subscribe(
+        [](auto) {},
+        [](auto) { FAIL() << "onComplete should have been called"; },
+        []() { throw std::runtime_error("throw at onComplete"); });
+  } catch (const std::runtime_error&) {
+    FAIL() << "Error thrown in onComplete should have been caught.";
+  } catch (...) {
+    LOG(INFO) << "The app crashes in DEBUG mode to inform the implementor.";
+  }
+}
+
+} // namespace flowable
+} // namespace yarpl


### PR DESCRIPTION
We have two common ways to subscribe to a flowable. One is implementing a `Subscriber` and providing this to the `subscribe` method. This is kind of a pro way of consuming the `Flowable`.

Another easy to use, common usage, case is just providing a `lambda` function that consumes the data. When this way is selected, if the given `lambda` function throws, it causes the whole application to crash.

In this update, I have encapsulated the user provided function with try/catch, so we will not need to do any more changes in the base Subscriber class at all and still be able to provide safety for the simple usage.

Note: instead of calling `onError` method of the parent class, I have taken the `onError` method of the Subscriber to Base class via `using`. So when this function is overriden, it will not call the parent class, but the method which has overrided it. So it will call the `error` lambda that the user has provided.