### PR TITLE
Fix RSocketServerState::close() being unsafe

### DIFF
--- a/rsocket/RSocketServerState.h
+++ b/rsocket/RSocketServerState.h
@@ -13,8 +13,8 @@ namespace rsocket {
 class RSocketServerState {
  public:
   void close() {
-    eventBase_.runInEventBaseThread([this]() {
-      rSocketStateMachine_->close({}, StreamCompletionSignal::SOCKET_CLOSED);
+    eventBase_.runInEventBaseThread([sm = rSocketStateMachine_] {
+      sm->close({}, StreamCompletionSignal::SOCKET_CLOSED);
     });
   }
 


### PR DESCRIPTION
It passed `this` as a raw pointer to an EventBase callback.  Grab a reference to
the right shared_ptr field instead.