### PR TITLE
Fix benchmarks destroying latch too early

### DIFF
--- a/benchmarks/FireForgetThroughputTcp.cpp
+++ b/benchmarks/FireForgetThroughputTcp.cpp
@@ -36,10 +36,10 @@ class Responder : public RSocketResponder {
 BENCHMARK(FireForgetThroughput, n) {
   (void)n;
 
+  Latch latch{static_cast<size_t>(FLAGS_items)};
+
   std::unique_ptr<Fixture> fixture;
   Fixture::Options opts;
-
-  Latch latch{static_cast<size_t>(FLAGS_items)};
 
   BENCHMARK_SUSPEND {
     auto responder = std::make_shared<Responder>(latch);

--- a/benchmarks/RequestResponseThroughputTcp.cpp
+++ b/benchmarks/RequestResponseThroughputTcp.cpp
@@ -56,10 +56,10 @@ class Observer : public yarpl::single::SingleObserverBase<Payload> {
 BENCHMARK(RequestResponseThroughput, n) {
   (void)n;
 
+  Latch latch{static_cast<size_t>(FLAGS_items)};
+
   std::unique_ptr<Fixture> fixture;
   Fixture::Options opts;
-
-  Latch latch{static_cast<size_t>(FLAGS_items)};
 
   BENCHMARK_SUSPEND {
     auto responder =

--- a/benchmarks/StreamThroughputTcp.cpp
+++ b/benchmarks/StreamThroughputTcp.cpp
@@ -25,10 +25,10 @@ DEFINE_int32(streams, 1, "number of streams, per client");
 BENCHMARK(StreamThroughput, n) {
   (void)n;
 
+  Latch latch{static_cast<size_t>(FLAGS_streams)};
+
   std::unique_ptr<Fixture> fixture;
   Fixture::Options opts;
-
-  Latch latch{static_cast<size_t>(FLAGS_streams)};
 
   BENCHMARK_SUSPEND {
     auto responder =


### PR DESCRIPTION
It needs to be destroyed after the Fixture, because the Fixture contains the
clients that are accessing it.

Noticed after benchmarks started failing locally for me with
stack-use-after-free errors.