### PR TITLE
[Yarpl] Implement flatMap for Flowable

### DIFF
--- a/yarpl/CMakeLists.txt
+++ b/yarpl/CMakeLists.txt
@@ -131,6 +131,7 @@ if (BUILD_TESTS)
     yarpl-tests
     test/MocksTest.cpp
     test/FlowableTest.cpp
+    test/FlowableFlatMapTest.cpp
     test/Observable_test.cpp
     test/RefcountedTest.cpp
     test/ReferenceTest.cpp

--- a/yarpl/include/yarpl/flowable/Flowable.h
+++ b/yarpl/include/yarpl/flowable/Flowable.h
@@ -79,6 +79,9 @@ class Flowable : public virtual Refcounted, public yarpl::enable_get_ref {
       typename R = typename std::result_of<Function(T)>::type>
   Reference<Flowable<R>> map(Function function);
 
+  template <typename R>
+  Reference<Flowable<R>> flatMap(folly::Function<Reference<Flowable<R>>(T)>);
+
   template <typename Function>
   Reference<Flowable<T>> filter(Function function);
 
@@ -166,6 +169,14 @@ template <typename T>
 Reference<Flowable<T>> Flowable<T>::observeOn(folly::Executor& executor) {
   return make_ref<yarpl::flowable::detail::ObserveOnOperator<T>>(
       this->ref_from_this(this), executor);
+}
+
+template <typename T>
+template <typename R>
+Reference<Flowable<R>> Flowable<T>::flatMap(
+    folly::Function<Reference<Flowable<R>>(T)> func) {
+  return make_ref<FlatMapOperator<T, R>>(
+      this->ref_from_this(this), std::move(func));
 }
 
 } // flowable

