### PR TITLE
Bug fix - RequestResponseResponder gives subscription_ is not available failure

### DIFF
--- a/rsocket/statemachine/RequestResponseResponder.cpp
+++ b/rsocket/statemachine/RequestResponseResponder.cpp
@@ -22,8 +22,11 @@ void RequestResponseResponder::onSubscribe(
 }
 
 void RequestResponseResponder::onSuccess(Payload response) noexcept {
-  DCHECK(producingSubscription_) << "didnt call onSubscribe";
-  switch (state_) {
+  if (!producingSubscription_) {
+    // Already closed.
+    return;
+  }
+  switch (state_) l{
     case State::RESPONDING: {
       state_ = State::CLOSED;
       writePayload(std::move(response), true);


### PR DESCRIPTION
When the client abruptly disconnects from the server, it causes the server to crash in the Debug builds. This update eliminates this failure:

```
00025] Check faRequestResponseResponder.cpp didnt call onSubscribe:25] Check failed: producingSubscription_ didnt call onSubscribeF1106 09:08:50.119361 2583206 RequestResponseResponder.cpp:25] Check failed: produ
cingSubscription_ didnt call onSubscribeF1106 09:08:50.119788 2583170 RequestResponseResponder.cpp:25] Check failed: producingSubscription_ didnt call onSubscribeF01106110960080:50.12:0 08:50.120455     2583184 R
equestResponseResponder.cpp:25] 200 RequestResponseResponder.cppChe]  failed: producingSubscription_ didnt call onSubscribe
heck failed: producingSubscription_ didnt call onSubscribeF1106 09:08:50.120478 F112583177 6 09:08R50uestResponseResponder.cpp:.12048325] Check failed: producingSubscription_ didnt c RequestResponseResponder.cpp:
25] Check failed: producingSubscription_ didnt call onSubscribeF1106 09:08:50.120625 2583181 RequestResponseResponder.cpp:25] Check failed: producingSubscription_ didnt call onSubscribeF1106 09:08:50.120641 25832
05 RequestResponseResponder.cpp:25] Check failed: producingSubscription_ didnt call onSubscribeF1106 09:08:50.120651 2583179 RequestResponseResponder.cpp:25] Check failed: producingSubscription_ didnt call onSubs
cribeF110F060 09:11080:50.12069306  09:08:50.120694 2583189 Request esponseResponder.cpp:25] RequestResponseResponder.cpp:25] Check failed: producingSubscription_ Check failed: producingSubscription_ didnt call o
nSubscribeF1106 09:08:50.120712 2583201 RequestResponseResponder.cpp:25] Check failed: producingSubscription_ didnt call onSubscribeF1106 09:08:50.121124 2583185 RequestResponseResponder.cpp:25] Check failed: pro
ducingSubscription_ didnt call onSubscribe
*** Check failure stack trace: ***
    @ 00007f75157d893d folly::symbolizer::(anonymous namespace)::innerSignalHandler(int, siginfo_t*, void*)
                       ./folly/experimental/symbolizer/SignalHandler.cpp:414
    @ 00007f75157d7907 folly::symbolizer::(anonymous namespace)::signalHandler(int, siginfo_t*, void*)
                       ./folly/experimental/symbolizer/SignalHandler.cpp:424
    @ 00007f7518b20acf (unknown)
    @ 00007f75180507c8 __GI_raise
    @ 00007f7518052590 __GI_abort
    @ 00007f751bc6d08c google::LogMessage::Fail()
                       /home/engshare/third-party2/glog/0.3.2_fb/src/glog-0.3.2/src/logging.cc:1496
    @ 00007f751bc70a88 google::LogMessage::SendToLog()
                       /home/engshare/third-party2/glog/0.3.2_fb/src/glog-0.3.2/src/logging.cc:1450
    @ 00007f751bc6cc6f google::LogMessage::Flush()
                       /home/engshare/third-party2/glog/0.3.2_fb/src/glog-0.3.2/src/logging.cc:1323
    @ 00007f751bc6df8e google::LogMessageFatal::~LogMessageFatal()
                       /home/engshare/third-party2/glog/0.3.2_fb/src/glog-0.3.2/src/logging.cc:2022
    @ 00007f7516b9b460 rsocket::RequestResponseResponder::onSuccess(rsocket::Payload)
                       ./rsocket/dev/rsocket/statemachine/RequestResponseResponder.cpp:25
    @ 00007f7516d78432 apache::thrift::RequestResponseThriftChannel::sendThriftResponse(std::unique_ptr<apache::thrift::ResponseRpcMetadata, std::default_delete<apache::thrift::ResponseRpcMetadata> >, std::unique
_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> >)
                       ./thrift/lib/cpp2/transport/rsocket/server/RequestResponseThriftChannel.cpp:57
    @ 00007f751677067d apache::thrift::ThriftRequest::sendReplyInternal(std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> >&&, apache::thrift::MessageChannel::SendCallback*)
                       ./thrift/lib/cpp2/transport/core/ThriftRequest.h:153
                       -> ./thrift/lib/cpp2/transport/core/ThriftProcessor.cpp
    @ 00007f75167625e3 apache::thrift::ThriftRequest::sendReply(std::unique_ptr<folly::IOBuf, std::default_delete<folly::IOBuf> >&&, apache::thrift::MessageChannel::SendCallback*)
                       ./thrift/lib/cpp2/transport/core/ThriftRequest.h:118
                       -> ./thrift/lib/cpp2/transport/core/ThriftProcessor.cpp
    @ 00007f751fa22609 apache::thrift::HandlerCallbackBase::sendReply(folly::IOBufQueue)::{lambda()#1}::operator()()
                       ./thrift/lib/cpp2/async/AsyncProcessor.h:492
                       -> ./buck-out/dev-asan/gen/thrift/perf/cpp2/if/benchmark-cpp2-Api.thrift=gen-cpp2/Benchmark.cpp/gen-cpp2/Benchmark.cpp
    @ 00007f751fa223f4 void folly::detail::function::FunctionTraits<void ()>::callSmall<apache::thrift::HandlerCallbackBase::sendReply(folly::IOBufQueue)::{lambda()#1}>(folly::detail::function::Data&)
                       ./folly/Function.h:304
                       -> ./buck-out/dev-asan/gen/thrift/perf/cpp2/if/benchmark-cpp2-Api.thrift=gen-cpp2/Benchmark.cpp/gen-cpp2/Benchmark.cpp
    @ 00007f751688afb9 folly::detail::function::FunctionTraits<void ()>::operator()()
                       ./folly/Function.h:320
                       -> ./folly/io/async/EventBase.cpp
    @ 00007f75168b532d folly::EventBase::FunctionRunner::messageAvailable(folly::Function<void ()>&&)
                       ./folly/io/async/EventBase.cpp:59
```