### PR TITLE
Don't fail resumption if an old connection is still running

### DIFF
--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -97,19 +97,9 @@ bool RSocketStateMachine::resumeServer(
   int64_t serverDelta =
       resumeManager_->lastSentPosition() - resumeParams.serverPosition;
 
-  if (!isDisconnected()) {
-    VLOG(1) << "Old connection (" << frameTransport_.get() << ") exists. "
-            << "Terminating new connection (" << frameTransport.get() << ")";
-    frameTransport->closeWithError(
-        ResumptionException{"Old connection still exists"});
+  std::runtime_error exn{"Connection being resumed, dropping old connection"};
+  disconnect(std::move(exn));
 
-    stats_->serverResume(
-        clientAvailable,
-        serverAvailable,
-        serverDelta,
-        RSocketStats::ResumeOutcome::FAILURE);
-    return false;
-  }
   connect(std::move(frameTransport), resumeParams.protocolVersion);
 
   auto result = resumeFromPositionOrClose(

--- a/test/ColdResumptionTest.cpp
+++ b/test/ColdResumptionTest.cpp
@@ -348,7 +348,7 @@ TEST(ColdResumptionTest, DifferentEvb) {
 // Attempt a resumption when the previous transport/client hasn't
 // disconnected it.  Verify resumption succeeds after the previous
 // transport is disconnected.
-TEST(ColdResumptionTest, FailedResumption) {
+TEST(ColdResumptionTest, DisconnectResumption) {
   auto server = makeResumableServer(std::make_shared<HelloServiceHandler>());
   auto port = *server->listeningPort();
 
@@ -378,17 +378,6 @@ TEST(ColdResumptionTest, FailedResumption) {
       HelloSubscribers({{payload, resumedSub}}));
 
   std::shared_ptr<RSocketClient> resumedClient;
-  EXPECT_THROW(
-      resumedClient = createResumedClient(
-          transportWorker.getEventBase(),
-          port,
-          token,
-          resumeManager,
-          resumedCrh),
-      RSocketException);
-
-  client->disconnect().get();
-
   EXPECT_NO_THROW(
       resumedClient = createResumedClient(
           transportWorker.getEventBase(),


### PR DESCRIPTION
Instead, disconnect it and then move forward with resumption.