### PR TITLE
Adding support for temporarily accessing the underlying transport object for TcpDuplexConnection

### DIFF
--- a/rsocket/DuplexConnection.h
+++ b/rsocket/DuplexConnection.h
@@ -54,8 +54,7 @@ private:
 /// before the connection is destroyed.
 class DuplexConnection {
  public:
-  using Subscriber =
-      yarpl::flowable::Subscriber<std::unique_ptr<folly::IOBuf>>;
+  using Subscriber = yarpl::flowable::Subscriber<std::unique_ptr<folly::IOBuf>>;
   using DuplexSubscriber = rsocket::DuplexSubscriber;
 
   virtual ~DuplexConnection() = default;

--- a/rsocket/RSocketRequester.cpp
+++ b/rsocket/RSocketRequester.cpp
@@ -155,4 +155,8 @@ void RSocketRequester::metadataPush(std::unique_ptr<folly::IOBuf> metadata) {
         srs->metadataPush(std::move(metadata));
       });
 }
+
+DuplexConnection* RSocketRequester::getConnection() {
+  return stateMachine_? stateMachine_->getConnection() : nullptr;
+}
 } // namespace rsocket

--- a/rsocket/RSocketRequester.h
+++ b/rsocket/RSocketRequester.h
@@ -93,6 +93,10 @@ class RSocketRequester {
    */
   virtual void metadataPush(std::unique_ptr<folly::IOBuf> metadata);
 
+  /**
+   * To be used only temporarily to check the transport's status.
+   */
+  DuplexConnection* getConnection();
  private:
   std::shared_ptr<rsocket::RSocketStateMachine> stateMachine_;
   folly::EventBase& eventBase_;

--- a/rsocket/framing/FrameTransport.h
+++ b/rsocket/framing/FrameTransport.h
@@ -13,5 +13,7 @@ class FrameTransport : public virtual yarpl::Refcounted {
   virtual void outputFrameOrDrop(std::unique_ptr<folly::IOBuf>) = 0;
   virtual void close() = 0;
   virtual void closeWithError(folly::exception_wrapper) = 0;
+  // Just for observation purposes!
+  virtual DuplexConnection* getConnection() = 0;
 };
 }

--- a/rsocket/framing/FrameTransportImpl.h
+++ b/rsocket/framing/FrameTransportImpl.h
@@ -41,6 +41,10 @@ class FrameTransportImpl final
     return !connection_;
   }
 
+  DuplexConnection* getConnection() override {
+    return connection_.get();
+  }
+
  private:
   void connect();
 

--- a/rsocket/framing/FramedDuplexConnection.h
+++ b/rsocket/framing/FramedDuplexConnection.h
@@ -27,6 +27,10 @@ class FramedDuplexConnection : public virtual DuplexConnection {
     return true;
   }
 
+  DuplexConnection* getConnection() {
+    return inner_.get();
+  }
+
  private:
   std::unique_ptr<DuplexConnection> inner_;
   yarpl::Reference<FramedReader> inputReader_;

--- a/rsocket/framing/ScheduledFrameTransport.h
+++ b/rsocket/framing/ScheduledFrameTransport.h
@@ -33,7 +33,11 @@ class ScheduledFrameTransport : public FrameTransport,
   void close() override;
   void closeWithError(folly::exception_wrapper ex) override;
 
- private:
+  DuplexConnection* getConnection() override {
+    return frameTransport_ ? frameTransport_->getConnection() : nullptr;
+  }
+
+private:
   folly::EventBase* transportEvb_;
   folly::EventBase* stateMachineEvb_;
   yarpl::Reference<FrameTransport> frameTransport_;

--- a/rsocket/framing/ScheduledFrameTransport.h
+++ b/rsocket/framing/ScheduledFrameTransport.h
@@ -33,11 +33,16 @@ class ScheduledFrameTransport : public FrameTransport,
   void close() override;
   void closeWithError(folly::exception_wrapper ex) override;
 
+ private:
   DuplexConnection* getConnection() override {
-    return frameTransport_ ? frameTransport_->getConnection() : nullptr;
+    DLOG(FATAL)
+        << "ScheduledFrameTransport doesn't support getConnection method, "
+            "because it can create safe usage issues when EventBase of the "
+            "transport and the RSocketClient is not the same.";
+    return nullptr;
   }
 
-private:
+ private:
   folly::EventBase* transportEvb_;
   folly::EventBase* stateMachineEvb_;
   yarpl::Reference<FrameTransport> frameTransport_;

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -119,7 +119,8 @@ bool RSocketStateMachine::resumeServer(
       clientAvailable,
       serverAvailable,
       serverDelta,
-      result ? RSocketStats::ResumeOutcome::SUCCESS : RSocketStats::ResumeOutcome::FAILURE);
+      result ? RSocketStats::ResumeOutcome::SUCCESS
+             : RSocketStats::ResumeOutcome::FAILURE);
 
   return result;
 }
@@ -1012,4 +1013,7 @@ void RSocketStateMachine::registerSet(std::shared_ptr<ConnectionSet> set) {
   connectionSet_ = std::move(set);
 }
 
+DuplexConnection* RSocketStateMachine::getConnection() {
+  return frameTransport_ ? frameTransport_->getConnection() : nullptr;
+}
 } // namespace rsocket

--- a/rsocket/statemachine/RSocketStateMachine.h
+++ b/rsocket/statemachine/RSocketStateMachine.h
@@ -157,6 +157,8 @@ class RSocketStateMachine final
     return streamsFactory_;
   }
 
+  DuplexConnection* getConnection();
+
  private:
   void connect(yarpl::Reference<FrameTransport>, ProtocolVersion);
 

--- a/rsocket/transports/tcp/TcpDuplexConnection.cpp
+++ b/rsocket/transports/tcp/TcpDuplexConnection.cpp
@@ -28,6 +28,10 @@ class TcpReaderWriter : public folly::AsyncTransportWrapper::WriteCallback,
     DCHECK(!inputSubscriber_);
   }
 
+  folly::AsyncSocket* getTransport() {
+    return socket_.get();
+  }
+
   void setInput(
       yarpl::Reference<DuplexConnection::Subscriber> inputSubscriber) {
     if (inputSubscriber && isClosed()) {
@@ -252,6 +256,10 @@ TcpDuplexConnection::~TcpDuplexConnection() {
     stats_->duplexConnectionClosed("tcp", this);
   }
   tcpReaderWriter_->close();
+}
+
+folly::AsyncSocket* TcpDuplexConnection::getTransport() {
+  return tcpReaderWriter_ ? tcpReaderWriter_->getTransport() : nullptr;
 }
 
 yarpl::Reference<DuplexConnection::Subscriber>

--- a/rsocket/transports/tcp/TcpDuplexConnection.h
+++ b/rsocket/transports/tcp/TcpDuplexConnection.h
@@ -24,6 +24,9 @@ class TcpDuplexConnection : public DuplexConnection {
 
   void setInput(yarpl::Reference<DuplexConnection::Subscriber>) override;
 
+  // Only to be used for observation purposes.
+  folly::AsyncSocket* getTransport();
+
  private:
   boost::intrusive_ptr<TcpReaderWriter> tcpReaderWriter_;
   std::shared_ptr<RSocketStats> stats_;


### PR DESCRIPTION
I need to get a pointer to the underlying Transport object to be able to fulfill requirements of an interface.
So I have added getConnection and getTransport functions to the TcpDuplexConnection class and relevant classes. I kept the update at minimum to be able to accomplish the goal.