### PR TITLE
remove InternalSubscriber

### DIFF
--- a/examples/resumption/WarmResumption_Client.cpp
+++ b/examples/resumption/WarmResumption_Client.cpp
@@ -22,7 +22,7 @@ DEFINE_int32(port, 9898, "host:port to connect to");
 namespace {
 
 class HelloSubscriber : public virtual yarpl::Refcounted,
-                        public yarpl::flowable::InternalSubscriber<Payload> {
+                        public yarpl::flowable::Subscriber<Payload> {
  public:
   void request(int n) {
     LOG(INFO) << "... requesting " << n;

--- a/examples/util/ExampleSubscriber.h
+++ b/examples/util/ExampleSubscriber.h
@@ -16,7 +16,7 @@
  */
 namespace rsocket_example {
 class ExampleSubscriber
-    : public yarpl::flowable::InternalSubscriber<rsocket::Payload> {
+    : public yarpl::flowable::Subscriber<rsocket::Payload> {
  public:
   ~ExampleSubscriber();
   ExampleSubscriber(int initialRequest, int numToTake);

--- a/rsocket/RSocketResponder.cpp
+++ b/rsocket/RSocketResponder.cpp
@@ -45,7 +45,7 @@ RSocketResponder::handleRequestChannelCore(
     const yarpl::Reference<yarpl::flowable::Subscriber<Payload>>&
         response) noexcept {
   class EagerSubscriberBridge
-      : public yarpl::flowable::InternalSubscriber<rsocket::Payload> {
+      : public yarpl::flowable::Subscriber<rsocket::Payload> {
    public:
     void onSubscribe(yarpl::Reference<yarpl::flowable::Subscription>
                          subscription) noexcept override {

--- a/rsocket/framing/FramedReader.cpp
+++ b/rsocket/framing/FramedReader.cpp
@@ -67,7 +67,7 @@ size_t FramedReader::readFrameLength() const {
 }
 
 void FramedReader::onSubscribe(yarpl::Reference<Subscription> subscription) {
-  DuplexConnection::InternalSubscriber::onSubscribe(subscription);
+  DuplexConnection::DuplexSubscriber::onSubscribe(subscription);
   subscription->request(std::numeric_limits<int64_t>::max());
 }
 
@@ -131,7 +131,7 @@ void FramedReader::parseFrames() {
 
 void FramedReader::onComplete() {
   payloadQueue_.move();
-  DuplexConnection::InternalSubscriber::onComplete();
+  DuplexConnection::DuplexSubscriber::onComplete();
   if (auto subscriber = std::move(inner_)) {
     // After this call the instance can be destroyed!
     subscriber->onComplete();
@@ -140,7 +140,7 @@ void FramedReader::onComplete() {
 
 void FramedReader::onError(folly::exception_wrapper ex) {
   payloadQueue_.move();
-  DuplexConnection::InternalSubscriber::onError({});
+  DuplexConnection::DuplexSubscriber::onError({});
   if (auto subscriber = std::move(inner_)) {
     // After this call the instance can be destroyed!
     subscriber->onError(std::move(ex));
@@ -205,8 +205,8 @@ void FramedReader::error(std::string errorMsg) {
   VLOG(1) << "error: " << errorMsg;
 
   payloadQueue_.move();
-  if (DuplexConnection::InternalSubscriber::subscription()) {
-    DuplexConnection::InternalSubscriber::subscription()->cancel();
+  if (DuplexConnection::DuplexSubscriber::subscription()) {
+    DuplexConnection::DuplexSubscriber::subscription()->cancel();
   }
   if (auto subscriber = std::move(inner_)) {
     // After this call the instance can be destroyed!

--- a/rsocket/framing/FramedReader.h
+++ b/rsocket/framing/FramedReader.h
@@ -11,7 +11,7 @@
 
 namespace rsocket {
 
-class FramedReader : public DuplexConnection::InternalSubscriber,
+class FramedReader : public DuplexConnection::DuplexSubscriber,
                      public yarpl::flowable::Subscription {
  public:
   explicit FramedReader(std::shared_ptr<ProtocolVersion> version)

--- a/rsocket/framing/FramedWriter.cpp
+++ b/rsocket/framing/FramedWriter.cpp
@@ -50,7 +50,7 @@ size_t FramedWriter::getPayloadLength(size_t payloadLength) const {
 }
 
 void FramedWriter::onSubscribe(yarpl::Reference<Subscription> subscription) {
-  DuplexConnection::InternalSubscriber::onSubscribe(subscription);
+  DuplexConnection::DuplexSubscriber::onSubscribe(subscription);
   stream_->onSubscribe(std::move(subscription));
 }
 
@@ -112,17 +112,17 @@ void FramedWriter::onNextMultiple(
 void FramedWriter::error(std::string errorMsg) {
   VLOG(1) << "error: " << errorMsg;
   onError(std::runtime_error(std::move(errorMsg)));
-  DuplexConnection::InternalSubscriber::subscription()->cancel();
+  DuplexConnection::DuplexSubscriber::subscription()->cancel();
 }
 
 void FramedWriter::onComplete() {
-  DuplexConnection::InternalSubscriber::onComplete();
+  DuplexConnection::DuplexSubscriber::onComplete();
   stream_->onComplete();
   stream_ = nullptr;
 }
 
 void FramedWriter::onError(folly::exception_wrapper ex) {
-  DuplexConnection::InternalSubscriber::onError(ex);
+  DuplexConnection::DuplexSubscriber::onError(ex);
   stream_->onError(std::move(ex));
   stream_ = nullptr;
 }

--- a/rsocket/framing/FramedWriter.h
+++ b/rsocket/framing/FramedWriter.h
@@ -12,7 +12,7 @@ namespace rsocket {
 
 struct ProtocolVersion;
 
-class FramedWriter : public DuplexConnection::InternalSubscriber {
+class FramedWriter : public DuplexConnection::DuplexSubscriber {
  public:
   explicit FramedWriter(
       yarpl::Reference<DuplexConnection::Subscriber> stream,

--- a/rsocket/internal/ScheduledSubscriber.h
+++ b/rsocket/internal/ScheduledSubscriber.h
@@ -19,7 +19,7 @@ namespace rsocket {
 //
 
 template <typename T>
-class ScheduledSubscriber : public yarpl::flowable::InternalSubscriber<T> {
+class ScheduledSubscriber : public yarpl::flowable::Subscriber<T> {
  public:
   ScheduledSubscriber(
       yarpl::Reference<yarpl::flowable::Subscriber<T>> inner,
@@ -89,7 +89,7 @@ class ScheduledSubscriber : public yarpl::flowable::InternalSubscriber<T> {
 //
 template <typename T>
 class ScheduledSubscriptionSubscriber
-    : public yarpl::flowable::InternalSubscriber<T> {
+    : public yarpl::flowable::Subscriber<T> {
  public:
   ScheduledSubscriptionSubscriber(
       yarpl::Reference<yarpl::flowable::Subscriber<T>> inner,

--- a/rsocket/internal/SetupResumeAcceptor.cpp
+++ b/rsocket/internal/SetupResumeAcceptor.cpp
@@ -44,7 +44,7 @@ void closeWithError(
 
 /// Subscriber that owns a connection, sets itself as that connection's input,
 /// and reads out a single frame before cancelling.
-class OneFrameSubscriber : public DuplexConnection::InternalSubscriber {
+class OneFrameSubscriber : public DuplexConnection::DuplexSubscriber {
  public:
   OneFrameSubscriber(
       SetupResumeAcceptor& acceptor,
@@ -65,7 +65,7 @@ class OneFrameSubscriber : public DuplexConnection::InternalSubscriber {
   }
 
   void onSubscribe(yarpl::Reference<yarpl::flowable::Subscription> sub) override {
-    DuplexConnection::InternalSubscriber::onSubscribe(sub);
+    DuplexConnection::DuplexSubscriber::onSubscribe(sub);
     sub->request(std::numeric_limits<int32_t>::max());
   }
 
@@ -75,7 +75,7 @@ class OneFrameSubscriber : public DuplexConnection::InternalSubscriber {
     auto self = ref_from_this(this);
     acceptor_.remove(self);
 
-    if (auto sub = DuplexConnection::InternalSubscriber::subscription()) {
+    if (auto sub = DuplexConnection::DuplexSubscriber::subscription()) {
       sub->cancel();
     }
 
@@ -88,13 +88,13 @@ class OneFrameSubscriber : public DuplexConnection::InternalSubscriber {
 
   void onComplete() override {
     auto self = ref_from_this(this);
-    DuplexConnection::InternalSubscriber::onComplete();
+    DuplexConnection::DuplexSubscriber::onComplete();
     acceptor_.remove(self);
   }
 
   void onError(folly::exception_wrapper ew) override {
     auto self = ref_from_this(this);
-    DuplexConnection::InternalSubscriber::onError(std::move(ew));
+    DuplexConnection::DuplexSubscriber::onError(std::move(ew));
     acceptor_.remove(self);
   }
 

--- a/rsocket/statemachine/ChannelRequester.h
+++ b/rsocket/statemachine/ChannelRequester.h
@@ -12,7 +12,7 @@ namespace rsocket {
 /// Implementation of stream stateMachine that represents a Channel requester.
 class ChannelRequester : public ConsumerBase,
                          public PublisherBase,
-                         public yarpl::flowable::InternalSubscriber<Payload> {
+                         public yarpl::flowable::Subscriber<Payload> {
  public:
   ChannelRequester(std::shared_ptr<StreamsWriter> writer, StreamId streamId)
       : ConsumerBase(std::move(writer), streamId),

--- a/rsocket/statemachine/ChannelResponder.h
+++ b/rsocket/statemachine/ChannelResponder.h
@@ -13,7 +13,7 @@ namespace rsocket {
 /// Implementation of stream stateMachine that represents a Channel responder.
 class ChannelResponder : public ConsumerBase,
                          public PublisherBase,
-                         public yarpl::flowable::InternalSubscriber<Payload> {
+                         public yarpl::flowable::Subscriber<Payload> {
  public:
   ChannelResponder(
       std::shared_ptr<StreamsWriter> writer,

--- a/rsocket/statemachine/StreamResponder.h
+++ b/rsocket/statemachine/StreamResponder.h
@@ -11,7 +11,7 @@ namespace rsocket {
 /// Implementation of stream stateMachine that represents a Stream responder
 class StreamResponder : public StreamStateMachineBase,
                         public PublisherBase,
-                        public yarpl::flowable::InternalSubscriber<Payload> {
+                        public yarpl::flowable::Subscriber<Payload> {
  public:
   StreamResponder(
       std::shared_ptr<StreamsWriter> writer,

--- a/test/fuzzers/frame_fuzzer.cpp
+++ b/test/fuzzers/frame_fuzzer.cpp
@@ -30,11 +30,12 @@ struct FuzzerConnectionAcceptor : rsocket::ConnectionAcceptor {
 
 struct FuzzerDuplexConnection : rsocket::DuplexConnection {
   using Subscriber = rsocket::DuplexConnection::Subscriber;
+  using DuplexSubscriber = rsocket::DuplexConnection::DuplexSubscriber;
 
-  struct SinkSubscriber : InternalSubscriber {
+  struct SinkSubscriber : DuplexSubscriber {
     std::vector<std::unique_ptr<folly::IOBuf>> sent_buffers;
 
-    void onNext(std::unique_ptr<folly::IOBuf> buf) {
+    void onNext(std::unique_ptr<folly::IOBuf> buf) override {
       VLOG(1) << "SinkSubscriber::onNext(\""
               << folly::humanify(buf->cloneAsValue().moveToFbString()) << "\")"
               << std::endl;

--- a/test/test_utils/MockDuplexConnection.h
+++ b/test/test_utils/MockDuplexConnection.h
@@ -11,9 +11,7 @@ namespace rsocket {
 
 class MockDuplexConnection : public DuplexConnection {
 public:
- using InternalSubscriber =
-     yarpl::flowable::InternalSubscriber<std::unique_ptr<folly::IOBuf>>;
- using Subscriber = yarpl::flowable::Subscriber<std::unique_ptr<folly::IOBuf>>;
+ using Subscriber = DuplexConnection::Subscriber;
 
  MockDuplexConnection() {
    ON_CALL(*this, getOutput_()).WillByDefault(testing::Invoke([] {

--- a/test/test_utils/PrintSubscriber.h
+++ b/test/test_utils/PrintSubscriber.h
@@ -6,7 +6,7 @@
 #include "yarpl/flowable/Subscriber.h"
 
 namespace rsocket {
-class PrintSubscriber : public yarpl::flowable::InternalSubscriber<Payload> {
+class PrintSubscriber : public yarpl::flowable::Subscriber<Payload> {
  public:
   ~PrintSubscriber();
 

--- a/yarpl/include/yarpl/flowable/CancelingSubscriber.h
+++ b/yarpl/include/yarpl/flowable/CancelingSubscriber.h
@@ -13,15 +13,20 @@ namespace flowable {
  * A Subscriber that always cancels the subscription passed to it.
  */
 template <typename T>
-class CancelingSubscriber final : public InternalSubscriber<T> {
+class CancelingSubscriber final : public BaseSubscriber<T> {
  public:
-  void onSubscribe(
-      yarpl::Reference<yarpl::flowable::Subscription> sub) override {
-    sub->cancel();
+  void onSubscribeImpl() override {
+    this->cancel();
   }
 
-  void onNext(T) override {
+  void onNextImpl(T) override {
     throw std::logic_error{"CancelingSubscriber::onNext() can never be called"};
+  }
+  void onCompleteImpl() override {
+    throw std::logic_error{"CancelingSubscriber::onComplete() can never be called"};
+  }
+  void onErrorImpl(folly::exception_wrapper) override {
+    throw std::logic_error{"CancelingSubscriber::onError() can never be called"};
   }
 };
 }

--- a/yarpl/include/yarpl/flowable/EmitterFlowable.h
+++ b/yarpl/include/yarpl/flowable/EmitterFlowable.h
@@ -31,7 +31,7 @@ class EmiterBase : public virtual Refcounted {
  * of a request(n) call.
  */
 template <typename T>
-class EmiterSubscription : public Subscription, public InternalSubscriber<T> {
+class EmiterSubscription : public Subscription, public Subscriber<T> {
   constexpr static auto kCanceled = credits::kCanceled;
   constexpr static auto kNoFlowControl = credits::kNoFlowControl;
 

--- a/yarpl/include/yarpl/flowable/FlowableObserveOnOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableObserveOnOperator.h
@@ -40,7 +40,7 @@ class ObserveOnOperatorSubscription : public yarpl::flowable::Subscription,
 
 template <typename T>
 class ObserveOnOperatorSubscriber
-    : public yarpl::flowable::InternalSubscriber<T> {
+    : public yarpl::flowable::Subscriber<T> {
  public:
   ObserveOnOperatorSubscriber(
       Reference<Subscriber<T>> inner,

--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -36,7 +36,7 @@ class FlowableOperator : public Flowable<D> {
   /// subscriber for the previous stage; as a subscription for the next one, the
   /// user-supplied subscriber being the last of the pipeline stages.
   class Subscription : public yarpl::flowable::Subscription,
-                       public InternalSubscriber<U> {
+                       public Subscriber<U> {
    protected:
     Subscription(
         Reference<Operator> flowable,

--- a/yarpl/include/yarpl/flowable/Subscriber.h
+++ b/yarpl/include/yarpl/flowable/Subscriber.h
@@ -21,40 +21,6 @@ class Subscriber : public virtual Refcounted, public yarpl::enable_get_ref {
   virtual void onNext(T) = 0;
 };
 
-// codemod all things that inherit from Subscriber to inherit from
-// InternalSubscriber
-template <typename T>
-class InternalSubscriber : public Subscriber<T> {
- public:
-  // Note: If any of the following methods is overridden in a subclass, the new
-  // methods SHOULD ensure that these are invoked as well.
-  void onSubscribe(Reference<Subscription> subscription) override {
-    DCHECK(subscription);
-    CHECK(!subscription_);
-    subscription_ = std::move(subscription);
-  }
-
-  // No further calls to the subscription after this method is invoked.
-  void onComplete() override {
-    DCHECK(subscription_) << "Calling onComplete() without a subscription";
-    subscription_.reset();
-  }
-
-  // No further calls to the subscription after this method is invoked.
-  void onError(folly::exception_wrapper) override {
-    DCHECK(subscription_) << "Calling onError() without a subscription";
-    subscription_.reset();
-  }
-
- protected:
-  Reference<Subscription> subscription() {
-    return subscription_;
-  }
-
- private:
-  Reference<Subscription> subscription_;
-};
-
 // T : Type of Flowable that this Subscriber operates on
 //
 // keep_reference_to_this : BaseSubscriber will keep a live reference to
@@ -79,8 +45,6 @@ class BaseSubscriber : public Subscriber<T> {
 
   // No further calls to the subscription after this method is invoked.
   void onComplete() final override {
-    DCHECK(subscription_) << "Calling onComplete() without a subscription";
-
     if(auto sub = subscription_.exchange(nullptr)) {
       onCompleteImpl();
       onTerminateImpl();
@@ -89,8 +53,6 @@ class BaseSubscriber : public Subscriber<T> {
 
   // No further calls to the subscription after this method is invoked.
   void onError(folly::exception_wrapper e) final override {
-    DCHECK(subscription_) << "Calling onError() without a subscription";
-
     if(auto sub = subscription_.exchange(nullptr)) {
       onErrorImpl(std::move(e));
       onTerminateImpl();

--- a/yarpl/include/yarpl/flowable/TestSubscriber.h
+++ b/yarpl/include/yarpl/flowable/TestSubscriber.h
@@ -26,7 +26,7 @@ namespace flowable {
  * ts->assert...
  */
 template <typename T>
-class TestSubscriber : public InternalSubscriber<T> {
+class TestSubscriber : public Subscriber<T> {
  public:
   static_assert(
       std::is_copy_constructible<T>::value,

--- a/yarpl/test/FlowableTest.cpp
+++ b/yarpl/test/FlowableTest.cpp
@@ -20,27 +20,24 @@ namespace {
  * Used in place of TestSubscriber where we have move-only types.
  */
 template <typename T>
-class CollectingSubscriber : public InternalSubscriber<T> {
+class CollectingSubscriber : public BaseSubscriber<T> {
  public:
   explicit CollectingSubscriber(int64_t requestCount = 100)
       : requestCount_(requestCount) {}
 
-  void onSubscribe(Reference<Subscription> subscription) override {
-    InternalSubscriber<T>::onSubscribe(subscription);
-    subscription->request(requestCount_);
+  void onSubscribeImpl() override {
+    this->request(requestCount_);
   }
 
-  void onNext(T next) override {
+  void onNextImpl(T next) override {
     values_.push_back(std::move(next));
   }
 
-  void onComplete() override {
-    InternalSubscriber<T>::onComplete();
+  void onCompleteImpl() override {
     complete_ = true;
   }
 
-  void onError(folly::exception_wrapper ex) override {
-    InternalSubscriber<T>::onError(ex);
+  void onErrorImpl(folly::exception_wrapper ex) override {
     error_ = true;
     errorMsg_ = ex.get_exception()->what();
   }
@@ -62,7 +59,7 @@ class CollectingSubscriber : public InternalSubscriber<T> {
   }
 
   void cancelSubscription() {
-    InternalSubscriber<T>::subscription()->cancel();
+    this->cancel();
   }
 
  private:
@@ -404,27 +401,25 @@ TEST(FlowableTest, FlowableCompleteInTheMiddle) {
   EXPECT_EQ(std::size_t{1}, subscriber->values().size());
 }
 
-class RangeCheckingSubscriber : public InternalSubscriber<int32_t> {
+class RangeCheckingSubscriber : public BaseSubscriber<int32_t> {
  public:
   explicit RangeCheckingSubscriber(int32_t total, folly::Baton<>& b)
       : total_(total), onComplete_(b) {}
 
-  void onSubscribe(Reference<Subscription> subscription) override {
-    InternalSubscriber<int32_t>::onSubscribe(subscription);
-    subscription->request(total_);
+  void onSubscribeImpl() override {
+    this->request(total_);
   }
 
-  void onNext(int32_t val) override {
+  void onNextImpl(int32_t val) override {
     EXPECT_EQ(val, current_);
     current_++;
   }
 
-  void onError(folly::exception_wrapper) override {
+  void onErrorImpl(folly::exception_wrapper) override {
     FAIL() << "shouldn't call onError";
   }
 
-  void onComplete() override {
-    InternalSubscriber<int32_t>::onComplete();
+  void onCompleteImpl() override {
     EXPECT_EQ(total_, current_);
     onComplete_.post();
   }
@@ -464,7 +459,7 @@ TEST(FlowableTest, FlowableFromDifferentThreads) {
 }
 } // namespace
 
-class ErrorRangeCheckingSubscriber : public InternalSubscriber<int32_t> {
+class ErrorRangeCheckingSubscriber : public BaseSubscriber<int32_t> {
  public:
   explicit ErrorRangeCheckingSubscriber(
       int32_t expect,
@@ -476,17 +471,16 @@ class ErrorRangeCheckingSubscriber : public InternalSubscriber<int32_t> {
         onError_(b),
         expectedErr_(expected_err) {}
 
-  void onSubscribe(Reference<Subscription> subscription) override {
-    InternalSubscriber<int32_t>::onSubscribe(subscription);
-    subscription->request(request_);
+  void onSubscribeImpl() override {
+    this->request(request_);
   }
 
-  void onNext(int32_t val) override {
+  void onNextImpl(int32_t val) override {
     EXPECT_EQ(val, current_);
     current_++;
   }
 
-  void onError(folly::exception_wrapper err) override {
+  void onErrorImpl(folly::exception_wrapper err) override {
     EXPECT_EQ(expect_, current_);
     EXPECT_TRUE(err);
     EXPECT_EQ(
@@ -494,8 +488,7 @@ class ErrorRangeCheckingSubscriber : public InternalSubscriber<int32_t> {
     onError_.post();
   }
 
-  void onComplete() override {
-    InternalSubscriber<int32_t>::onComplete();
+  void onCompleteImpl() override {
     FAIL() << "shouldn't ever onComplete";
   }
 
@@ -593,6 +586,22 @@ TEST(FlowableTest, SubscribeMultipleTimes) {
   EXPECT_EQ(results[4], std::vector<int64_t>({1, 2, 3, 4, 5}));
 }
 
+/* following test should probably behave like:
+ *
+TEST(FlowableTest, ConsumerThrows_OnNext) {
+  auto range = Flowables::range(1, 10);
+
+  EXPECT_THROWS({
+    range->subscribe(
+        // onNext
+        [](auto) { throw std::runtime_error("throw at consumption"); },
+        // onError
+        [](auto) { FAIL(); },
+        // onComplete
+        []() { FAIL(); });
+  });
+}
+*/
 TEST(FlowableTest, ConsumerThrows_OnNext) {
   bool onErrorIsCalled{false};
 

--- a/yarpl/test/ReferenceTest.cpp
+++ b/yarpl/test/ReferenceTest.cpp
@@ -11,14 +11,17 @@
 using yarpl::Refcounted;
 using yarpl::Reference;
 using yarpl::AtomicReference;
-using yarpl::flowable::InternalSubscriber;
 using yarpl::flowable::Subscriber;
+using yarpl::flowable::BaseSubscriber;
 
 namespace {
 
 template <class T>
-class MySubscriber : public InternalSubscriber<T> {
-  void onNext(T) override {}
+class MySubscriber : public BaseSubscriber<T> {
+  void onSubscribeImpl() override {}
+  void onNextImpl(T) override {}
+  void onCompleteImpl() override {}
+  void onErrorImpl(folly::exception_wrapper) override {}
 };
 }
 

--- a/yarpl/test/SubscribeObserveOnTests.cpp
+++ b/yarpl/test/SubscribeObserveOnTests.cpp
@@ -145,36 +145,34 @@ TEST(ObserveSubscribeTests, BothObserveAndSubscribeOn) {
 }
 
 namespace {
-class EarlyCancelSubscriber
-    : public yarpl::flowable::InternalSubscriber<int64_t> {
+class EarlyCancelSubscriber : public yarpl::flowable::BaseSubscriber<int64_t> {
  public:
   EarlyCancelSubscriber(
       folly::EventBase& on_base,
       folly::Baton<>& subscriber_complete)
       : on_base_(on_base), subscriber_complete_(subscriber_complete) {}
 
-  void onSubscribe(Reference<yarpl::flowable::Subscription> s) override {
-    InternalSubscriber::onSubscribe(s);
-    s->request(5);
+  void onSubscribeImpl() override {
+    this->request(5);
   }
 
-  void onNext(int64_t n) override {
+  void onNextImpl(int64_t n) override {
     if (did_cancel_) {
       FAIL();
     }
 
     EXPECT_TRUE(on_base_.isInEventBaseThread());
     EXPECT_EQ(n, 1);
-    subscription()->cancel();
+    this->cancel();
     did_cancel_ = true;
     subscriber_complete_.post();
   }
 
-  void onError(folly::exception_wrapper e) override {
+  void onErrorImpl(folly::exception_wrapper e) override {
     FAIL();
   }
 
-  void onComplete() override {
+  void onCompleteImpl() override {
     FAIL();
   }
 

--- a/yarpl/test/yarpl/test_utils/Mocks.h
+++ b/yarpl/test/yarpl/test_utils/Mocks.h
@@ -35,7 +35,7 @@ class MockFlowable : public flowable::Flowable<T> {
 /// For the same reason putting mock instance in a smart pointer is a poor idea.
 /// Can only be instanciated for CopyAssignable E type.
 template <typename T>
-class MockSubscriber : public flowable::InternalSubscriber<T> {
+class MockSubscriber : public flowable::Subscriber<T> {
  public:
   MOCK_METHOD1(
       onSubscribe_,


### PR DESCRIPTION
What's on the tin

Has instances which rely on a `subscrption_` use BaseSubscriber 