### PR TITLE
Fix RequestResponseTest.FailureOnRequest

### DIFF
--- a/test/RequestResponseTest.cpp
+++ b/test/RequestResponseTest.cpp
@@ -174,13 +174,11 @@ TEST(RequestResponseTest, MultipleRequestsError) {
   auto flowable = requester->requestResponse(Payload("foo", "bar"));
 }
 
-// TODO: Currently, this hangs when the client sends a request,
-// we should fix this
-TEST(DISABLED_RequestResponseTest, FailureOnRequest) {
+TEST(RequestResponseTest, FailureOnRequest) {
   folly::ScopedEventBaseThread worker;
   auto server = makeServer(
       std::make_shared<GenericRequestResponseHandler>([](auto const&) {
-        ASSERT(false); // should never reach
+        ADD_FAILURE();
         return payload_response("", "");
       }));
 
@@ -197,5 +195,5 @@ TEST(DISABLED_RequestResponseTest, FailureOnRequest) {
       ->map(payload_to_stringpair)
       ->subscribe(to);
   to->awaitTerminalEvent();
-  to->assertOnErrorMessage("???"); // ??? this probably isn't correct
+  EXPECT_TRUE(to->getError());
 }

--- a/yarpl/include/yarpl/single/SingleTestObserver.h
+++ b/yarpl/include/yarpl/single/SingleTestObserver.h
@@ -165,12 +165,21 @@ class SingleTestObserver : public yarpl::single::SingleObserver<T> {
 
   /**
    * Get a reference to the received value if onSuccess was called.
-   *
-   * @return
    */
   T& getOnSuccessValue() {
     std::lock_guard<std::mutex> g(m_);
     return value_;
+  }
+
+  /**
+   * Get the error received from onError if it was called.
+   */
+  folly::exception_wrapper getError() {
+    std::lock_guard<std::mutex> g(m_);
+    if (!terminated_) {
+      throw std::logic_error{"Must call getError() on a terminated observer"};
+    }
+    return e_;
   }
 
   /**


### PR DESCRIPTION
Seems like the only thing that was still broken was comparing the exception
message against the bogus "???" string.  Fix it by just checking for an error.