### PR TITLE
Fix crash when old transport hasn't disconnected yet

### DIFF
--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -100,8 +100,8 @@ bool RSocketStateMachine::resumeServer(
   if (!isDisconnected()) {
     VLOG(1) << "Old connection (" << frameTransport_.get() << ") exists. "
             << "Terminating new connection (" << frameTransport.get() << ")";
-    std::runtime_error exn{"Old connection still exists"};
-    frameTransport_->closeWithError(std::move(exn));
+    frameTransport->closeWithError(
+        ResumptionException{"Old connection still exists"});
 
     stats_->serverResume(
         clientAvailable,


### PR DESCRIPTION
Without the change, the included test would trigger the following check in EventBase.cpp
`EventBase.cpp:211] Check failed: evbTid == curTid

Test passes fine after the change.