### PR TITLE
Don't use ConnectionSet in RSocketClient

### DIFF
--- a/rsocket/RSocketClient.h
+++ b/rsocket/RSocketClient.h
@@ -16,7 +16,6 @@
 
 namespace rsocket {
 
-class ConnectionSet;
 class RSocket;
 
 /**
@@ -72,7 +71,6 @@ class RSocketClient {
   void createState();
 
   std::shared_ptr<ConnectionFactory> connectionFactory_;
-  std::shared_ptr<ConnectionSet> connectionSet_;
   std::shared_ptr<RSocketResponder> responder_;
   std::chrono::milliseconds keepaliveInterval_;
   std::shared_ptr<RSocketStats> stats_;


### PR DESCRIPTION
It only has one connection, why does it need a set of them?

Makes ~RSocketClient destroy the RSocketStateMachine synchronously, where
previously this was async.  I'm worried about users destroying their
RSocketClient objects, and then having their EventBases accidentally access more
state later via stream subscribers.