### PR TITLE
ConsumerBase sends excessive numbers of requestN messages

### DIFF
--- a/rsocket/statemachine/ConsumerBase.h
+++ b/rsocket/statemachine/ConsumerBase.h
@@ -27,9 +27,7 @@ class ConsumerBase : public StreamStateMachineBase,
   ///
   /// This portion of allowance will not be synced to the remote end, but will
   /// count towards the limit of allowance the remote PublisherBase may use.
-  void addImplicitAllowance(size_t n) {
-    allowance_.add(n);
-  }
+  void addImplicitAllowance(size_t n);
 
   void subscribe(
       yarpl::Reference<yarpl::flowable::Subscriber<Payload>> subscriber);
@@ -67,6 +65,10 @@ class ConsumerBase : public StreamStateMachineBase,
   /// An allowance that have yet to be synced to the other end by sending
   /// REQUEST_N frames.
   Allowance pendingAllowance_;
+
+  /// The number of already requested payload count.
+  /// Prevent excessive requestN calls.
+  Allowance activeRequests_;
 
   enum class State : uint8_t {
     RESPONDING,

--- a/test/RSocketTests.h
+++ b/test/RSocketTests.h
@@ -13,12 +13,32 @@ namespace rsocket {
 namespace tests {
 namespace client_server {
 
+class RSocketStatsFlowControl : public RSocketStats {
+public:
+  void frameWritten(FrameType frameType) {
+    if (frameType == FrameType::REQUEST_N) {
+      ++writeRequestN_;
+    }
+  }
+
+  void frameRead(FrameType frameType) {
+    if (frameType == FrameType::REQUEST_N) {
+      ++readRequestN_;
+    }
+  }
+
+public:
+  int writeRequestN_{0};
+  int readRequestN_{0};
+};
+
 std::unique_ptr<TcpConnectionFactory> getConnFactory(
     folly::EventBase* eventBase,
     uint16_t port);
 
 std::unique_ptr<RSocketServer> makeServer(
-    std::shared_ptr<rsocket::RSocketResponder> responder);
+    std::shared_ptr<rsocket::RSocketResponder> responder,
+    std::shared_ptr<RSocketStats> stats = RSocketStats::noop());
 
 std::unique_ptr<RSocketServer> makeResumableServer(
     std::shared_ptr<RSocketServiceHandler> serviceHandler);
@@ -26,7 +46,8 @@ std::unique_ptr<RSocketServer> makeResumableServer(
 std::unique_ptr<RSocketClient> makeClient(
     folly::EventBase* eventBase,
     uint16_t port,
-    folly::EventBase* stateMachineEvb = nullptr);
+    folly::EventBase* stateMachineEvb = nullptr,
+    std::shared_ptr<RSocketStats> stats = RSocketStats::noop());
 
 std::unique_ptr<RSocketClient> makeDisconnectedClient(
     folly::EventBase* eventBase);
@@ -34,7 +55,8 @@ std::unique_ptr<RSocketClient> makeDisconnectedClient(
 folly::Future<std::unique_ptr<RSocketClient>> makeClientAsync(
     folly::EventBase* eventBase,
     uint16_t port,
-    folly::EventBase* stateMachineEvb = nullptr);
+    folly::EventBase* stateMachineEvb = nullptr,
+    std::shared_ptr<RSocketStats> stats = RSocketStats::noop());
 
 std::unique_ptr<RSocketClient> makeWarmResumableClient(
     folly::EventBase* eventBase,


### PR DESCRIPTION
Prevent sending requestN(MAX_INT) message again and again.
Request more only if more than half of the requested amount is consumed.