### PR TITLE
Don't use an output subscriber for DuplexConnection

### DIFF
--- a/rsocket/DuplexConnection.h
+++ b/rsocket/DuplexConnection.h
@@ -65,11 +65,10 @@ class DuplexConnection {
   /// complete the previous subscriber.
   virtual void setInput(yarpl::Reference<Subscriber>) = 0;
 
-  /// Obtains a Subscriber that should be fed with frames to send (a writer).
+  /// Write a serialized frame to the connection.
   ///
-  /// If getOutput() has already been called, it is only safe to call again if
-  /// all previous output subscribers have been terminated.
-  virtual yarpl::Reference<Subscriber> getOutput() = 0;
+  /// Does nothing if the underlying connection is closed.
+  virtual void send(std::unique_ptr<folly::IOBuf>) = 0;
 
   /// Whether the duplex connection respects frame boundaries.
   virtual bool isFramed() const {

--- a/rsocket/framing/FrameTransport.h
+++ b/rsocket/framing/FrameTransport.h
@@ -12,7 +12,6 @@ class FrameTransport : public virtual yarpl::Refcounted {
   virtual void setFrameProcessor(std::shared_ptr<FrameProcessor>) = 0;
   virtual void outputFrameOrDrop(std::unique_ptr<folly::IOBuf>) = 0;
   virtual void close() = 0;
-  virtual void closeWithError(folly::exception_wrapper) = 0;
   // Just for observation purposes!
   virtual DuplexConnection* getConnection() = 0;
 };

--- a/rsocket/framing/FrameTransportImpl.h
+++ b/rsocket/framing/FrameTransportImpl.h
@@ -15,9 +15,7 @@ class FrameProcessor;
 
 class FrameTransportImpl : public FrameTransport,
                            /// Registered as an input in the DuplexConnection.
-                           public DuplexConnection::Subscriber,
-                           /// Receives signals about connection writability.
-                           public yarpl::flowable::Subscription {
+                           public DuplexConnection::Subscriber {
  public:
   explicit FrameTransportImpl(std::unique_ptr<DuplexConnection> connection);
   ~FrameTransportImpl();
@@ -28,13 +26,8 @@ class FrameTransportImpl : public FrameTransport,
   /// drop the frame.
   void outputFrameOrDrop(std::unique_ptr<folly::IOBuf>) override;
 
-  /// Cancel the input, complete the output, and close the underlying
-  /// connection.
+  /// Cancel the input and close the underlying connection.
   void close() override;
-
-  /// Cancel the input, error the output, and close the underlying connection.
-  /// This must be closed with a non-empty exception_wrapper.
-  void closeWithError(folly::exception_wrapper) override;
 
   bool isClosed() const {
     return !connection_;
@@ -54,16 +47,9 @@ class FrameTransportImpl : public FrameTransport,
   void onComplete() override;
   void onError(folly::exception_wrapper) override;
 
-  // Subscription.
-
-  void request(int64_t) override;
-  void cancel() override;
-
   /// Terminates the FrameProcessor.  Will queue up the exception if no
   /// processor is set, overwriting any previously queued exception.
   void terminateProcessor(folly::exception_wrapper);
-
-  void closeImpl(folly::exception_wrapper);
 
   std::shared_ptr<FrameProcessor> frameProcessor_;
   std::shared_ptr<DuplexConnection> connection_;
@@ -71,4 +57,4 @@ class FrameTransportImpl : public FrameTransport,
   yarpl::Reference<DuplexConnection::Subscriber> connectionOutput_;
   yarpl::Reference<yarpl::flowable::Subscription> connectionInputSub_;
 };
-}
+} // namespace rsocket

--- a/rsocket/framing/FramedDuplexConnection.cpp
+++ b/rsocket/framing/FramedDuplexConnection.cpp
@@ -1,13 +1,92 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "rsocket/framing/FramedDuplexConnection.h"
+
+#include <folly/io/Cursor.h>
+
 #include "rsocket/framing/FrameSerializer.h"
+#include "rsocket/framing/FrameSerializer_v1_0.h"
 #include "rsocket/framing/FramedReader.h"
-#include "rsocket/framing/FramedWriter.h"
 
 namespace rsocket {
 
 using namespace yarpl::flowable;
+
+namespace {
+
+constexpr auto kMaxFrameLength = 0xFFFFFF; // 24bit max value
+
+template <typename TWriter>
+void writeFrameLength(
+    TWriter& cur,
+    size_t frameLength,
+    size_t frameSizeFieldLength) {
+  DCHECK(frameSizeFieldLength > 0);
+
+  // starting from the highest byte
+  // frameSizeFieldLength == 3 => shift = [16,8,0]
+  // frameSizeFieldLength == 4 => shift = [24,16,8,0]
+  auto shift = (frameSizeFieldLength - 1) * 8;
+
+  while (frameSizeFieldLength--) {
+    auto byte = (frameLength >> shift) & 0xFF;
+    cur.write(static_cast<uint8_t>(byte));
+    shift -= 8;
+  }
+}
+
+size_t getFrameSizeFieldLength(ProtocolVersion version) {
+  CHECK(version != ProtocolVersion::Unknown);
+  if (version < FrameSerializerV1_0::Version) {
+    return sizeof(int32_t);
+  } else {
+    return 3; // bytes
+  }
+}
+
+size_t getPayloadLength(ProtocolVersion version, size_t payloadLength) {
+  DCHECK(version != ProtocolVersion::Unknown);
+  if (version < FrameSerializerV1_0::Version) {
+    return payloadLength + getFrameSizeFieldLength(version);
+  } else {
+    return payloadLength;
+  }
+}
+
+std::unique_ptr<folly::IOBuf> prependSize(
+    ProtocolVersion version,
+    std::unique_ptr<folly::IOBuf> payload) {
+  CHECK(payload);
+
+  const auto frameSizeFieldLength = getFrameSizeFieldLength(version);
+  // the frame size includes the payload size and the size value
+  auto payloadLength =
+      getPayloadLength(version, payload->computeChainDataLength());
+  if (payloadLength > kMaxFrameLength) {
+    return nullptr;
+  }
+
+  if (payload->headroom() >= frameSizeFieldLength) {
+    // move the data pointer back and write value to the payload
+    payload->prepend(frameSizeFieldLength);
+    folly::io::RWPrivateCursor cur(payload.get());
+    writeFrameLength(cur, payloadLength, frameSizeFieldLength);
+    VLOG(4) << "writing frame length=" << payload->length() << std::endl
+            << hexDump(payload->clone()->moveToFbString());
+    return payload;
+  } else {
+    auto newPayload = folly::IOBuf::createCombined(frameSizeFieldLength);
+    folly::io::Appender appender(newPayload.get(), /* do not grow */ 0);
+    writeFrameLength(appender, payloadLength, frameSizeFieldLength);
+    newPayload->appendChain(std::move(payload));
+    VLOG(4) << "writing frame length=" << newPayload->computeChainDataLength()
+            << std::endl
+            << hexDump(newPayload->clone()->moveToFbString());
+    return newPayload;
+  }
+}
+
+} // namespace
 
 FramedDuplexConnection::~FramedDuplexConnection() {}
 
@@ -17,9 +96,20 @@ FramedDuplexConnection::FramedDuplexConnection(
     : inner_(std::move(connection)),
       protocolVersion_(std::make_shared<ProtocolVersion>(protocolVersion)) {}
 
-yarpl::Reference<DuplexConnection::Subscriber>
-FramedDuplexConnection::getOutput() {
-  return yarpl::make_ref<FramedWriter>(inner_->getOutput(), protocolVersion_);
+void FramedDuplexConnection::send(std::unique_ptr<folly::IOBuf> buf) {
+  if (!inner_) {
+    return;
+  }
+
+  auto sized = prependSize(*protocolVersion_, std::move(buf));
+  if (!sized) {
+    protocolVersion_.reset();
+    inputReader_.reset();
+    inner_.reset();
+    return;
+  }
+
+  inner_->send(std::move(sized));
 }
 
 void FramedDuplexConnection::setInput(
@@ -30,4 +120,4 @@ void FramedDuplexConnection::setInput(
   }
   inputReader_->setInput(std::move(framesSink));
 }
-}
+} // namespace rsocket

--- a/rsocket/framing/FramedDuplexConnection.h
+++ b/rsocket/framing/FramedDuplexConnection.h
@@ -19,7 +19,7 @@ class FramedDuplexConnection : public virtual DuplexConnection {
 
   ~FramedDuplexConnection();
 
-  yarpl::Reference<DuplexConnection::Subscriber> getOutput() override;
+  void send(std::unique_ptr<folly::IOBuf>) override;
 
   void setInput(yarpl::Reference<DuplexConnection::Subscriber>) override;
 

--- a/rsocket/framing/ScheduledFrameTransport.cpp
+++ b/rsocket/framing/ScheduledFrameTransport.cpp
@@ -30,11 +30,4 @@ void ScheduledFrameTransport::close() {
   });
 }
 
-void ScheduledFrameTransport::closeWithError(folly::exception_wrapper ex) {
-  transportEvb_->runInEventBaseThread(
-      [ ft = frameTransport_, ex = std::move(ex) ]() mutable {
-        ft->closeWithError(std::move(ex));
-      });
-}
-
 } // rsocket

--- a/rsocket/framing/ScheduledFrameTransport.h
+++ b/rsocket/framing/ScheduledFrameTransport.h
@@ -31,7 +31,6 @@ class ScheduledFrameTransport : public FrameTransport,
   void setFrameProcessor(std::shared_ptr<FrameProcessor> fp) override;
   void outputFrameOrDrop(std::unique_ptr<folly::IOBuf> ioBuf) override;
   void close() override;
-  void closeWithError(folly::exception_wrapper ex) override;
 
  private:
   DuplexConnection* getConnection() override {

--- a/rsocket/statemachine/RSocketStateMachine.h
+++ b/rsocket/statemachine/RSocketStateMachine.h
@@ -233,7 +233,7 @@ class RSocketStateMachine final
   void handleUnknownStream(StreamId, FrameType, std::unique_ptr<folly::IOBuf>);
 
   void closeStreams(StreamCompletionSignal);
-  void closeFrameTransport(folly::exception_wrapper, StreamCompletionSignal);
+  void closeFrameTransport(folly::exception_wrapper);
 
   void sendKeepalive(FrameFlags, std::unique_ptr<folly::IOBuf>);
 

--- a/rsocket/transports/tcp/TcpDuplexConnection.h
+++ b/rsocket/transports/tcp/TcpDuplexConnection.h
@@ -21,7 +21,7 @@ class TcpDuplexConnection : public DuplexConnection {
       std::shared_ptr<RSocketStats> stats = RSocketStats::noop());
   ~TcpDuplexConnection();
 
-  yarpl::Reference<DuplexConnection::Subscriber> getOutput() override;
+  void send(std::unique_ptr<folly::IOBuf>) override;
 
   void setInput(yarpl::Reference<DuplexConnection::Subscriber>) override;
 

--- a/test/RSocketClientServerTest.cpp
+++ b/test/RSocketClientServerTest.cpp
@@ -103,10 +103,7 @@ TEST(RSocketClientServer, ServerGetsGarbage) {
   auto evb = &result.eventBase;
 
   evb->runInEventBaseThreadAndWait([conn = std::move(connection)]() mutable {
-    auto output = conn->getOutput();
-    output->onSubscribe(yarpl::flowable::Subscription::empty());
-    output->onNext(folly::IOBuf::copyBuffer("ABCDEFGHIJKLMNOP"));
-    output->onComplete();
+    conn->send(folly::IOBuf::copyBuffer("ABCDEFGHIJKLMNOP"));
     conn.reset();
   });
 }

--- a/test/WarmResumeManagerTest.cpp
+++ b/test/WarmResumeManagerTest.cpp
@@ -8,19 +8,13 @@
 #include "rsocket/framing/FrameSerializer.h"
 #include "rsocket/framing/FrameTransportImpl.h"
 #include "rsocket/internal/WarmResumeManager.h"
+#include "test/test_utils/MockDuplexConnection.h"
 #include "test/test_utils/MockStats.h"
 
 using namespace ::testing;
 using namespace ::rsocket;
 
 namespace {
-
-class MockDuplexConnection : public DuplexConnection {
-  void setInput(yarpl::Reference<Subscriber>) override {}
-  yarpl::Reference<Subscriber> getOutput() override {
-    return nullptr;
-  }
-};
 
 class FrameTransportMock : public FrameTransportImpl {
  public:
@@ -33,6 +27,7 @@ class FrameTransportMock : public FrameTransportImpl {
     outputFrameOrDrop_(frame);
   }
 };
+
 } // namespace
 
 class WarmResumeManagerTest : public Test {


### PR DESCRIPTION
DuplexConnection uses a subscriber to send frames along the underlying
connection.  However, it makes no use of this subscriber other than onNext().
No implementation makes use of flow control, frames are always sent and always
received which makes onSubscribe() do nothing.  The received frame flow control
is handled by the stream state machines.  On top of that, terminating the output
subscriber does nothing, the underlying connection is kept active so a follow up
subscriber can attach and send frames.  Which implies that onComplete() and
onError() are also unnecessary.

Replace it with a `send(std::unique_ptr<folly::IOBuf>)` method.  This makes
things significantly simpler and keeps the same behavior that we have today.