### PR TITLE
Allow client stateMachine to run on separate EventBase

### DIFF
--- a/rsocket/RSocket.cpp
+++ b/rsocket/RSocket.cpp
@@ -12,17 +12,19 @@ folly::Future<std::unique_ptr<RSocketClient>> RSocket::createConnectedClient(
     std::shared_ptr<RSocketStats> stats,
     std::shared_ptr<RSocketConnectionEvents> connectionEvents,
     std::shared_ptr<ResumeManager> resumeManager,
-    std::shared_ptr<ColdResumeHandler> coldResumeHandler) {
+    std::shared_ptr<ColdResumeHandler> coldResumeHandler,
+    folly::EventBase* stateMachineEvb) {
   auto createRSC = [
-      connectionFactory,
-      setupParameters = std::move(setupParameters),
-      responder = std::move(responder),
-      keepaliveTimer = std::move(keepaliveTimer),
-      stats = std::move(stats),
-      connectionEvents = std::move(connectionEvents),
-      resumeManager = std::move(resumeManager),
-      coldResumeHandler = std::move(coldResumeHandler)](
-      ConnectionFactory::ConnectedDuplexConnection connection) mutable {
+    connectionFactory,
+    setupParameters = std::move(setupParameters),
+    responder = std::move(responder),
+    keepaliveTimer = std::move(keepaliveTimer),
+    stats = std::move(stats),
+    connectionEvents = std::move(connectionEvents),
+    resumeManager = std::move(resumeManager),
+    coldResumeHandler = std::move(coldResumeHandler),
+    stateMachineEvb
+  ](ConnectionFactory::ConnectedDuplexConnection connection) mutable {
     VLOG(3) << "createConnectedClient received DuplexConnection";
     return RSocket::createClientFromConnection(
         std::move(connection.connection),
@@ -34,23 +36,22 @@ folly::Future<std::unique_ptr<RSocketClient>> RSocket::createConnectedClient(
         std::move(stats),
         std::move(connectionEvents),
         std::move(resumeManager),
-        std::move(coldResumeHandler));
+        std::move(coldResumeHandler),
+        stateMachineEvb);
   };
 
-  return connectionFactory->connect().then(
-      [createRSC = std::move(createRSC)](
-          ConnectionFactory::ConnectedDuplexConnection connection) mutable {
-        // fromConnection method must be called from the eventBase and since
-        // there is no guarantee that the Future returned from the
-        // connectionFactory::connect method is executed on the event base,
-        // we have to ensure it by using folly::via
-        auto* eventBase = &connection.eventBase;
-        return via(eventBase,
-            [connection = std::move(
-                connection), createRSC = std::move(createRSC)]() mutable {
-              return createRSC(std::move(connection));
-            });
-      });
+  return connectionFactory->connect().then([createRSC = std::move(createRSC)](
+      ConnectionFactory::ConnectedDuplexConnection connection) mutable {
+    // fromConnection method must be called from the transport eventBase
+    // and since there is no guarantee that the Future returned from the
+    // connectionFactory::connect method is executed on the event base, we
+    // have to ensure it by using folly::via
+    auto* transportEvb = &connection.eventBase;
+    return via(transportEvb, [
+      connection = std::move(connection),
+      createRSC = std::move(createRSC)
+    ]() mutable { return createRSC(std::move(connection)); });
+  });
 }
 
 folly::Future<std::unique_ptr<RSocketClient>> RSocket::createResumedClient(
@@ -62,7 +63,8 @@ folly::Future<std::unique_ptr<RSocketClient>> RSocket::createResumedClient(
     std::unique_ptr<KeepaliveTimer> keepaliveTimer,
     std::shared_ptr<RSocketStats> stats,
     std::shared_ptr<RSocketConnectionEvents> connectionEvents,
-    ProtocolVersion protocolVersion) {
+    ProtocolVersion protocolVersion,
+    folly::EventBase* stateMachineEvb) {
   auto* c = new RSocketClient(
       std::move(connectionFactory),
       std::move(protocolVersion),
@@ -74,15 +76,15 @@ folly::Future<std::unique_ptr<RSocketClient>> RSocket::createResumedClient(
       std::move(resumeManager),
       std::move(coldResumeHandler));
 
-  return c->resume().then(
-      [client = std::unique_ptr<RSocketClient>(c)]() mutable {
+  return c->resume(stateMachineEvb)
+      .then([client = std::unique_ptr<RSocketClient>(c)]() mutable {
         return std::move(client);
       });
 }
 
 std::unique_ptr<RSocketClient> RSocket::createClientFromConnection(
     std::unique_ptr<DuplexConnection> connection,
-    folly::EventBase& eventBase,
+    folly::EventBase& transportEvb,
     SetupParameters setupParameters,
     std::shared_ptr<ConnectionFactory> connectionFactory,
     std::shared_ptr<RSocketResponder> responder,
@@ -90,7 +92,8 @@ std::unique_ptr<RSocketClient> RSocket::createClientFromConnection(
     std::shared_ptr<RSocketStats> stats,
     std::shared_ptr<RSocketConnectionEvents> connectionEvents,
     std::shared_ptr<ResumeManager> resumeManager,
-    std::shared_ptr<ColdResumeHandler> coldResumeHandler) {
+    std::shared_ptr<ColdResumeHandler> coldResumeHandler,
+    folly::EventBase* stateMachineEvb) {
   auto c = std::unique_ptr<RSocketClient>(new RSocketClient(
       std::move(connectionFactory),
       setupParameters.protocolVersion,
@@ -101,7 +104,11 @@ std::unique_ptr<RSocketClient> RSocket::createClientFromConnection(
       std::move(connectionEvents),
       std::move(resumeManager),
       std::move(coldResumeHandler)));
-  c->fromConnection(std::move(connection), eventBase, std::move(setupParameters));
+  c->fromConnection(
+      std::move(connection),
+      stateMachineEvb,
+      transportEvb,
+      std::move(setupParameters));
   return c;
 }
 

--- a/rsocket/RSocket.h
+++ b/rsocket/RSocket.h
@@ -25,7 +25,8 @@ class RSocket {
           std::shared_ptr<RSocketConnectionEvents>(),
       std::shared_ptr<ResumeManager> resumeManager = nullptr,
       std::shared_ptr<ColdResumeHandler> coldResumeHandler =
-          std::shared_ptr<ColdResumeHandler>());
+          std::shared_ptr<ColdResumeHandler>(),
+      folly::EventBase* stateMachineEvb = nullptr);
 
   // Creates a RSocketClient which cold-resumes from the provided state
   static folly::Future<std::unique_ptr<RSocketClient>> createResumedClient(
@@ -40,12 +41,13 @@ class RSocket {
       std::shared_ptr<RSocketStats> stats = RSocketStats::noop(),
       std::shared_ptr<RSocketConnectionEvents> connectionEvents =
           std::shared_ptr<RSocketConnectionEvents>(),
-      ProtocolVersion protocolVersion = ProtocolVersion::Current());
+      ProtocolVersion protocolVersion = ProtocolVersion::Current(),
+      folly::EventBase* stateMachineEvb = nullptr);
 
   // Creates a RSocketClient from an existing DuplexConnection
   static std::unique_ptr<RSocketClient> createClientFromConnection(
       std::unique_ptr<DuplexConnection> connection,
-      folly::EventBase& eventBase,
+      folly::EventBase& transportEvb,
       SetupParameters setupParameters = SetupParameters(),
       std::shared_ptr<ConnectionFactory> connectionFactory = nullptr,
       std::shared_ptr<RSocketResponder> responder =
@@ -57,7 +59,8 @@ class RSocket {
           std::shared_ptr<RSocketConnectionEvents>(),
       std::shared_ptr<ResumeManager> resumeManager = nullptr,
       std::shared_ptr<ColdResumeHandler> coldResumeHandler =
-          std::shared_ptr<ColdResumeHandler>());
+          std::shared_ptr<ColdResumeHandler>(),
+      folly::EventBase* stateMachineEvb = nullptr);
 
   // A convenience function to create RSocketServer
   static std::unique_ptr<RSocketServer> createServer(

--- a/rsocket/RSocketClient.h
+++ b/rsocket/RSocketClient.h
@@ -42,7 +42,7 @@ class RSocketClient {
   // it does a cold-resumption.  The returned future resolves on successful
   // resumption.  Else either a ConnectionException or a ResumptionException
   // is raised.
-  folly::Future<folly::Unit> resume();
+  folly::Future<folly::Unit> resume(folly::EventBase* smEvb = nullptr);
 
   // Disconnect the underlying transport.
   folly::Future<folly::Unit> disconnect(folly::exception_wrapper = {});
@@ -64,12 +64,12 @@ class RSocketClient {
   // Create stateMachine with the given DuplexConnection
   void fromConnection(
       std::unique_ptr<DuplexConnection> connection,
-      folly::EventBase& eventBase,
-      SetupParameters setupParameters
-  );
+      folly::EventBase* smEvb,
+      folly::EventBase& transportEvb,
+      SetupParameters setupParameters);
 
   // Creates RSocketStateMachine and RSocketRequester
-  void createState(folly::EventBase& eventBase);
+  void createState();
 
   std::shared_ptr<ConnectionFactory> connectionFactory_;
   std::shared_ptr<ConnectionSet> connectionSet_;

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -99,7 +99,7 @@ bool RSocketStateMachine::resumeServer(
 }
 
 void RSocketStateMachine::connectClient(
-    std::unique_ptr<DuplexConnection> connection,
+    yarpl::Reference<FrameTransport> transport,
     SetupParameters params) {
   auto const version = params.protocolVersion == ProtocolVersion::Unknown
       ? ProtocolVersion::Current()
@@ -107,8 +107,6 @@ void RSocketStateMachine::connectClient(
   setFrameSerializer(FrameSerializer::createFrameSerializer(version));
 
   setResumable(params.resumable);
-
-  auto transport = yarpl::make_ref<FrameTransportImpl>(std::move(connection));
 
   Frame_SETUP frame(
       params.resumable ? FrameFlags::RESUME_ENABLE : FrameFlags::EMPTY,

--- a/rsocket/statemachine/RSocketStateMachine.h
+++ b/rsocket/statemachine/RSocketStateMachine.h
@@ -80,7 +80,7 @@ class RSocketStateMachine final
   bool resumeServer(yarpl::Reference<FrameTransport>, const ResumeParameters&);
 
   /// Connect as a client.  Sends a SETUP frame.
-  void connectClient(std::unique_ptr<DuplexConnection>, SetupParameters);
+  void connectClient(yarpl::Reference<FrameTransport>, SetupParameters);
 
   /// Resume a connection as a client.  Sends a RESUME frame.
   void resumeClient(

--- a/test/RSocketClientServerTest.cpp
+++ b/test/RSocketClientServerTest.cpp
@@ -68,6 +68,16 @@ TEST(RSocketClientServer, ConnectManyAsync) {
   workers.clear();
 }
 
+TEST(RSocketClientServer, ConnectOnDifferentEvb) {
+  folly::ScopedEventBaseThread transportWorker;
+  folly::ScopedEventBaseThread stateMachineWorker;
+  auto server = makeServer(std::make_shared<HelloStreamRequestHandler>());
+  auto client = makeClient(
+      transportWorker.getEventBase(),
+      *server->listeningPort(),
+      stateMachineWorker.getEventBase());
+}
+
 /// Test destroying a client with an open connection on the same worker thread
 /// as that connection.
 TEST(RSocketClientServer, ClientClosesOnWorker) {

--- a/test/RSocketTests.h
+++ b/test/RSocketTests.h
@@ -25,26 +25,30 @@ std::unique_ptr<RSocketServer> makeResumableServer(
 
 std::unique_ptr<RSocketClient> makeClient(
     folly::EventBase* eventBase,
-    uint16_t port);
+    uint16_t port,
+    folly::EventBase* stateMachineEvb = nullptr);
 
 std::unique_ptr<RSocketClient> makeDisconnectedClient(
     folly::EventBase* eventBase);
 
 folly::Future<std::unique_ptr<RSocketClient>> makeClientAsync(
     folly::EventBase* eventBase,
-    uint16_t port);
+    uint16_t port,
+    folly::EventBase* stateMachineEvb = nullptr);
 
 std::unique_ptr<RSocketClient> makeWarmResumableClient(
     folly::EventBase* eventBase,
     uint16_t port,
-    std::shared_ptr<RSocketConnectionEvents> connectionEvents = nullptr);
+    std::shared_ptr<RSocketConnectionEvents> connectionEvents = nullptr,
+    folly::EventBase* stateMachineEvb = nullptr);
 
 std::unique_ptr<RSocketClient> makeColdResumableClient(
     folly::EventBase* eventBase,
     uint16_t port,
     ResumeIdentificationToken token,
     std::shared_ptr<ResumeManager> resumeManager,
-    std::shared_ptr<ColdResumeHandler> resumeHandler);
+    std::shared_ptr<ColdResumeHandler> resumeHandler,
+    folly::EventBase* stateMachineEvb = nullptr);
 
 } // namespace client_server
 } // namespace tests


### PR DESCRIPTION
This PR allows clients (new/warm-resumed/cold-resumed) to run the stateMachine and transport in different EventBases.

Added normal connect/disconnect, warm-resumed-client and cold-resumed-client tests.