### PR TITLE
remove pure virtual from rsocketstats

### DIFF
--- a/rsocket/RSocketStats.h
+++ b/rsocket/RSocketStats.h
@@ -2,10 +2,10 @@
 
 #pragma once
 
+#include <folly/Optional.h>
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <folly/Optional.h>
 
 #include "rsocket/framing/FrameType.h"
 #include "rsocket/internal/Common.h"
@@ -22,34 +22,36 @@ class RSocketStats {
 
   static std::shared_ptr<RSocketStats> noop();
 
-  virtual void socketCreated() = 0;
-  virtual void socketConnected() = 0;
-  virtual void socketDisconnected() = 0;
-  virtual void socketClosed(StreamCompletionSignal signal) = 0;
+  virtual void socketCreated() {}
+  virtual void socketConnected() {}
+  virtual void socketDisconnected() {}
+  virtual void socketClosed(StreamCompletionSignal /* signal */) {}
 
-  virtual void serverConnectionAccepted() = 0;
+  virtual void serverConnectionAccepted() {}
 
   virtual void duplexConnectionCreated(
-      const std::string& type,
-      DuplexConnection* connection) = 0;
+      const std::string& /* type */,
+      DuplexConnection* /* connection */) {}
   virtual void duplexConnectionClosed(
-      const std::string& type,
-      DuplexConnection* connection) = 0;
+      const std::string& /* type */,
+      DuplexConnection* /* connection */) {}
   virtual void serverResume(
-      folly::Optional<int64_t> clientAvailable,
-      int64_t serverAvailable,
-      int64_t serverDelta,
-      ResumeOutcome outcome) = 0;
-  virtual void bytesWritten(size_t bytes) = 0;
-  virtual void bytesRead(size_t bytes) = 0;
-  virtual void frameWritten(FrameType frameType) = 0;
-  virtual void frameRead(FrameType frameType) = 0;
-  virtual void resumeBufferChanged(int framesCountDelta, int dataSizeDelta) = 0;
+      folly::Optional<int64_t> /* clientAvailable */,
+      int64_t /* serverAvailable */,
+      int64_t /* serverDelta */,
+      ResumeOutcome /* outcome */) {}
+  virtual void bytesWritten(size_t /* bytes */) {}
+  virtual void bytesRead(size_t /* bytes */) {}
+  virtual void frameWritten(FrameType /* frameType */) {}
+  virtual void frameRead(FrameType /* frameType */) {}
+  virtual void resumeBufferChanged(
+      int /* framesCountDelta */,
+      int /* dataSizeDelta */) {}
   virtual void streamBufferChanged(
-      int64_t framesCountDelta,
-      int64_t dataSizeDelta) = 0;
-  virtual void resumeFailedNoState() = 0;
-  virtual void keepaliveSent() = 0;
-  virtual void keepaliveReceived() = 0;
+      int64_t /* framesCountDelta */,
+      int64_t /* dataSizeDelta */) {}
+  virtual void resumeFailedNoState() {}
+  virtual void keepaliveSent() {}
+  virtual void keepaliveReceived() {}
 };
 } // namespace rsocket


### PR DESCRIPTION
Shall we also remove NoopStats?  Since it not doesn't do anything unique now.
Although, it's name is nice and clear about it's purpose..
Thoughts?