### PR TITLE
Make the data members of RSocketRequester protected

### DIFF
--- a/rsocket/RSocketRequester.h
+++ b/rsocket/RSocketRequester.h
@@ -100,7 +100,7 @@ class RSocketRequester {
 
   virtual void closeSocket();
 
- private:
+ protected:
   std::shared_ptr<rsocket::RSocketStateMachine> stateMachine_;
   folly::EventBase& eventBase_;
 };


### PR DESCRIPTION
Make the data members of RSocketRequester protected so it will be possible to apply Decorator DP on it.