### PR TITLE
Introduce yarpl::single::SingleObserver interface and SingleObserverBase abstract class for easier subclassing

### DIFF
--- a/benchmarks/FireForgetThroughputTcp.cpp
+++ b/benchmarks/FireForgetThroughputTcp.cpp
@@ -63,7 +63,7 @@ BENCHMARK(FireForgetThroughput, n) {
     for (auto& client : fixture->clients) {
       client->getRequester()
           ->fireAndForget(Payload("TcpFireAndForget"))
-          ->subscribe(yarpl::make_ref<yarpl::single::SingleObserver<void>>());
+          ->subscribe(yarpl::make_ref<yarpl::single::SingleObserverBase<void>>());
     }
   }
 

--- a/benchmarks/RequestResponseThroughputTcp.cpp
+++ b/benchmarks/RequestResponseThroughputTcp.cpp
@@ -28,24 +28,24 @@ DEFINE_int32(
 
 namespace {
 
-class Observer : public yarpl::single::SingleObserver<Payload> {
+class Observer : public yarpl::single::SingleObserverBase<Payload> {
  public:
   explicit Observer(Latch& latch) : latch_{latch} {}
 
   void onSubscribe(yarpl::Reference<yarpl::single::SingleSubscription>
                        subscription) override {
-    yarpl::single::SingleObserver<Payload>::onSubscribe(
+    yarpl::single::SingleObserverBase<Payload>::onSubscribe(
         std::move(subscription));
   }
 
   void onSuccess(Payload) override {
     latch_.post();
-    yarpl::single::SingleObserver<Payload>::onSuccess({});
+    yarpl::single::SingleObserverBase<Payload>::onSuccess({});
   }
 
   void onError(folly::exception_wrapper) override {
     latch_.post();
-    yarpl::single::SingleObserver<Payload>::onError({});
+    yarpl::single::SingleObserverBase<Payload>::onError({});
   }
 
  private:

--- a/rsocket/RSocketRequester.cpp
+++ b/rsocket/RSocketRequester.cpp
@@ -134,7 +134,7 @@ yarpl::Reference<yarpl::single::Single<void>> RSocketRequester::fireAndForget(
     eb = &eventBase_,
     request = std::move(request),
     srs = stateMachine_
-  ](yarpl::Reference<yarpl::single::SingleObserver<void>> subscriber) mutable {
+  ](yarpl::Reference<yarpl::single::SingleObserverBase<void>> subscriber) mutable {
     auto lambda = [
       request = std::move(request),
       subscriber = std::move(subscriber),

--- a/yarpl/include/yarpl/single/Single.h
+++ b/yarpl/include/yarpl/single/Single.h
@@ -77,7 +77,7 @@ class Single : public virtual Refcounted, public yarpl::enable_get_ref {
 template <>
 class Single<void> : public virtual Refcounted {
  public:
-  virtual void subscribe(Reference<SingleObserver<void>>) = 0;
+  virtual void subscribe(Reference<SingleObserverBase<void>>) = 0;
 
   /**
    * Subscribe overload taking lambda for onSuccess that is called upon writing
@@ -88,22 +88,22 @@ class Single<void> : public virtual Refcounted {
       typename = typename std::enable_if<
           std::is_callable<Success(), void>::value>::type>
   void subscribe(Success s) {
-    class SuccessSingleObserver : public SingleObserver<void> {
+    class SuccessSingleObserver : public SingleObserverBase<void> {
      public:
       SuccessSingleObserver(Success success) : success_{std::move(success)} {}
 
       void onSubscribe(Reference<SingleSubscription> subscription) override {
-        SingleObserver<void>::onSubscribe(std::move(subscription));
+        SingleObserverBase<void>::onSubscribe(std::move(subscription));
       }
 
       void onSuccess() override {
         success_();
-        SingleObserver<void>::onSuccess();
+        SingleObserverBase<void>::onSuccess();
       }
 
       // No further calls to the subscription after this method is invoked.
       void onError(folly::exception_wrapper ex) override {
-        SingleObserver<void>::onError(std::move(ex));
+        SingleObserverBase<void>::onError(std::move(ex));
       }
 
      private:
@@ -116,7 +116,7 @@ class Single<void> : public virtual Refcounted {
   template <
       typename OnSubscribe,
       typename = typename std::enable_if<std::is_callable<
-          OnSubscribe(Reference<SingleObserver<void>>),
+          OnSubscribe(Reference<SingleObserverBase<void>>),
           void>::value>::type>
   static auto create(OnSubscribe);
 };

--- a/yarpl/include/yarpl/single/SingleObservers.h
+++ b/yarpl/include/yarpl/single/SingleObservers.h
@@ -28,7 +28,7 @@ class SingleObservers {
  public:
   template <typename T, typename Next, typename = EnableIfCompatible<T, Next>>
   static auto create(Next next) {
-    return make_ref<Base<T, Next>, SingleObserver<T>>(std::move(next));
+    return make_ref<Base<T, Next>, SingleObserverBase<T>>(std::move(next));
   }
 
   template <
@@ -37,13 +37,13 @@ class SingleObservers {
       typename Error,
       typename = EnableIfCompatible<T, Success, Error>>
   static auto create(Success next, Error error) {
-    return make_ref<WithError<T, Success, Error>, SingleObserver<T>>(
+    return make_ref<WithError<T, Success, Error>, SingleObserverBase<T>>(
         std::move(next), std::move(error));
   }
 
  private:
   template <typename T, typename Next>
-  class Base : public SingleObserver<T> {
+  class Base : public SingleObserverBase<T> {
    public:
     explicit Base(Next next) : next_(std::move(next)) {}
 

--- a/yarpl/include/yarpl/single/SingleOperator.h
+++ b/yarpl/include/yarpl/single/SingleOperator.h
@@ -209,7 +209,7 @@ class SingleVoidFromPublisherOperator : public Single<void> {
   explicit SingleVoidFromPublisherOperator(OnSubscribe&& function)
       : function_(std::move(function)) {}
 
-  void subscribe(Reference<SingleObserver<void>> observer) override {
+  void subscribe(Reference<SingleObserverBase<void>> observer) override {
     function_(std::move(observer));
   }
 


### PR DESCRIPTION
When I tried to extend SingleObserver class in Thrift integration effort, I have had some difficulties because the parent class's functions were not virtual.

- Introduce a pure virtual interface yarpl::single::SingleObserver<T>.
- Use the interface instead of abstract class for non-void template cases.