--- a/yarpl/test/FlowableFlatMapTest.cpp
+++ b/yarpl/test/FlowableFlatMapTest.cpp
@@ -1,0 +1,275 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <gtest/gtest.h>
+#include <deque>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+#include <folly/Baton.h>
+#include <folly/io/async/EventBase.h>
+#include <folly/io/async/EventBaseThread.h>
+
+#include "yarpl/test_utils/Mocks.h"
+
+#include "yarpl/Flowable.h"
+#include "yarpl/flowable/TestSubscriber.h"
+
+namespace yarpl {
+namespace flowable {
+
+namespace {
+
+/// Construct a pipeline with a test subscriber against the supplied
+/// flowable.  Return the items that were sent to the subscriber.  If some
+/// exception was sent, the exception is thrown.
+template <typename T>
+std::vector<T> run(
+    Reference<Flowable<T>> flowable,
+    int64_t requestCount = 100) {
+  auto subscriber = make_ref<TestSubscriber<T>>(requestCount);
+  flowable->subscribe(subscriber);
+  return std::move(subscriber->values());
+}
+
+} // namespace
+
+template <typename Pred>
+std::vector<int64_t> filter_run(std::vector<int64_t> in, Pred pred) {
+  std::vector<int64_t> ret;
+  std::copy_if(in.begin(), in.end(), std::back_inserter(ret), pred);
+  return ret;
+}
+
+std::vector<int64_t>
+filter_range(std::vector<int64_t> in, int64_t startat, int64_t endat) {
+  CHECK_LE(startat, endat);
+  return filter_run(
+      in, [=](int64_t i) { return (i >= startat) && (i < endat); });
+}
+
+auto make_flowable_mapper_func() {
+  return folly::Function<Reference<Flowable<int64_t>>(int)>([](int n) {
+    switch (n) {
+      case 10:
+        return Flowables::range(n, 2);
+      case 20:
+        return Flowables::range(n, 3);
+      case 30:
+        return Flowables::range(n, 4);
+    }
+    return Flowables::range(n, 3);
+  });
+}
+
+// assumes that separate streams of values in separate_streams are entirely
+// disjoint
+template <typename T>
+bool validate_flatmapped_values(
+    std::vector<T> flatmapped,
+    std::vector<std::deque<T>> separate_streams) {
+  for (auto elem : flatmapped) {
+    bool found_match = false;
+    for (auto& stream : separate_streams) {
+      if (stream.size() > 0) {
+        if (elem == stream[0]) {
+          stream.pop_front();
+          found_match = true;
+          break;
+        }
+      }
+    }
+
+    EXPECT_TRUE(found_match)
+        << "Did not find elem '" << elem << "' in any input streams";
+    if (!found_match) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+TEST(FlowableFlatMapTest, AllRequestedTest) {
+  auto f =
+      Flowables::justN<int>({10, 20, 30})->flatMap(make_flowable_mapper_func());
+
+  std::vector<int64_t> res = run(f);
+  EXPECT_EQ(9UL, res.size());
+  EXPECT_EQ(filter_range(res, 10, 20), std::vector<int64_t>({10, 11}));
+  EXPECT_EQ(filter_range(res, 20, 30), std::vector<int64_t>({20, 21, 22}));
+  EXPECT_EQ(filter_range(res, 30, 40), std::vector<int64_t>({30, 31, 32, 33}));
+}
+
+TEST(FlowableFlatMapTest, FiniteRequested) {
+  auto f =
+      Flowables::justN<int>({10, 20, 30})->flatMap(make_flowable_mapper_func());
+
+  auto subscriber = make_ref<TestSubscriber<int64_t>>(1);
+  f->subscribe(subscriber);
+
+  EXPECT_EQ(1UL, subscriber->values().size());
+  EXPECT_TRUE(
+      validate_flatmapped_values(subscriber->values(), {{10}, {20}, {30}}));
+
+  subscriber->request(3);
+  EXPECT_TRUE(validate_flatmapped_values(
+      subscriber->values(), {{10, 11}, {20, 21, 22}, {30, 31, 32, 33}}));
+  EXPECT_EQ(subscriber->getValueCount(), 4);
+  subscriber->cancel();
+  EXPECT_EQ(subscriber->getValueCount(), 4);
+}
+
+TEST(FlowableFlatMapTest, MappingLambdaThrowsErrorOnFirstCall) {
+  folly::Function<Reference<Flowable<int64_t>>(int)> func = [](int n) {
+    CHECK_EQ(1, n);
+    throw std::runtime_error{"throwing in mapper!"};
+    return Flowables::empty<int64_t>();
+  };
+
+  auto f = Flowables::just<int>(1)->flatMap(std::move(func));
+
+  auto subscriber = make_ref<TestSubscriber<int64_t>>(1);
+  f->subscribe(subscriber);
+
+  EXPECT_EQ(subscriber->getValueCount(), 0);
+  EXPECT_TRUE(subscriber->isError());
+  EXPECT_EQ(subscriber->getErrorMsg(), "throwing in mapper!");
+}
+
+TEST(FlowableFlatMapTest, MappedStreamThrows) {
+  folly::Function<Reference<Flowable<int64_t>>(int)> func = [](int n) {
+    CHECK_EQ(1, n);
+
+    // flowable which emits an onNext, then the next iteration, emits an error
+    int64_t i = 1;
+    return Flowable<int64_t>::create([i](auto subscriber, int64_t req) mutable {
+      CHECK_EQ(1, req);
+      if (i > 0) {
+        subscriber->onNext(i);
+        i--;
+      } else {
+        subscriber->onError(std::runtime_error{"throwing in stream!"});
+      }
+      return std::tuple<int64_t, bool>(1, false);
+    });
+  };
+
+  auto f = Flowables::just<int>(1)->flatMap(std::move(func));
+
+  auto subscriber = make_ref<TestSubscriber<int64_t>>(2);
+  f->subscribe(subscriber);
+
+  EXPECT_EQ(subscriber->values(), std::vector<int64_t>({1}));
+  EXPECT_TRUE(subscriber->isError());
+  EXPECT_EQ(subscriber->getErrorMsg(), "throwing in stream!");
+}
+
+struct CBSubscription : yarpl::flowable::Subscription {
+  template <typename OnReq, typename OnCancel>
+  CBSubscription(OnReq&& r, OnCancel&& c)
+      : onRequest(std::move(r)), onCancel(std::move(c)) {}
+
+  void request(int64_t n) override {
+    onRequest(n);
+  };
+  void cancel() override {
+    onCancel();
+  }
+
+  folly::Function<void(int64_t)> onRequest;
+  folly::Function<void(void)> onCancel;
+};
+
+struct FlowableEvbPair {
+  FlowableEvbPair() = default;
+  Reference<Flowable<int>> flowable{nullptr};
+  folly::EventBaseThread evb{};
+};
+
+std::shared_ptr<FlowableEvbPair> make_range_flowable(int start, int end) {
+  auto ret = std::make_shared<FlowableEvbPair>();
+  ret->evb.start("MRF_Worker");
+
+  ret->flowable = Flowables::fromPublisher<int>(
+      [&ret, start, end](Reference<Subscriber<int>> s) mutable {
+        auto evb = ret->evb.getEventBase();
+        auto subscription = yarpl::make_ref<CBSubscription>(
+            [=](int64_t req) mutable {
+              /* request */
+              CHECK_EQ(req, 1);
+              if (start >= end) {
+                evb->runInEventBaseThread([=] {
+                  s->onComplete();
+                });
+              } else {
+                auto n = start++;
+                evb->runInEventBaseThread([=] {
+                  s->onNext(n);
+                });
+              }
+            },
+            /* onCancel: do nothing */
+            []() {});
+
+        evb->runInEventBaseThread([=] { s->onSubscribe(subscription); });
+      });
+
+  return ret;
+}
+
+TEST(FlowableFlatMapTest, Multithreaded) {
+  auto p1 = make_range_flowable(10, 12);
+  auto p2 = make_range_flowable(20, 25);
+
+  folly::Function<Reference<Flowable<int>>(int64_t)> mappingFunc = [&](auto i) {
+    if (i == 0) {
+      return p1->flowable;
+    } else {
+      return p2->flowable;
+    }
+  };
+
+  auto f = Flowables::range(0, 2)->flatMap(std::move(mappingFunc));
+
+  auto sub = yarpl::make_ref<TestSubscriber<int>>(0);
+  f->subscribe(sub);
+
+  sub->request(2);
+  sub->awaitValueCount(2);
+  EXPECT_TRUE(validate_flatmapped_values(sub->values(), {{10, 11}, {20, 21}}));
+
+  sub->cancel();
+  p1->evb.stop();
+  p2->evb.stop();
+}
+
+TEST(FlowableFlatMapTest, MultithreadedLargeAmount) {
+  auto p1 = make_range_flowable(10000, 40000);
+  auto p2 = make_range_flowable(50000, 80000);
+
+  folly::Function<Reference<Flowable<int>>(int64_t)> mappingFunc = [&](auto i) {
+    if (i == 0) {
+      return p1->flowable;
+    } else {
+      return p2->flowable;
+    }
+  };
+
+  auto f = Flowables::range(0, 2)->flatMap(std::move(mappingFunc));
+
+  auto sub = yarpl::make_ref<TestSubscriber<int>>();
+  sub->dropValues(true);
+
+  f->subscribe(sub);
+
+  sub->awaitTerminalEvent(std::chrono::seconds{5});
+  EXPECT_EQ(60000, sub->getValueCount());
+  EXPECT_TRUE(sub->isComplete());
+
+  p1->evb.stop();
+  p2->evb.stop();
+}
+
+} // namespace flowable
+} // namespace yarpl


### PR DESCRIPTION
WIP implementation of flow aware flatMap

TODO: 
 - Take an arbitrary lambda with a compatible type signature instead of a `folly::Function`
 - Buffer more than 1 element at a time (1 element currently for simplicity and to verify higher-level threading synchronization is correct). This should be the largest perf win. 

What has been tested to work:
 - Requesting an entire stream
 - Requesting 'n' elements of a stream, and having number of requested elements be respected
 - Error coming from the mapping function
 - Error coming from a Flowable coming from the mapping function
 - Pumping the flowable from multiple threads