### PR TITLE
wait for server to shutdown before destructing eventbases

### DIFF
--- a/rsocket/framing/ScheduledFrameProcessor.cpp
+++ b/rsocket/framing/ScheduledFrameProcessor.cpp
@@ -5,29 +5,20 @@
 
 namespace rsocket {
 
-ScheduledFrameProcessor::~ScheduledFrameProcessor() {
-  // ScheduledFrameProcessor could get destroyed before the scheduled events of
-  // the class get executed.  So preserve a copy of inner frameProcessor_ in
-  // the event queue.  Since the events in the queue are executed in order we
-  // are guaranteed to have the frameProcessor_ during all the other events
-  // which were added before the destruction of this class.
-  evb_->runInEventBaseThread([frameProcessor = frameProcessor_](){});
-}
+ScheduledFrameProcessor::~ScheduledFrameProcessor() {}
 
 void ScheduledFrameProcessor::processFrame(
     std::unique_ptr<folly::IOBuf> ioBuf) {
-  auto frameProcessorPtr = frameProcessor_.get();
   evb_->runInEventBaseThread(
-      [ frameProcessorPtr, ioBuf = std::move(ioBuf) ]() mutable {
-        frameProcessorPtr->processFrame(std::move(ioBuf));
+      [ fp = frameProcessor_, ioBuf = std::move(ioBuf) ]() mutable {
+        fp->processFrame(std::move(ioBuf));
       });
 }
 
 void ScheduledFrameProcessor::onTerminal(folly::exception_wrapper ex) {
-  auto frameProcessorPtr = frameProcessor_.get();
   evb_->runInEventBaseThread(
-      [ ex = std::move(ex), frameProcessorPtr ]() mutable {
-        frameProcessorPtr->onTerminal(std::move(ex));
+      [ ex = std::move(ex), fp = frameProcessor_ ]() mutable {
+        fp->onTerminal(std::move(ex));
       });
 }
 }

--- a/rsocket/framing/ScheduledFrameTransport.cpp
+++ b/rsocket/framing/ScheduledFrameTransport.cpp
@@ -4,44 +4,36 @@
 
 namespace rsocket {
 
-ScheduledFrameTransport::~ScheduledFrameTransport() {
-  // ScheduledFrameTransport could get destroyed before the scheduled events of
-  // the class get executed.  So preserve a copy of inner frameProcessor_ in
-  // the event queue.  Since the events in the queue are executed in order we
-  // are guaranteed to have the frameTransport_ during all the other events
-  // which were added before the destruction of this class.
-  transportEvb_->runInEventBaseThread([frameTransport = frameTransport_](){});
-}
+ScheduledFrameTransport::~ScheduledFrameTransport() {}
 
 void ScheduledFrameTransport::setFrameProcessor(
     std::shared_ptr<FrameProcessor> fp) {
-  transportEvb_->runInEventBaseThread([ this, fp = std::move(fp) ]() mutable {
-    auto scheduledFP = std::make_shared<ScheduledFrameProcessor>(
-        std::move(fp), stateMachineEvb_);
-    frameTransport_->setFrameProcessor(std::move(scheduledFP));
-  });
+  transportEvb_->runInEventBaseThread(
+      [ this, self = this->ref_from_this(this), fp = std::move(fp) ]() mutable {
+        auto scheduledFP = std::make_shared<ScheduledFrameProcessor>(
+            std::move(fp), stateMachineEvb_);
+        frameTransport_->setFrameProcessor(std::move(scheduledFP));
+      });
 }
 
 void ScheduledFrameTransport::outputFrameOrDrop(
     std::unique_ptr<folly::IOBuf> ioBuf) {
-  auto frameTransportPtr = frameTransport_.get();
   transportEvb_->runInEventBaseThread(
-      [ frameTransportPtr, ioBuf = std::move(ioBuf) ]() mutable {
-        frameTransportPtr->outputFrameOrDrop(std::move(ioBuf));
+      [ ft = frameTransport_, ioBuf = std::move(ioBuf) ]() mutable {
+        ft->outputFrameOrDrop(std::move(ioBuf));
       });
 }
 
 void ScheduledFrameTransport::close() {
-  auto frameTransportPtr = frameTransport_.get();
-  transportEvb_->runInEventBaseThread(
-      [frameTransportPtr]() { frameTransportPtr->close(); });
+  transportEvb_->runInEventBaseThread([ft = frameTransport_]() {
+    ft->close();
+  });
 }
 
 void ScheduledFrameTransport::closeWithError(folly::exception_wrapper ex) {
-  auto frameTransportPtr = frameTransport_.get();
   transportEvb_->runInEventBaseThread(
-      [ frameTransportPtr, ex = std::move(ex) ]() mutable {
-        frameTransportPtr->closeWithError(std::move(ex));
+      [ ft = frameTransport_, ex = std::move(ex) ]() mutable {
+        ft->closeWithError(std::move(ex));
       });
 }
 

--- a/rsocket/framing/ScheduledFrameTransport.h
+++ b/rsocket/framing/ScheduledFrameTransport.h
@@ -15,7 +15,8 @@ namespace rsocket {
 // original RSocketStateMachine was constructed for the client.  Here the
 // RSocketStateMachine uses this class to schedule events of the Transport in
 // the new EventBase.
-class ScheduledFrameTransport : public FrameTransport {
+class ScheduledFrameTransport : public FrameTransport,
+                                public yarpl::enable_get_ref {
  public:
   ScheduledFrameTransport(
       yarpl::Reference<FrameTransport> frameTransport,

--- a/test/ColdResumptionTest.cpp
+++ b/test/ColdResumptionTest.cpp
@@ -279,8 +279,9 @@ TEST(ColdResumptionTest, DifferentEvb) {
   auto payload = "InitialPayload";
   size_t latestValue;
 
-  folly::ScopedEventBaseThread transportWorker;
-  folly::ScopedEventBaseThread SMWorker;
+  folly::ScopedEventBaseThread transportWorker{"transportWorker"};
+  folly::ScopedEventBaseThread SMWorker{"SMWorker"};
+
   auto token = ResumeIdentificationToken::generateNew();
   auto resumeManager =
       std::make_shared<ColdResumeManager>(RSocketStats::noop());
@@ -338,4 +339,6 @@ TEST(ColdResumptionTest, DifferentEvb) {
       firstSub->awaitLatestValue(10);
     }
   }
+
+  server->shutdownAndWait();
 }

--- a/test/RSocketClientServerTest.cpp
+++ b/test/RSocketClientServerTest.cpp
@@ -69,8 +69,8 @@ TEST(RSocketClientServer, ConnectManyAsync) {
 }
 
 TEST(RSocketClientServer, ConnectOnDifferentEvb) {
-  folly::ScopedEventBaseThread transportWorker;
-  folly::ScopedEventBaseThread stateMachineWorker;
+  folly::ScopedEventBaseThread transportWorker{"transportWorker"};
+  folly::ScopedEventBaseThread stateMachineWorker{"stateMachineWorker"};
   auto server = makeServer(std::make_shared<HelloStreamRequestHandler>());
   auto client = makeClient(
       transportWorker.getEventBase(),


### PR DESCRIPTION
was causing a use-after-free when a destructor triggered in transportWorker would access the destroyed evb in SMWorker. 