### PR TITLE
Add a toString() function for FrameType

### DIFF
--- a/rsocket/framing/FrameType.cpp
+++ b/rsocket/framing/FrameType.cpp
@@ -4,45 +4,57 @@
 
 #include <ostream>
 
+#include <glog/logging.h>
+
 namespace rsocket {
 
-std::ostream& operator<<(std::ostream& os, FrameType type) {
+constexpr folly::StringPiece kUnknown{"UNKNOWN_FRAME_TYPE"};
+
+folly::StringPiece toString(FrameType type) {
   switch (type) {
     case FrameType::RESERVED:
-      return os << "RESERVED";
+      return "RESERVED";
     case FrameType::SETUP:
-      return os << "SETUP";
+      return "SETUP";
     case FrameType::LEASE:
-      return os << "LEASE";
+      return "LEASE";
     case FrameType::KEEPALIVE:
-      return os << "KEEPALIVE";
+      return "KEEPALIVE";
     case FrameType::REQUEST_RESPONSE:
-      return os << "REQUEST_RESPONSE";
+      return "REQUEST_RESPONSE";
     case FrameType::REQUEST_FNF:
-      return os << "REQUEST_FNF";
+      return "REQUEST_FNF";
     case FrameType::REQUEST_STREAM:
-      return os << "REQUEST_STREAM";
+      return "REQUEST_STREAM";
     case FrameType::REQUEST_CHANNEL:
-      return os << "REQUEST_CHANNEL";
+      return "REQUEST_CHANNEL";
     case FrameType::REQUEST_N:
-      return os << "REQUEST_N";
+      return "REQUEST_N";
     case FrameType::CANCEL:
-      return os << "CANCEL";
+      return "CANCEL";
     case FrameType::PAYLOAD:
-      return os << "PAYLOAD";
+      return "PAYLOAD";
     case FrameType::ERROR:
-      return os << "ERROR";
+      return "ERROR";
     case FrameType::METADATA_PUSH:
-      return os << "METADATA_PUSH";
+      return "METADATA_PUSH";
     case FrameType::RESUME:
-      return os << "RESUME";
+      return "RESUME";
     case FrameType::RESUME_OK:
-      return os << "RESUME_OK";
+      return "RESUME_OK";
     case FrameType::EXT:
-      return os << "EXT";
+      return "EXT";
     default:
-      break;
+      DLOG(FATAL) << "Unknown frame type";
+      return kUnknown;
   }
-  return os << "Unknown FrameType[" << static_cast<int>(type) << "]";
+}
+
+std::ostream& operator<<(std::ostream& os, FrameType type) {
+  auto const str = toString(type);
+  if (str == kUnknown) {
+    return os << "Unknown FrameType[" << static_cast<int>(type) << "]";
+  }
+  return os << str;
 }
 }

--- a/rsocket/framing/FrameType.h
+++ b/rsocket/framing/FrameType.h
@@ -5,6 +5,8 @@
 #include <cstdint>
 #include <iosfwd>
 
+#include <folly/Range.h>
+
 namespace rsocket {
 
 enum class FrameType : uint8_t {
@@ -26,5 +28,8 @@ enum class FrameType : uint8_t {
   EXT = 0x3F,
 };
 
+folly::StringPiece toString(FrameType);
+
 std::ostream& operator<<(std::ostream&, FrameType);
+
 }

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -624,9 +624,9 @@ void RSocketStateMachine::handleConnectionFrame(
     case FrameType::PAYLOAD:
     case FrameType::EXT:
     default: {
-      std::stringstream message;
-      message << "Unexpected " << frameType << " frame for stream 0";
-      closeWithError(Frame_ERROR::connectionError(message.str()));
+      auto msg = folly::sformat(
+          "Unexpected {} frame for stream 0", toString(frameType));
+      closeWithError(Frame_ERROR::connectionError(std::move(msg)));
       return;
     }
   }
@@ -696,9 +696,9 @@ void RSocketStateMachine::handleStreamFrame(
     case FrameType::RESUME:
     case FrameType::RESUME_OK:
     case FrameType::EXT: {
-      std::stringstream message;
-      message << "Unexpected " << frameType << " frame for stream " << streamId;
-      closeWithError(Frame_ERROR::connectionError(message.str()));
+      auto msg = folly::sformat(
+          "Unexpected {} frame for stream {}", toString(frameType), streamId);
+      closeWithError(Frame_ERROR::connectionError(std::move(msg)));
       break;
     }
     default:
@@ -721,10 +721,10 @@ void RSocketStateMachine::handleUnknownStream(
   }
 
   if (!isNewStreamFrame(frameType)) {
-    std::stringstream msg;
-    msg << "Unexpected frame " << frameType << " for stream " << streamId;
-    VLOG(1) << msg.str();
-    closeWithError(Frame_ERROR::connectionError(msg.str()));
+    auto msg = folly::sformat(
+        "Unexpected frame {} for stream {}", toString(frameType), streamId);
+    VLOG(1) << msg;
+    closeWithError(Frame_ERROR::connectionError(std::move(msg)));
     return;
   }
 


### PR DESCRIPTION
In the past we've logged these a lot (every frame received and sent), and in a
few cases we would be forced into feeding them through a std::stringstream
unnecessarily, incurring a lot of extra work.

Add a FrameType -> folly::StringPiece function in cases where the operator<<
would be too expensive, leave the operator around as it's still useful.