### PR TITLE
Drop ProtocolVersion argument to SetupResumeAcceptor

### DIFF
--- a/rsocket/RSocketServer.cpp
+++ b/rsocket/RSocketServer.cpp
@@ -18,9 +18,7 @@ RSocketServer::RSocketServer(
     : duplexConnectionAcceptor_(std::move(connectionAcceptor)),
       setupResumeAcceptors_([] {
         return new rsocket::SetupResumeAcceptor{
-            ProtocolVersion::Unknown,
-            folly::EventBaseManager::get()->getExistingEventBase()
-          };
+            folly::EventBaseManager::get()->getExistingEventBase()};
       }),
       connectionSet_(std::make_shared<ConnectionSet>()),
       stats_(std::move(stats)) {}
@@ -66,11 +64,12 @@ void RSocketServer::start(
   }
   started = true;
 
-  duplexConnectionAcceptor_->start([this, serviceHandler](
-      std::unique_ptr<DuplexConnection> connection,
-      folly::EventBase& eventBase) {
-    acceptConnection(std::move(connection), eventBase, serviceHandler);
-  });
+  duplexConnectionAcceptor_->start(
+      [this, serviceHandler](
+          std::unique_ptr<DuplexConnection> connection,
+          folly::EventBase& eventBase) {
+        acceptConnection(std::move(connection), eventBase, serviceHandler);
+      });
 }
 
 void RSocketServer::start(OnNewSetupFn onNewSetupFn) {

--- a/rsocket/internal/SetupResumeAcceptor.h
+++ b/rsocket/internal/SetupResumeAcceptor.h
@@ -10,7 +10,6 @@
 
 #include "rsocket/DuplexConnection.h"
 #include "rsocket/RSocketParameters.h"
-#include "rsocket/internal/Common.h"
 #include "yarpl/Refcounted.h"
 
 namespace folly {
@@ -18,11 +17,10 @@ class EventBase;
 class Executor;
 class IOBuf;
 class exception_wrapper;
-}
+} // namespace folly
 
 namespace rsocket {
 
-class FrameSerializer;
 class FrameTransport;
 
 /// Acceptor of DuplexConnections that lets us decide whether the connection is
@@ -37,8 +35,7 @@ class SetupResumeAcceptor final {
   using OnResume =
       folly::Function<void(yarpl::Reference<FrameTransport>, ResumeParameters)>;
 
-  SetupResumeAcceptor(ProtocolVersion, folly::EventBase*);
-
+  explicit SetupResumeAcceptor(folly::EventBase*);
   ~SetupResumeAcceptor();
 
   /// Wait for and process the first frame on a DuplexConnection, calling the
@@ -103,15 +100,11 @@ class SetupResumeAcceptor final {
   /// work within the owner thread.
   bool inOwnerThread() const;
 
-  /// Get the default FrameSerializer if one exists, otherwise try to autodetect
-  /// the correct FrameSerializer from the given frame.
-  std::shared_ptr<FrameSerializer> createSerializer(const folly::IOBuf&);
-
   std::unordered_set<yarpl::Reference<OneFrameSubscriber>> connections_;
 
   bool closed_{false};
 
-  std::shared_ptr<FrameSerializer> defaultSerializer_;
   folly::EventBase* eventBase_;
 };
-}
+
+} // namespace rsocket

--- a/test/internal/SetupResumeAcceptorTest.cpp
+++ b/test/internal/SetupResumeAcceptorTest.cpp
@@ -58,25 +58,22 @@ bool resumeFail(yarpl::Reference<FrameTransport> transport, ResumeParameters) {
   ADD_FAILURE() << "resumeFail() was called";
   return false;
 }
