### PR TITLE
Turn RSocketStateMachine::disconnect() into close() for non-resumable…

### DIFF
--- a/rsocket/internal/KeepaliveTimer.cpp
+++ b/rsocket/internal/KeepaliveTimer.cpp
@@ -38,8 +38,8 @@ void KeepaliveTimer::sendKeepalive() {
     auto localPtr = connection_;
     stop();
     // TODO: we need to use max lifetime from the setup frame for this
-    localPtr->disconnectOrCloseWithError(
-        Frame_ERROR::connectionError("no response to keepalive"));
+    auto error = Frame_ERROR::connectionError("No response to KEEPALIVE");
+    localPtr->disconnectWithError(std::move(error));
   } else {
     connection_->sendKeepalive();
     pending_ = true;
@@ -66,4 +66,4 @@ void KeepaliveTimer::start(const std::shared_ptr<FrameSink>& connection) {
 void KeepaliveTimer::keepaliveReceived() {
   pending_ = false;
 }
-}
+} // namespace rsocket

--- a/rsocket/internal/KeepaliveTimer.h
+++ b/rsocket/internal/KeepaliveTimer.h
@@ -4,9 +4,24 @@
 
 #include <folly/io/async/EventBase.h>
 
-#include "rsocket/statemachine/RSocketStateMachine.h"
+#include "rsocket/framing/Frame.h"
 
 namespace rsocket {
+
+class FrameSink {
+ public:
+  virtual ~FrameSink() = default;
+
+  /// Terminates underlying connection sending the error frame
+  /// on the connection.
+  ///
+  /// This may synchronously deliver terminal signals to all StreamAutomatonBase
+  /// attached to this RSocketStateMachine.
+  virtual void disconnectWithError(Frame_ERROR&&) = 0;
+
+  virtual void sendKeepalive(
+      std::unique_ptr<folly::IOBuf> data = folly::IOBuf::create(0)) = 0;
+};
 
 class KeepaliveTimer {
  public:

--- a/test/internal/KeepaliveTimerTest.cpp
+++ b/test/internal/KeepaliveTimerTest.cpp
@@ -24,10 +24,10 @@ class MockConnectionAutomaton : public FrameSink {
   }
   MOCK_METHOD1(sendKeepalive_, void(std::unique_ptr<folly::IOBuf>&));
 
-  MOCK_METHOD1(disconnectOrCloseWithError_, void(Frame_ERROR&));
+  MOCK_METHOD1(disconnectWithError_, void(Frame_ERROR&));
 
-  void disconnectOrCloseWithError(Frame_ERROR&& error) override {
-    disconnectOrCloseWithError_(error);
+  void disconnectWithError(Frame_ERROR&& error) override {
+    disconnectWithError_(error);
   }
 };
 }
@@ -58,7 +58,7 @@ TEST(FollyKeepaliveTimerTest, NoResponse) {
       std::make_shared<StrictMock<MockConnectionAutomaton>>();
 
   EXPECT_CALL(*connectionAutomaton, sendKeepalive_(_)).Times(1);
-  EXPECT_CALL(*connectionAutomaton, disconnectOrCloseWithError_(_)).Times(1);
+  EXPECT_CALL(*connectionAutomaton, disconnectWithError_(_)).Times(1);
 
   folly::EventBase eventBase;
 


### PR DESCRIPTION
… connections

Making things simpler to follow along.  We have close() and closeWithError() for
closing connections, and now we'll have disconnect() and disconnectWithError()
for disconnecting them.  If a connection can't be reconnected, then disconnect()
should behave like close().

Renames disconnectOrCloseWithError() to disconnectWithError().

Move FrameSink into KeepaliveTimer.h.  It makes sense to have it there and not
with RSocketStateMachine right now.

Inline uses of RSocketStateMachine private methods setResumable(), isClosed(),
and getKeepaliveTime().