### PR TITLE
ColdResumeHandler should be nullptr as its not to be used in default

### DIFF
--- a/rsocket/RSocket.h
+++ b/rsocket/RSocket.h
@@ -24,8 +24,7 @@ class RSocket {
       std::shared_ptr<RSocketConnectionEvents> connectionEvents =
           std::shared_ptr<RSocketConnectionEvents>(),
       std::shared_ptr<ResumeManager> resumeManager = nullptr,
-      std::shared_ptr<ColdResumeHandler> coldResumeHandler =
-          std::shared_ptr<ColdResumeHandler>(),
+      std::shared_ptr<ColdResumeHandler> coldResumeHandler = nullptr,
       folly::EventBase* stateMachineEvb = nullptr);
 
   // Creates a RSocketClient which cold-resumes from the provided state
@@ -58,8 +57,7 @@ class RSocket {
       std::shared_ptr<RSocketConnectionEvents> connectionEvents =
           std::shared_ptr<RSocketConnectionEvents>(),
       std::shared_ptr<ResumeManager> resumeManager = nullptr,
-      std::shared_ptr<ColdResumeHandler> coldResumeHandler =
-          std::shared_ptr<ColdResumeHandler>(),
+      std::shared_ptr<ColdResumeHandler> coldResumeHandler = nullptr,
       folly::EventBase* stateMachineEvb = nullptr);
 
   // A convenience function to create RSocketServer

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -445,7 +445,6 @@ void RSocketStateMachine::closeStreams(StreamCompletionSignal signal) {
 }
 
 void RSocketStateMachine::processFrame(std::unique_ptr<folly::IOBuf> frame) {
-
   if (isClosed()) {
     VLOG(4) << "StateMachine has been closed.  Discarding incoming frame";
     return;
@@ -717,8 +716,7 @@ void RSocketStateMachine::handleUnknownStream(
   // we should change the version to struct
   DCHECK_GT(frameSerializer_->protocolVersion(), ProtocolVersion(0, 0));
 
-  if (frameType != FrameType::REQUEST_FNF &&
-      !streamsFactory_.registerNewPeerStreamId(streamId)) {
+  if (!streamsFactory_.registerNewPeerStreamId(streamId)) {
     return;
   }
 

--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -715,7 +715,9 @@ void RSocketStateMachine::handleUnknownStream(
   // TODO: comparing string versions is odd because from version
   // 10.0 the lexicographic comparison doesn't work
   // we should change the version to struct
-  if (frameSerializer_->protocolVersion() > ProtocolVersion{0, 0} &&
+  DCHECK_GT(frameSerializer_->protocolVersion(), ProtocolVersion(0, 0));
+
+  if (frameType != FrameType::REQUEST_FNF &&
       !streamsFactory_.registerNewPeerStreamId(streamId)) {
     return;
   }


### PR DESCRIPTION
When the coldResumeHandler is not null, the handleUnknownStream function uses this object to save a token and some states. 

In default, we don't need this functionality, so it should be assigned to `nullptr` at the constructor's default parameters. Why to pay the cost if we don't want to use it.

For FireAndForget, we don't need to create/register any stream. Don't pay the cost of creating a stream even though we will not use it.