### PR TITLE
Ensure queued frames are discarded after the StateMachine is closed

### DIFF
--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -417,7 +417,11 @@ void RSocketStateMachine::closeStreams(StreamCompletionSignal signal) {
 }
 
 void RSocketStateMachine::processFrame(std::unique_ptr<folly::IOBuf> frame) {
-  CHECK(!isClosed());
+
+  if (isClosed()) {
+    VLOG(4) << "StateMachine has been closed.  Discarding incoming frame";
+    return;
+  }
 
   // Necessary in case the only stream state machine closes itself, and takes
   // the RSocketStateMachine with it.


### PR DESCRIPTION
Since the client StateMachine and transport can run in different eventbases now, there is a possibility that the stateMachine has been closed on stateMachineEvb, but there is a frame queued on stateMachineEvb for processing.  Discard all such frames, the client can request them back from the server after resumption.

Testing:  Some tests were occasionally failing, they pass consistently now.