### PR TITLE
Add opt-in feature to don't use scheduled responders

### DIFF
--- a/rsocket/RSocketServer.cpp
+++ b/rsocket/RSocketServer.cpp
@@ -81,6 +81,10 @@ void RSocketServer::startAndPark(OnNewSetupFn onNewSetupFn) {
   startAndPark(RSocketServiceHandler::create(std::move(onNewSetupFn)));
 }
 
+void RSocketServer::setSingleThreadedResponder() {
+  useScheduledResponder_ = false;
+}
+
 void RSocketServer::acceptConnection(
     std::unique_ptr<DuplexConnection> connection,
     folly::EventBase&,
@@ -131,15 +135,16 @@ void RSocketServer::onRSocketSetup(
     VLOG(3) << "Terminating SETUP attempt from client.  No Responder";
     throw result.error();
   }
-  auto connectionParams = result.value();
+  auto connectionParams = std::move(result.value());
   if (!connectionParams.responder) {
     LOG(ERROR) << "Received invalid Responder. Dropping connection";
     throw RSocketException("Received invalid Responder from server");
   }
-  auto responder = std::make_shared<ScheduledRSocketResponder>(
-      std::move(connectionParams.responder), *eventBase);
   auto rs = std::make_shared<RSocketStateMachine>(
-      std::move(responder),
+      useScheduledResponder_
+          ? std::make_shared<ScheduledRSocketResponder>(
+              std::move(connectionParams.responder), *eventBase)
+          : std::move(connectionParams.responder),
       nullptr,
       RSocketMode::SERVER,
       std::move(connectionParams.stats),

--- a/rsocket/RSocketServer.h
+++ b/rsocket/RSocketServer.h
@@ -83,6 +83,12 @@ class RSocketServer {
    */
   folly::Optional<uint16_t> listeningPort() const;
 
+  /**
+   * Use the same EventBase that is provided to acceptConnection function for
+   * internal operations. Don't schedule to another event base.
+   */
+  void setSingleThreadedResponder();
+
  private:
   void onRSocketSetup(
       std::shared_ptr<RSocketServiceHandler> serviceHandler,
@@ -105,5 +111,12 @@ class RSocketServer {
 
   std::shared_ptr<ConnectionSet> connectionSet_;
   std::shared_ptr<RSocketStats> stats_;
+
+  /**
+   * If this field is false, acceptConnection() function will assume that there
+   * will be a single thread for each connected client. The execution will not
+   * be scheduled to another event base.
+   */
+  bool useScheduledResponder_{true};
 };
 } // namespace rsocket


### PR DESCRIPTION
Eliminate extra layer of indirection, creation and destruction of the object and many if/else checks, if we know that the execution will already be in a single thread.

It brings good performance improvements.