### PR TITLE
remove RSocketRequster::closeSocket()

### DIFF
--- a/rsocket/RSocketRequester.cpp
+++ b/rsocket/RSocketRequester.cpp
@@ -23,14 +23,6 @@ RSocketRequester::~RSocketRequester() {
   VLOG(1) << "Destroying RSocketRequester";
 }
 
-void RSocketRequester::closeSocket() {
-  eventBase_.add([stateMachine = std::move(stateMachine_)] {
-    VLOG(2) << "Closing RSocketStateMachine on EventBase";
-    stateMachine->close(
-        folly::exception_wrapper(), StreamCompletionSignal::SOCKET_CLOSED);
-  });
-}
-
 yarpl::Reference<yarpl::flowable::Flowable<rsocket::Payload>>
 RSocketRequester::requestChannel(
     yarpl::Reference<yarpl::flowable::Flowable<rsocket::Payload>>

--- a/rsocket/RSocketRequester.h
+++ b/rsocket/RSocketRequester.h
@@ -93,8 +93,6 @@ class RSocketRequester {
    */
   virtual void metadataPush(std::unique_ptr<folly::IOBuf> metadata);
 
-  virtual void closeSocket();
-
  private:
   std::shared_ptr<rsocket::RSocketStateMachine> stateMachine_;
   folly::EventBase& eventBase_;


### PR DESCRIPTION
Simplifies usage and reduces confusion about how a requester can be used

Prior, it's possible to put the RSocketClient in a state such that it can't be resumed; fully destructing the client should only be possible by calling its destructor. 

Disconnecting the underlying socket should be done through `RSocketClient::disconnect()`