### PR TITLE
fix flakey RequestChannelTest; fix incorrect Subscriber usage

### DIFF
--- a/test/RequestChannelTest.cpp
+++ b/test/RequestChannelTest.cpp
@@ -101,7 +101,7 @@ class TestChannelResponder : public rsocket::RSocketResponder {
       yarpl::Reference<Flowable<rsocket::Payload>> requestStream,
       rsocket::StreamId) override {
     // add initial payload to testSubscriber values list
-    testSubscriber_->onNext(initialPayload.moveDataToString());
+    testSubscriber_->manuallyPush(initialPayload.moveDataToString());
 
     requestStream->map([](auto p) { return p.moveDataToString(); })
         ->subscribe(testSubscriber_);
@@ -279,7 +279,7 @@ class TestChannelResponderFailure : public rsocket::RSocketResponder {
       yarpl::Reference<Flowable<rsocket::Payload>> requestStream,
       rsocket::StreamId) override {
     // add initial payload to testSubscriber values list
-    testSubscriber_->onNext(initialPayload.moveDataToString());
+    testSubscriber_->manuallyPush(initialPayload.moveDataToString());
 
     requestStream->map([](auto p) { return p.moveDataToString(); })
         ->subscribe(testSubscriber_);


### PR DESCRIPTION
TestSubscriber inherits from BaseSubscriber, which doesn't like it if you call onNext without a subscription (it'll drop that on the floor). Adds method `manuallyPush` to manually push a value into the TestSubscriber, without going through the rigamarole that BaseSubscriber assumes. 