### PR TITLE
Let limiting the max number of active streams

### DIFF
--- a/rsocket/RSocketClient.cpp
+++ b/rsocket/RSocketClient.cpp
@@ -47,6 +47,24 @@ const std::shared_ptr<RSocketRequester>& RSocketClient::getRequester() const {
   return requester_;
 }
 
+bool RSocketClient::isClosed() const {
+  return !stateMachine_ || stateMachine_->isClosed();
+}
+
+size_t RSocketClient::getStreamCount() const {
+  if (stateMachine_) {
+    return stateMachine_->getStreamCount();
+  }
+  return 0;
+}
+
+void RSocketClient::setMaxActiveStreams(size_t count) {
+  maxActiveStreams_ = count;
+  if (stateMachine_) {
+    stateMachine_->setMaxActiveStreams(maxActiveStreams_);
+  }
+}
+
 folly::Future<folly::Unit> RSocketClient::resume() {
   VLOG(2) << "Resuming connection";
 
@@ -217,6 +235,8 @@ void RSocketClient::createState() {
       std::move(connectionEvents_),
       std::move(resumeManager_),
       std::move(coldResumeHandler_));
+
+  stateMachine_->setMaxActiveStreams(maxActiveStreams_);
 
   requester_ = std::make_shared<RSocketRequester>(stateMachine_, *evb_);
 

--- a/rsocket/RSocketClient.h
+++ b/rsocket/RSocketClient.h
@@ -34,6 +34,12 @@ class RSocketClient {
 
   friend class RSocket;
 
+  bool isClosed() const;
+
+  size_t getStreamCount() const;
+
+  void setMaxActiveStreams(size_t count);
+
   // Returns the RSocketRequester associated with the RSocketClient.
   const std::shared_ptr<RSocketRequester>& getRequester() const;
 
@@ -86,6 +92,8 @@ class RSocketClient {
   ProtocolVersion protocolVersion_;
   ResumeIdentificationToken token_;
 
+  size_t maxActiveStreams_{std::numeric_limits<size_t>::max()};
+
   // Remember the StateMachine's evb (supplied through constructor).  If no
   // EventBase is provided, the underlying transport's EventBase will be used
   // to drive the StateMachine.
@@ -96,6 +104,5 @@ class RSocketClient {
   // EventBase, but the transport ends up being in different EventBase after
   // resumption, and vice versa.
   folly::EventBase* evb_{nullptr};
-
 };
 }

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -389,6 +389,18 @@ void RSocketStateMachine::reconnect(
   connect(std::move(newFrameTransport), ProtocolVersion::Unknown);
 }
 
+size_t RSocketStateMachine::getStreamCount() const {
+  return streamState_.streams_.size();
+}
+
+void RSocketStateMachine::setMaxActiveStreams(size_t maxStreams) {
+  maxActiveStreams_ = maxStreams;
+}
+
+bool RSocketStateMachine::canCreateNewStream() {
+  return !isDisconnected() && maxActiveStreams_ > getStreamCount();
+}
+
 void RSocketStateMachine::addStream(
     StreamId streamId,
     yarpl::Reference<StreamStateMachineBase> stateMachine) {

--- a/rsocket/statemachine/RSocketStateMachine.h
+++ b/rsocket/statemachine/RSocketStateMachine.h
@@ -157,6 +157,15 @@ class RSocketStateMachine final
     return streamsFactory_;
   }
 
+  /// Whether the connection has been closed.
+  bool isClosed() const;
+
+  size_t getStreamCount() const;
+
+  void setMaxActiveStreams(size_t maxStreams);
+
+  bool canCreateNewStream();
+
  private:
   void connect(yarpl::Reference<FrameTransport>, ProtocolVersion);
 
@@ -172,9 +181,6 @@ class RSocketStateMachine final
       ResumePosition clientPosition);
 
   bool isPositionAvailable(ResumePosition) const;
-
-  /// Whether the connection has been closed.
-  bool isClosed() const;
 
   uint32_t getKeepaliveTime() const;
 
@@ -290,7 +296,11 @@ class RSocketStateMachine final
 
   std::shared_ptr<RSocketConnectionEvents> connectionEvents_;
 
-  /// Back reference to the set that's holding this state machine.
+  // Back reference to the set that's holding this state machine.
   std::weak_ptr<ConnectionSet> connectionSet_;
+
+  // If the number of active requests reach this number, don't allow creating
+  // any more.
+  size_t maxActiveStreams_;
 };
 }

