### PR TITLE
Make RSocketRequester's getConnection method also virtual

### DIFF
--- a/rsocket/RSocketRequester.h
+++ b/rsocket/RSocketRequester.h
@@ -96,7 +96,7 @@ class RSocketRequester {
   /**
    * To be used only temporarily to check the transport's status.
    */
-  DuplexConnection* getConnection();
+  virtual DuplexConnection* getConnection();
 
   virtual void closeSocket();
 


### PR DESCRIPTION
With this change, all of the functions of the RSocketRequester will be virtual.
So it will be possible to override all of these functions and apply Decorator pattern on top of it.