-}
+} // namespace
 
 TEST(SetupResumeAcceptor, ImmediateDtor) {
   folly::EventBase evb;
-  SetupResumeAcceptor acceptor1{ProtocolVersion::Latest, &evb};
-  SetupResumeAcceptor acceptor2{ProtocolVersion::Unknown, &evb};
+  SetupResumeAcceptor acceptor{&evb};
 }
 
 TEST(SetupResumeAcceptor, ImmediateClose) {
   folly::EventBase evb;
-  SetupResumeAcceptor acceptor1{ProtocolVersion::Latest, &evb};
-  SetupResumeAcceptor acceptor2{ProtocolVersion::Unknown, &evb};
-  acceptor1.close().get();
-  acceptor2.close().get();
+  SetupResumeAcceptor acceptor{&evb};
+  acceptor.close().get();
 }
 
 TEST(SetupResumeAcceptor, CloseWithActiveConnection) {
   folly::EventBase evb;
-  SetupResumeAcceptor acceptor{ProtocolVersion::Unknown, &evb};
+  SetupResumeAcceptor acceptor{&evb};
 
   yarpl::Reference<DuplexConnection::Subscriber> outerInput;
 
@@ -99,7 +96,7 @@ TEST(SetupResumeAcceptor, CloseWithActiveConnection) {
 
 TEST(SetupResumeAcceptor, EarlyComplete) {
   folly::EventBase evb;
-  SetupResumeAcceptor acceptor{ProtocolVersion::Unknown, &evb};
+  SetupResumeAcceptor acceptor{&evb};
 
   auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
       [](auto input) {
@@ -118,7 +115,7 @@ TEST(SetupResumeAcceptor, EarlyComplete) {
 
 TEST(SetupResumeAcceptor, EarlyError) {
   folly::EventBase evb;
-  SetupResumeAcceptor acceptor{ProtocolVersion::Unknown, &evb};
+  SetupResumeAcceptor acceptor{&evb};
 
   auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
       [](auto input) {
@@ -137,7 +134,7 @@ TEST(SetupResumeAcceptor, EarlyError) {
 
 TEST(SetupResumeAcceptor, SingleSetup) {
   folly::EventBase evb;
-  SetupResumeAcceptor acceptor{ProtocolVersion::Unknown, &evb};
+  SetupResumeAcceptor acceptor{&evb};
 
   auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
       [](auto input) {
@@ -169,7 +166,7 @@ TEST(SetupResumeAcceptor, SingleSetup) {
 
 TEST(SetupResumeAcceptor, InvalidSetup) {
   folly::EventBase evb;
-  SetupResumeAcceptor acceptor{ProtocolVersion::Unknown, &evb};
+  SetupResumeAcceptor acceptor{&evb};
 
   auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
       [](auto input) {
@@ -203,7 +200,7 @@ TEST(SetupResumeAcceptor, InvalidSetup) {
 
 TEST(SetupResumeAcceptor, RejectedSetup) {
   folly::EventBase evb;
-  SetupResumeAcceptor acceptor{ProtocolVersion::Unknown, &evb};
+  SetupResumeAcceptor acceptor{&evb};
 
   auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
       [](auto input) {
@@ -242,7 +239,7 @@ TEST(SetupResumeAcceptor, RejectedSetup) {
 
 TEST(SetupResumeAcceptor, RejectedResume) {
   folly::EventBase evb;
-  SetupResumeAcceptor acceptor{ProtocolVersion::Unknown, &evb};
+  SetupResumeAcceptor acceptor{&evb};
 
   auto connection = std::make_unique<StrictMock<MockDuplexConnection>>(
       [](auto input) {
@@ -274,11 +271,4 @@ TEST(SetupResumeAcceptor, RejectedResume) {
   evb.loop();
 
   EXPECT_TRUE(resumeCalled);
-}
-
-TEST(SetupResumeAcceptor, EventBaseDisappear) {
-  auto evb = std::make_unique<folly::EventBase>();
-
-  SetupResumeAcceptor acceptor{
-      ProtocolVersion::Unknown, evb.get()};
 }


### PR DESCRIPTION
Have it always autodetect the proper version.  Right now this is how we always
use SetupResumeAcceptor.  In the future we'll drop the 0.1 version and only use
1.0, but that still won't require an explicit version parameter.