--- a/rsocket/statemachine/StreamsFactory.cpp
+++ b/rsocket/statemachine/StreamsFactory.cpp
@@ -29,23 +29,23 @@ StreamsFactory::StreamsFactory(
                     even-numbered stream identifiers*/) {}
 
 static void subscribeToErrorFlowable(
-    Reference<yarpl::flowable::Subscriber<Payload>> responseSink) {
+    Reference<yarpl::flowable::Subscriber<Payload>> responseSink){
   yarpl::flowable::Flowables::error<Payload>(
-      std::runtime_error("state machine is disconnected/closed"))
+      std::runtime_error("it's not possible to create a new stream now"))
       ->subscribe(std::move(responseSink));
 }
 
 static void subscribeToErrorSingle(
     Reference<yarpl::single::SingleObserver<Payload>> responseSink) {
   yarpl::single::Singles::error<Payload>(
-      std::runtime_error("state machine is disconnected/closed"))
+      std::runtime_error("it's not possible to create a new stream now"))
       ->subscribe(std::move(responseSink));
 }
 
 Reference<yarpl::flowable::Subscriber<Payload>>
 StreamsFactory::createChannelRequester(
     Reference<yarpl::flowable::Subscriber<Payload>> responseSink) {
-  if (connection_.isDisconnected()) {
+  if (!connection_.canCreateNewStream()) {
     subscribeToErrorFlowable(std::move(responseSink));
     return nullptr;
   }
@@ -61,7 +61,7 @@ StreamsFactory::createChannelRequester(
 void StreamsFactory::createStreamRequester(
     Payload request,
     Reference<yarpl::flowable::Subscriber<Payload>> responseSink) {
-  if (connection_.isDisconnected()) {
+  if (!connection_.canCreateNewStream()) {
     subscribeToErrorFlowable(std::move(responseSink));
     return;
   }
@@ -77,7 +77,7 @@ void StreamsFactory::createStreamRequester(
     Reference<yarpl::flowable::Subscriber<Payload>> responseSink,
     StreamId streamId,
     size_t n) {
-  if (connection_.isDisconnected()) {
+  if (!connection_.canCreateNewStream()) {
     subscribeToErrorFlowable(std::move(responseSink));
     return;
   }
@@ -93,7 +93,7 @@ void StreamsFactory::createStreamRequester(
 void StreamsFactory::createRequestResponseRequester(
     Payload payload,
     Reference<yarpl::single::SingleObserver<Payload>> responseSink) {
-  if (connection_.isDisconnected()) {
+  if (!connection_.canCreateNewStream()) {
     subscribeToErrorSingle(std::move(responseSink));
     return;
   }

--- a/test/RSocketClientTest.cpp
+++ b/test/RSocketClientTest.cpp
@@ -4,12 +4,12 @@
 
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <gtest/gtest.h>
-
-#include "rsocket/transports/tcp/TcpConnectionFactory.h"
+#include "yarpl/flowable/TestSubscriber.h"
 
 using namespace rsocket;
 using namespace rsocket::tests;
 using namespace rsocket::tests::client_server;
+using namespace yarpl::flowable;
 
 TEST(RSocketClient, ConnectFails) {
   folly::ScopedEventBaseThread worker;
@@ -25,4 +25,24 @@ TEST(RSocketClient, ConnectFails) {
   }).onError([&](const std::exception&) {
     LOG(INFO) << "connection failed as expected";
   }).get();
+}
+
+TEST(RSocketClientServer, LimitActiveStreamCount) {
+  folly::ScopedEventBaseThread worker;
+  auto server = makeServer(nullptr);
+  auto client = makeClient(worker.getEventBase(), *server->listeningPort());
+  client->setMaxActiveStreams(0u);
+
+  auto requester = client->getRequester();
+  auto ts = TestSubscriber<std::string>::create();
+  requester
+      ->requestChannel(
+          Flowables::justN({"/hello", "Bob", "Jane"})->map([](std::string v) {
+            return Payload(v);
+          }))
+      ->map([](auto p) { return p.moveDataToString(); })
+      ->subscribe(ts);
+
+  ts->awaitTerminalEvent();
+  ts->assertOnErrorMessage("it's not possible to create a new stream now");
 }


### PR DESCRIPTION
In my integration of RSocket to Service Router, I need RSocketClient to inform 
 - if it is closed
 - how many streams does it currently serve
 - set/get max number of streams that can be active at a given time.