### PR TITLE
TcpConnectionAcceptor takes a AsyncTransportWrapper

### DIFF
--- a/benchmarks/BaselinesAsyncSocket.cpp
+++ b/benchmarks/BaselinesAsyncSocket.cpp
@@ -3,7 +3,6 @@
 #include <folly/Benchmark.h>
 #include <folly/io/IOBufQueue.h>
 #include <folly/io/async/AsyncServerSocket.h>
-#include <folly/io/async/AsyncSocket.h>
 #include <folly/io/async/AsyncTransport.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
 
@@ -16,7 +15,7 @@ using namespace folly;
 // class TcpReader : public ::folly::AsyncTransportWrapper::ReadCallback {
 // public:
 //  TcpReader(
-//      folly::AsyncSocket::UniquePtr&& socket,
+//      folly::AsyncTransportWrapper::UniquePtr&& socket,
 //      EventBase& eventBase,
 //      size_t loadSize,
 //      size_t recvBufferLength)
@@ -80,7 +79,7 @@ using namespace folly;
 //    }
 //  }
 //
-//  folly::AsyncSocket::UniquePtr socket_;
+//  folly::AsyncTransportWrapper::UniquePtr socket_;
 //  folly::IOBufQueue readBuffer_{folly::IOBufQueue::cacheChainLength()};
 //  EventBase& eventBase_;
 //  const size_t loadSize_;
@@ -103,7 +102,8 @@ using namespace folly;
 //      int fd,
 //      const SocketAddress&) noexcept override {
 //    auto socket =
-//        folly::AsyncSocket::UniquePtr(new AsyncSocket(&eventBase_, fd));
+//        folly::AsyncTransportWrapper::UniquePtr(new AsyncSocket(&eventBase_,
+//        fd));
 //
 //    new TcpReader(
 //        std::move(socket), eventBase_, loadSize_, recvBufferLength_);
@@ -191,7 +191,7 @@ using namespace folly;
 //    delete this;
 //  }
 //
-//  AsyncSocket::UniquePtr socket_;
+//  AsyncTransportWrapper::UniquePtr socket_;
 //  EventBase& eventBase_;
 //  const size_t loadSize_;
 //  const size_t msgLength_;

--- a/rsocket/transports/tcp/TcpConnectionAcceptor.cpp
+++ b/rsocket/transports/tcp/TcpConnectionAcceptor.cpp
@@ -5,6 +5,7 @@
 #include <folly/Format.h>
 #include <folly/ThreadName.h>
 #include <folly/futures/Future.h>
+#include <folly/io/async/AsyncSocket.h>
 #include <folly/io/async/EventBaseManager.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
 
@@ -24,7 +25,7 @@ class TcpConnectionAcceptor::SocketCallback
       const folly::SocketAddress& address) noexcept override {
     VLOG(2) << "Accepting TCP connection from " << address << " on FD " << fd;
 
-    folly::AsyncSocket::UniquePtr socket(
+    folly::AsyncTransportWrapper::UniquePtr socket(
         new folly::AsyncSocket(eventBase(), fd));
 
     auto connection = std::make_unique<TcpDuplexConnection>(std::move(socket));

--- a/rsocket/transports/tcp/TcpConnectionFactory.cpp
+++ b/rsocket/transports/tcp/TcpConnectionFactory.cpp
@@ -3,6 +3,7 @@
 #include "rsocket/transports/tcp/TcpConnectionFactory.h"
 
 #include <folly/io/async/AsyncSocket.h>
+#include <folly/io/async/AsyncTransport.h>
 #include <folly/io/async/EventBaseManager.h>
 #include <glog/logging.h>
 
@@ -90,7 +91,7 @@ TcpConnectionFactory::connect() {
 
 std::unique_ptr<DuplexConnection>
 TcpConnectionFactory::createDuplexConnectionFromSocket(
-    folly::AsyncSocket::UniquePtr socket,
+    folly::AsyncTransportWrapper::UniquePtr socket,
     std::shared_ptr<RSocketStats> stats) {
   return std::make_unique<TcpDuplexConnection>(
       std::move(socket), std::move(stats));

--- a/rsocket/transports/tcp/TcpConnectionFactory.h
+++ b/rsocket/transports/tcp/TcpConnectionFactory.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include <folly/SocketAddress.h>
-#include <folly/io/async/AsyncSocket.h>
+#include <folly/io/async/AsyncTransport.h>
 
 #include "rsocket/ConnectionFactory.h"
 #include "rsocket/DuplexConnection.h"
@@ -30,7 +30,7 @@ class TcpConnectionFactory : public ConnectionFactory {
   folly::Future<ConnectedDuplexConnection> connect() override;
 
   static std::unique_ptr<DuplexConnection> createDuplexConnectionFromSocket(
-      folly::AsyncSocket::UniquePtr socket,
+      folly::AsyncTransportWrapper::UniquePtr socket,
       std::shared_ptr<RSocketStats> stats = std::shared_ptr<RSocketStats>());
 
  private:

--- a/rsocket/transports/tcp/TcpDuplexConnection.h
+++ b/rsocket/transports/tcp/TcpDuplexConnection.h
@@ -4,6 +4,7 @@
 
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <folly/io/async/AsyncSocket.h>
+#include <folly/io/async/AsyncTransport.h>
 
 #include "rsocket/DuplexConnection.h"
 #include "rsocket/RSocketStats.h"
@@ -16,7 +17,7 @@ class TcpReaderWriter;
 class TcpDuplexConnection : public DuplexConnection {
  public:
   explicit TcpDuplexConnection(
-      folly::AsyncSocket::UniquePtr&& socket,
+      folly::AsyncTransportWrapper::UniquePtr&& socket,
       std::shared_ptr<RSocketStats> stats = RSocketStats::noop());
   ~TcpDuplexConnection();
 
@@ -25,7 +26,7 @@ class TcpDuplexConnection : public DuplexConnection {
   void setInput(yarpl::Reference<DuplexConnection::Subscriber>) override;
 
   // Only to be used for observation purposes.
-  folly::AsyncSocket* getTransport();
+  folly::AsyncTransportWrapper* getTransport();
 
  private:
   boost::intrusive_ptr<TcpReaderWriter> tcpReaderWriter_;

--- a/test/ColdResumptionTest.cpp
+++ b/test/ColdResumptionTest.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <folly/Conv.h>
+#include <folly/Format.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <folly/portability/GFlags.h>
 

--- a/test/transport/TcpDuplexConnectionTest.cpp
+++ b/test/transport/TcpDuplexConnectionTest.cpp
@@ -1,7 +1,7 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include <folly/futures/Future.h>
-#include <folly/io/async/AsyncSocket.h>
+#include <folly/io/async/AsyncTransport.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
A more general type lets a wider range of consumers of RSocket create clients with their own transports. 