### PR TITLE
Make it possible to set EventBase of RSocketRequester from outside

### DIFF
--- a/rsocket/RSocketRequester.cpp
+++ b/rsocket/RSocketRequester.cpp
@@ -17,14 +17,18 @@ namespace rsocket {
 RSocketRequester::RSocketRequester(
     std::shared_ptr<RSocketStateMachine> srs,
     EventBase& eventBase)
-    : stateMachine_(std::move(srs)), eventBase_(eventBase) {}
+    : stateMachine_(std::move(srs)), eventBase_(&eventBase) {}
 
 RSocketRequester::~RSocketRequester() {
   VLOG(1) << "Destroying RSocketRequester";
 }
 
+void RSocketRequester::setEventBase(folly::EventBase* evb) {
+  eventBase_ = evb;
+}
+
 void RSocketRequester::closeSocket() {
-  eventBase_.add([stateMachine = std::move(stateMachine_)] {
+  eventBase_->add([stateMachine = std::move(stateMachine_)] {
     VLOG(2) << "Closing RSocketStateMachine on EventBase";
     stateMachine->close(
         folly::exception_wrapper(), StreamCompletionSignal::SOCKET_CLOSED);
@@ -38,7 +42,7 @@ RSocketRequester::requestChannel(
   CHECK(stateMachine_); // verify the socket was not closed
 
   return yarpl::flowable::Flowables::fromPublisher<Payload>([
-    eb = &eventBase_,
+    eb = eventBase_,
     requestStream = std::move(requestStream),
     srs = stateMachine_
   ](yarpl::Reference<yarpl::flowable::Subscriber<Payload>> subscriber) mutable {
@@ -75,7 +79,7 @@ RSocketRequester::requestStream(Payload request) {
   CHECK(stateMachine_); // verify the socket was not closed
 
   return yarpl::flowable::Flowables::fromPublisher<Payload>([
-    eb = &eventBase_,
+    eb = eventBase_,
     request = std::move(request),
     srs = stateMachine_
   ](yarpl::Reference<yarpl::flowable::Subscriber<Payload>> subscriber) mutable {
@@ -103,7 +107,7 @@ RSocketRequester::requestResponse(Payload request) {
   CHECK(stateMachine_); // verify the socket was not closed
 
   return yarpl::single::Single<Payload>::create([
-    eb = &eventBase_,
+    eb = eventBase_,
     request = std::move(request),
     srs = stateMachine_
   ](yarpl::Reference<yarpl::single::SingleObserver<Payload>> observer) mutable {
@@ -131,7 +135,7 @@ yarpl::Reference<yarpl::single::Single<void>> RSocketRequester::fireAndForget(
   CHECK(stateMachine_); // verify the socket was not closed
 
   return yarpl::single::Single<void>::create([
-    eb = &eventBase_,
+    eb = eventBase_,
     request = std::move(request),
     srs = stateMachine_
   ](yarpl::Reference<yarpl::single::SingleObserverBase<void>> subscriber) mutable {
@@ -158,7 +162,7 @@ yarpl::Reference<yarpl::single::Single<void>> RSocketRequester::fireAndForget(
 void RSocketRequester::metadataPush(std::unique_ptr<folly::IOBuf> metadata) {
   CHECK(stateMachine_); // verify the socket was not closed
 
-  eventBase_.runInEventBaseThread(
+  eventBase_->runInEventBaseThread(
       [ srs = stateMachine_, metadata = std::move(metadata) ]() mutable {
         srs->metadataPush(std::move(metadata));
       });

--- a/rsocket/RSocketRequester.h
+++ b/rsocket/RSocketRequester.h
@@ -100,8 +100,10 @@ class RSocketRequester {
 
   virtual void closeSocket();
 
+  void setEventBase(folly::EventBase* evb);
+
  private:
   std::shared_ptr<rsocket::RSocketStateMachine> stateMachine_;
-  folly::EventBase& eventBase_;
+  folly::EventBase* eventBase_;
 };
 }

--- a/rsocket/RSocketRequester.h
+++ b/rsocket/RSocketRequester.h
@@ -100,10 +100,12 @@ class RSocketRequester {
 
   virtual void closeSocket();
 
-  void setEventBase(folly::EventBase* evb);
+  bool canReplaceEventBase();
+  bool setEventBase(folly::EventBase* evb);
 
  private:
   std::shared_ptr<rsocket::RSocketStateMachine> stateMachine_;
   folly::EventBase* eventBase_;
+  bool eventBaseIsReplaceable_{true};
 };
 }


### PR DESCRIPTION
Add a method to RSocketRequester that makes it possible to change the EventBase* data member in the RSocketRequester to be overriden.

With this simple change, we make it possible to perform EventBase switching on the client side for Thrift.