### PR TITLE
Implement merge operator, bugfixes for flatMap

### DIFF
--- a/yarpl/include/yarpl/flowable/Flowable.h
+++ b/yarpl/include/yarpl/flowable/Flowable.h
@@ -26,10 +26,10 @@ class Flowable;
 namespace detail {
 
 template <typename T>
-struct is_t_flowable : std::false_type {};
+struct IsFlowable : std::false_type {};
 
 template <typename R>
-struct is_t_flowable<Reference<Flowable<R>>> : std::true_type {
+struct IsFlowable<Reference<Flowable<R>>> : std::true_type {
   using ElemType = R;
 };
 
@@ -96,7 +96,7 @@ class Flowable : public virtual Refcounted, public yarpl::enable_get_ref {
 
   template <
       typename Function,
-      typename R = typename detail::is_t_flowable<
+      typename R = typename detail::IsFlowable<
           typename std::result_of<Function(T)>::type>::ElemType>
   Reference<Flowable<R>> flatMap(Function func);
 
@@ -120,7 +120,7 @@ class Flowable : public virtual Refcounted, public yarpl::enable_get_ref {
 
   template <typename Q>
   using enableWrapRef =
-      typename std::enable_if<detail::is_t_flowable<Q>::value, Q>::type;
+      typename std::enable_if<detail::IsFlowable<Q>::value, Q>::type;
 
   template <typename Q = T>
   enableWrapRef<Q> merge() {

--- a/yarpl/include/yarpl/flowable/Flowable.h
+++ b/yarpl/include/yarpl/flowable/Flowable.h
@@ -21,6 +21,21 @@ namespace yarpl {
 namespace flowable {
 
 template <typename T>
+class Flowable;
+
+namespace detail {
+
+template <typename T>
+struct is_t_flowable : std::false_type {};
+
+template <typename R>
+struct is_t_flowable<Reference<Flowable<R>>> : std::true_type {
+  using ElemType = R;
+};
+
+} // namespace detail
+
+template <typename T>
 class Flowable : public virtual Refcounted, public yarpl::enable_get_ref {
  public:
   virtual void subscribe(Reference<Subscriber<T>>) = 0;
@@ -79,8 +94,11 @@ class Flowable : public virtual Refcounted, public yarpl::enable_get_ref {
       typename R = typename std::result_of<Function(T)>::type>
   Reference<Flowable<R>> map(Function function);
 
-  template <typename R>
-  Reference<Flowable<R>> flatMap(folly::Function<Reference<Flowable<R>>(T)>);
+  template <
+      typename Function,
+      typename R = typename detail::is_t_flowable<
+          typename std::result_of<Function(T)>::type>::ElemType>
+  Reference<Flowable<R>> flatMap(Function func);
 
   template <typename Function>
   Reference<Flowable<T>> filter(Function function);
@@ -99,6 +117,15 @@ class Flowable : public virtual Refcounted, public yarpl::enable_get_ref {
   Reference<Flowable<T>> subscribeOn(folly::Executor&);
 
   Reference<Flowable<T>> observeOn(folly::Executor&);
+
+  template <typename Q>
+  using enableWrapRef =
+      typename std::enable_if<detail::is_t_flowable<Q>::value, Q>::type;
+
+  template <typename Q = T>
+  enableWrapRef<Q> merge() {
+    return this->flatMap([](auto f) { return std::move(f); });
+  }
 
   template <
       typename Emitter,
@@ -172,11 +199,10 @@ Reference<Flowable<T>> Flowable<T>::observeOn(folly::Executor& executor) {
 }
 
 template <typename T>
-template <typename R>
-Reference<Flowable<R>> Flowable<T>::flatMap(
-    folly::Function<Reference<Flowable<R>>(T)> func) {
+template <typename Function, typename R>
+Reference<Flowable<R>> Flowable<T>::flatMap(Function function) {
   return make_ref<FlatMapOperator<T, R>>(
-      this->ref_from_this(this), std::move(func));
+      this->ref_from_this(this), std::move(function));
 }
 
 } // flowable

--- a/yarpl/include/yarpl/flowable/Subscriber.h
+++ b/yarpl/include/yarpl/flowable/Subscriber.h
@@ -45,7 +45,7 @@ class BaseSubscriber : public Subscriber<T> {
     DCHECK(subscription);
     CHECK(!subscription_.load());
 
-#ifdef NDEBUG
+#ifdef DEBUG
     DCHECK(!gotOnSubscribe_.exchange(true))
         << "Already subscribed to BaseSubscriber";
 #endif
@@ -57,7 +57,7 @@ class BaseSubscriber : public Subscriber<T> {
 
   // No further calls to the subscription after this method is invoked.
   void onComplete() final override {
-#ifdef NDEBUG
+#ifdef DEBUG
     DCHECK(gotOnSubscribe_.load()) << "Not subscribed to BaseSubscriber";
     DCHECK(!gotTerminating_.exchange(true))
         << "Already got terminating signal method";
@@ -72,7 +72,7 @@ class BaseSubscriber : public Subscriber<T> {
 
   // No further calls to the subscription after this method is invoked.
   void onError(folly::exception_wrapper e) final override {
-#ifdef NDEBUG
+#ifdef DEBUG
     DCHECK(gotOnSubscribe_.load()) << "Not subscribed to BaseSubscriber";
     DCHECK(!gotTerminating_.exchange(true))
         << "Already got terminating signal method";
@@ -86,7 +86,7 @@ class BaseSubscriber : public Subscriber<T> {
   }
 
   void onNext(T t) final override {
-#ifdef NDEBUG
+#ifdef DEBUG
     DCHECK(gotOnSubscribe_.load()) << "Not subscibed to BaseSubscriber";
     if (gotTerminating_.load()) {
       VLOG(2) << "BaseSubscriber already got terminating signal method";
@@ -105,7 +105,7 @@ class BaseSubscriber : public Subscriber<T> {
       sub->cancel();
       onTerminateImpl();
     }
-#ifdef NDEBUG
+#ifdef DEBUG
     else {
       VLOG(2) << "cancel() on BaseSubscriber with no subscription_";
     }
@@ -117,7 +117,7 @@ class BaseSubscriber : public Subscriber<T> {
       KEEP_REF_TO_THIS();
       sub->request(n);
     }
-#ifdef NDEBUG
+#ifdef DEBUG
     else {
       VLOG(2) << "request() on BaseSubscriber with no subscription_";
     }
@@ -136,7 +136,7 @@ protected:
   // keeps a reference alive to the subscription
   AtomicReference<Subscription> subscription_;
 
-#ifdef NDEBUG
+#ifdef DEBUG
   std::atomic<bool> gotOnSubscribe_{false};
   std::atomic<bool> gotTerminating_{false};
 #endif


### PR DESCRIPTION
Implements the merge operator for Flowable, which converts a Flowable<Flowable<T>> into a Flowable<T>. It's implemented as a specialization of `flatMap`. 

Also included are bugfixes for flatMap, in which flatMap would terminate its subscriber too early, once all of this sub-streams had completed (but possibly still had outstanding elements to be consumed). 