### PR TITLE
All writes should be guarded with try/catch

### DIFF
--- a/rsocket/statemachine/StreamStateMachineBase.cpp
+++ b/rsocket/statemachine/StreamStateMachineBase.cpp
@@ -38,43 +38,82 @@ void StreamStateMachineBase::newStream(
     uint32_t initialRequestN,
     Payload payload,
     bool completed) {
-  writer_->writeNewStream(
-      streamId_, streamType, initialRequestN, std::move(payload), completed);
+  try {
+    writer_->writeNewStream(
+        streamId_, streamType, initialRequestN, std::move(payload), completed);
+  } catch (const std::exception& exn) {
+    LOG(ERROR) << "Failed to write new stream: " << exn.what();
+    closeStream(StreamCompletionSignal::ERROR);
+  }
 }
 
 void StreamStateMachineBase::writePayload(Payload&& payload, bool complete) {
-  writer_->writePayload(streamId_, std::move(payload), complete);
+  try {
+    writer_->writePayload(streamId_, std::move(payload), complete);
+  } catch (const std::exception& exn) {
+    LOG(ERROR) << "Failed to write payload: " << exn.what();
+    closeStream(StreamCompletionSignal::ERROR);
+  }
 }
 
 void StreamStateMachineBase::writeRequestN(uint32_t n) {
-  writer_->writeRequestN(streamId_, n);
+  try {
+    writer_->writeRequestN(streamId_, n);
+  } catch (const std::exception& exn) {
+    LOG(ERROR) << "Failed to write payload: " << exn.what();
+    closeStream(StreamCompletionSignal::ERROR);
+  }
 }
 
 void StreamStateMachineBase::applicationError(std::string errorPayload) {
   // TODO: a bad frame for a stream should not bring down the whole socket
   // https://github.com/ReactiveSocket/reactivesocket-cpp/issues/311
-  writer_->writeCloseStream(
-      streamId_,
-      StreamCompletionSignal::APPLICATION_ERROR,
-      std::move(errorPayload));
+  try {
+    writer_->writeCloseStream(
+        streamId_,
+        StreamCompletionSignal::APPLICATION_ERROR,
+        std::move(errorPayload));
+  } catch (const std::exception& exn) {
+    LOG(ERROR) << "Failed to write payload: " << exn.what();
+    closeStream(StreamCompletionSignal::ERROR);
+  }
 }
 
 void StreamStateMachineBase::errorStream(std::string errorPayload) {
-  writer_->writeCloseStream(
-      streamId_, StreamCompletionSignal::ERROR, std::move(errorPayload));
+  try {
+    writer_->writeCloseStream(
+        streamId_, StreamCompletionSignal::ERROR, std::move(errorPayload));
+  } catch (const std::exception& exn) {
+    LOG(ERROR) << "Failed to write payload: " << exn.what();
+  }
   closeStream(StreamCompletionSignal::ERROR);
 }
 
 void StreamStateMachineBase::cancelStream() {
-  writer_->writeCloseStream(streamId_, StreamCompletionSignal::CANCEL, "");
+  try {
+    writer_->writeCloseStream(streamId_, StreamCompletionSignal::CANCEL, "");
+  } catch (const std::exception& exn) {
+    LOG(ERROR) << "Failed to write payload: " << exn.what();
+    closeStream(StreamCompletionSignal::ERROR);
+  }
 }
 
 void StreamStateMachineBase::completeStream() {
-  writer_->writeCloseStream(streamId_, StreamCompletionSignal::COMPLETE, "");
+  try {
+    writer_->writeCloseStream(streamId_, StreamCompletionSignal::COMPLETE, "");
+  } catch (const std::exception& exn) {
+    LOG(ERROR) << "Failed to write payload: " << exn.what();
+    closeStream(StreamCompletionSignal::ERROR);
+  }
 }
 
 void StreamStateMachineBase::closeStream(StreamCompletionSignal signal) {
-  writer_->onStreamClosed(streamId_, signal);
-  // TODO: set writer_ to nullptr
+  try {
+    writer_->onStreamClosed(streamId_, signal);
+    // TODO: set writer_ to nullptr
+  } catch (const std::exception& exn) {
+    LOG(ERROR) << "Failed to write payload: " << exn.what();
+    closeStream(StreamCompletionSignal::ERROR);
+  }
 }
-}
+} // namespace rsocket


### PR DESCRIPTION
Details:  T22408574
realtime_gateway_task_crashes:trace:rsocket::FramedWriter::onNext:SIGSEGV

Because of asynchrony, there can be cases that the StreamStateMachine wants to write to the `output`, but the output is already closed, or more. 

I have added try/catch to each write operation to catch such errors and close the corresponding stream.

I will add a unit test to verify the update/fix.