### PR TITLE
SetupResumeAcceptor simplifications & refactorings 

### DIFF
--- a/rsocket/RSocketServer.cpp
+++ b/rsocket/RSocketServer.cpp
@@ -19,8 +19,8 @@ RSocketServer::RSocketServer(
       setupResumeAcceptors_([] {
         return new rsocket::SetupResumeAcceptor{
             ProtocolVersion::Unknown,
-            folly::EventBaseManager::get()->getExistingEventBase(),
-            std::this_thread::get_id()};
+            folly::EventBaseManager::get()->getExistingEventBase()
+          };
       }),
       connectionSet_(std::make_shared<ConnectionSet>()),
       stats_(std::move(stats)) {}

--- a/rsocket/internal/SetupResumeAcceptor.h
+++ b/rsocket/internal/SetupResumeAcceptor.h
@@ -39,8 +39,7 @@ class SetupResumeAcceptor final {
 
   SetupResumeAcceptor(
       ProtocolVersion,
-      folly::EventBase*,
-      std::thread::id = std::thread::id{});
+      folly::EventBase*);
 
   ~SetupResumeAcceptor();
 
@@ -87,8 +86,5 @@ class SetupResumeAcceptor final {
 
   std::shared_ptr<FrameSerializer> defaultSerializer_;
   folly::EventBase* eventBase_;
-
-  /// ID of the thread that owns this object.
-  const std::thread::id owner_;
 };
 }

--- a/rsocket/transports/tcp/TcpConnectionAcceptor.cpp
+++ b/rsocket/transports/tcp/TcpConnectionAcceptor.cpp
@@ -75,7 +75,7 @@ void TcpConnectionAcceptor::start(OnDuplexConnectionAccept onAccept) {
     callbacks_.push_back(std::make_unique<SocketCallback>(onAccept_));
     callbacks_[i]->eventBase()->runInEventBaseThread([i] {
       folly::EventBaseManager::get()->getEventBase()->setName(
-          folly::sformat("TCPAcceptor.Worker.{}", i));
+          folly::sformat("TCPWrk.{}", i));
     });
   }
 

--- a/test/internal/SetupResumeAcceptorTest.cpp
+++ b/test/internal/SetupResumeAcceptorTest.cpp
@@ -256,8 +256,7 @@ TEST(SetupResumeAcceptor, EventBaseDisappear) {
   auto evb = std::make_unique<folly::EventBase>();
 
   SetupResumeAcceptor acceptor{
-      ProtocolVersion::Unknown, evb.get(), std::this_thread::get_id()};
-  evb.reset();
+      ProtocolVersion::Unknown, evb.get()};
 }
 
 // TODO: Test for whether changing FrameProcessor in on{Resume,Setup} breaks


### PR DESCRIPTION
 - `owner_` looks like it wasn't being used, remove it 
 - add checks to verify that methods being called in the correct eventbase
 - don't accept new connections if the `SetupResumeAcceptor` has closed already
 - worker thread name was shortened, else it gets truncated 