### PR TITLE
Fix the build of yarpl under C++17 mode

### DIFF
--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -10,7 +10,8 @@
 #include "yarpl/flowable/Subscription.h"
 #include "yarpl/utils/credits.h"
 
-#include "folly/Executor.h"
+#include <folly/Executor.h>
+#include <folly/functional/Invoke.h>
 
 namespace yarpl {
 namespace flowable {
@@ -122,7 +123,7 @@ template <
     typename U,
     typename D,
     typename F,
-    typename = typename std::enable_if<std::is_callable<F(U), D>::value>::type>
+    typename = typename std::enable_if<folly::is_invocable_r<D, F, U>::value>::type>
 class MapOperator : public FlowableOperator<U, D, MapOperator<U, D, F>> {
   using ThisOperatorT = MapOperator<U, D, F>;
   using Super = FlowableOperator<U, D, ThisOperatorT>;
@@ -163,7 +164,7 @@ template <
     typename U,
     typename F,
     typename =
-        typename std::enable_if<std::is_callable<F(U), bool>::value>::type>
+        typename std::enable_if<folly::is_invocable_r<bool, F, U>::value>::type>
 class FilterOperator : public FlowableOperator<U, U, FilterOperator<U, F>> {
   // for use in subclasses
   using ThisOperatorT = FilterOperator<U, F>;
@@ -206,7 +207,7 @@ template <
     typename F,
     typename = typename std::enable_if<std::is_assignable<D, U>::value>,
     typename =
-        typename std::enable_if<std::is_callable<F(D, U), D>::value>::type>
+        typename std::enable_if<folly::is_invocable_r<D, F, D, U>::value>::type>
 class ReduceOperator : public FlowableOperator<U, D, ReduceOperator<U, D, F>> {
   using ThisOperatorT = ReduceOperator<U, D, F>;
   using Super = FlowableOperator<U, D, ThisOperatorT>;

--- a/yarpl/include/yarpl/flowable/Flowables.h
+++ b/yarpl/include/yarpl/flowable/Flowables.h
@@ -10,6 +10,8 @@
 
 #include "yarpl/flowable/Flowable.h"
 
+#include <folly/functional/Invoke.h>
+
 namespace yarpl {
 namespace flowable {
 
@@ -102,9 +104,8 @@ class Flowables {
   template <
       typename T,
       typename OnSubscribe,
-      typename = typename std::enable_if<std::is_callable<
-          OnSubscribe(Reference<Subscriber<T>>),
-          void>::value>::type>
+      typename = typename std::enable_if<folly::is_invocable<
+          OnSubscribe, Reference<Subscriber<T>>>::value>::type>
   static Reference<Flowable<T>> fromPublisher(OnSubscribe function) {
     return make_ref<FromPublisherOperator<T, OnSubscribe>>(std::move(function));
   }

--- a/yarpl/include/yarpl/flowable/Subscribers.h
+++ b/yarpl/include/yarpl/flowable/Subscribers.h
@@ -5,6 +5,8 @@
 #include <exception>
 #include <limits>
 
+#include <folly/functional/Invoke.h>
+
 #include "yarpl/flowable/Subscriber.h"
 #include "yarpl/utils/credits.h"
 #include "yarpl/utils/type_traits.h"
@@ -24,7 +26,7 @@ class Subscribers {
       typename T,
       typename Next,
       typename =
-          typename std::enable_if<std::is_callable<Next(T), void>::value>::type>
+          typename std::enable_if<folly::is_invocable<Next, T>::value>::type>
   static Reference<Subscriber<T>> create(
       Next next,
       int64_t batch = kNoFlowControl) {
@@ -36,8 +38,8 @@ class Subscribers {
       typename Next,
       typename Error,
       typename = typename std::enable_if<
-          std::is_callable<Next(T), void>::value &&
-          std::is_callable<Error(folly::exception_wrapper), void>::value>::type>
+          folly::is_invocable<Next, T>::value &&
+          folly::is_invocable<Error, folly::exception_wrapper>::value>::type>
   static Reference<Subscriber<T>>
   create(Next next, Error error, int64_t batch = kNoFlowControl) {
     return make_ref<WithError<T, Next, Error>>(
@@ -50,9 +52,9 @@ class Subscribers {
       typename Error,
       typename Complete,
       typename = typename std::enable_if<
-          std::is_callable<Next(T), void>::value &&
-          std::is_callable<Error(folly::exception_wrapper), void>::value &&
-          std::is_callable<Complete(), void>::value>::type>
+          folly::is_invocable<Next, T>::value &&
+          folly::is_invocable<Error, folly::exception_wrapper>::value &&
+          folly::is_invocable<Complete>::value>::type>
   static Reference<Subscriber<T>> create(
       Next next,
       Error error,

--- a/yarpl/include/yarpl/observable/ObservableOperator.h
+++ b/yarpl/include/yarpl/observable/ObservableOperator.h
@@ -8,6 +8,8 @@
 #include "yarpl/observable/Observer.h"
 #include "yarpl/observable/Subscriptions.h"
 
+#include <folly/functional/Invoke.h>
+
 namespace yarpl {
 namespace observable {
 
@@ -170,7 +172,7 @@ template <
     typename U,
     typename D,
     typename F,
-    typename = typename std::enable_if<std::is_callable<F(U), D>::value>::type>
+    typename = typename std::enable_if<folly::is_invocable_r<D, F, U>::value>::type>
 class MapOperator : public ObservableOperator<U, D, MapOperator<U, D, F>> {
   using ThisOperatorT = MapOperator<U, D, F>;
   using Super = ObservableOperator<U, D, ThisOperatorT>;
@@ -216,7 +218,7 @@ template <
     typename U,
     typename F,
     typename =
-        typename std::enable_if<std::is_callable<F(U), bool>::value>::type>
+        typename std::enable_if<folly::is_invocable_r<bool, F, U>::value>::type>
 class FilterOperator : public ObservableOperator<U, U, FilterOperator<U, F>> {
   using ThisOperatorT = FilterOperator<U, F>;
   using Super = ObservableOperator<U, U, ThisOperatorT>;
@@ -261,7 +263,7 @@ template <
     typename F,
     typename = typename std::enable_if<std::is_assignable<D, U>::value>,
     typename =
-        typename std::enable_if<std::is_callable<F(D, U), D>::value>::type>
+        typename std::enable_if<folly::is_invocable_r<U, F, D, U>::value>::type>
 class ReduceOperator
     : public ObservableOperator<U, D, ReduceOperator<U, D, F>> {
   using ThisOperatorT = ReduceOperator<U, D, F>;

--- a/yarpl/include/yarpl/observable/Observables.h
+++ b/yarpl/include/yarpl/observable/Observables.h
@@ -7,6 +7,8 @@
 #include "yarpl/observable/Observable.h"
 #include "yarpl/observable/Subscriptions.h"
 
+#include <folly/functional/Invoke.h>
+
 namespace yarpl {
 namespace observable {
 
@@ -70,7 +72,7 @@ class Observables {
       typename T,
       typename OnSubscribe,
       typename = typename std::enable_if<
-          std::is_callable<OnSubscribe(Reference<Observer<T>>), void>::value>::
+          folly::is_invocable<OnSubscribe, Reference<Observer<T>>>::value>::
           type>
   static Reference<Observable<T>> create(OnSubscribe function) {
     return make_ref<FromPublisherOperator<T, OnSubscribe>>(std::move(function));

--- a/yarpl/include/yarpl/observable/Observers.h
+++ b/yarpl/include/yarpl/observable/Observers.h
@@ -4,7 +4,9 @@
 
 #include <exception>
 #include <limits>
+
 #include <folly/ExceptionWrapper.h>
+#include <folly/functional/Invoke.h>
 
 #include "yarpl/observable/Observer.h"
 #include "yarpl/utils/type_traits.h"
@@ -26,9 +28,9 @@ class Observers {
       typename Error = void (*)(folly::exception_wrapper),
       typename Complete = void (*)()>
   using EnableIfCompatible = typename std::enable_if<
-      std::is_callable<Next(T), void>::value &&
-      std::is_callable<Error(folly::exception_wrapper), void>::value &&
-      std::is_callable<Complete(), void>::value>::type;
+      folly::is_invocable<Next, T>::value &&
+      folly::is_invocable<Error, folly::exception_wrapper>::value &&
+      folly::is_invocable<Complete>::value>::type;
 
  public:
   template <typename T, typename Next, typename = EnableIfCompatible<T, Next>>

--- a/yarpl/include/yarpl/single/SingleObservers.h
+++ b/yarpl/include/yarpl/single/SingleObservers.h
@@ -6,6 +6,8 @@
 
 #include "yarpl/single/SingleObserver.h"
 
+#include <folly/functional/Invoke.h>
+
 namespace yarpl {
 namespace single {
 
@@ -22,8 +24,8 @@ class SingleObservers {
       typename Success,
       typename Error = void (*)(folly::exception_wrapper)>
   using EnableIfCompatible = typename std::enable_if<
-      std::is_callable<Success(T), void>::value &&
-      std::is_callable<Error(folly::exception_wrapper), void>::value>::type;
+      folly::is_invocable<Success, T>::value &&
+      folly::is_invocable<Error, folly::exception_wrapper>::value>::type;
 
  public:
   template <typename T, typename Next, typename = EnableIfCompatible<T, Next>>

--- a/yarpl/include/yarpl/single/SingleOperator.h
+++ b/yarpl/include/yarpl/single/SingleOperator.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <folly/Try.h>
+#include <folly/functional/Invoke.h>
+
 #include <utility>
 
 #include "yarpl/single/Single.h"
@@ -149,7 +151,7 @@ template <
     typename U,
     typename D,
     typename F,
-    typename = typename std::enable_if<std::is_callable<F(U), D>::value>::type>
+    typename = typename std::enable_if<folly::is_invocable_r<D, F, U>::value>::type>
 class MapOperator : public SingleOperator<U, D> {
   using ThisOperatorT = MapOperator<U, D, F>;
   using Super = SingleOperator<U, D>;

--- a/yarpl/include/yarpl/single/Singles.h
+++ b/yarpl/include/yarpl/single/Singles.h
@@ -7,6 +7,8 @@
 #include "yarpl/single/Single.h"
 #include "yarpl/single/SingleSubscriptions.h"
 
+#include <folly/functional/Invoke.h>
+
 namespace yarpl {
 namespace single {
 
@@ -25,9 +27,8 @@ class Singles {
   template <
       typename T,
       typename OnSubscribe,
-      typename = typename std::enable_if<std::is_callable<
-          OnSubscribe(Reference<SingleObserver<T>>),
-          void>::value>::type>
+      typename = typename std::enable_if<folly::is_invocable<
+          OnSubscribe, Reference<SingleObserver<T>>>::value>::type>
   static Reference<Single<T>> create(OnSubscribe function) {
     return make_ref<FromPublisherOperator<T, OnSubscribe>>(std::move(function));
   }


### PR DESCRIPTION
`std::is_callable` became `std::is_invocable` and got a slightly different API shortly before C++17 was finalized.
To stay compatible with previous versions, use the backports in Folly.