### PR TITLE
fix AtomicReference correctness

### DIFF
--- a/yarpl/include/yarpl/flowable/FlowableOperator.h
+++ b/yarpl/include/yarpl/flowable/FlowableOperator.h
@@ -48,7 +48,7 @@ class FlowableOperator : public Flowable<D> {
         : flowableOperator_(std::move(flowable)),
           subscriber_(std::move(subscriber)) {
       assert(flowableOperator_);
-      assert(subscriber_);
+      assert(subscriber_.load());
     }
 
     const Reference<Operator>& getFlowableOperator() {
@@ -93,7 +93,7 @@ class FlowableOperator : public Flowable<D> {
     // Subscriber.
 
     void onSubscribeImpl() override {
-      subscriber_->onSubscribe(this->ref_from_this(this));
+      subscriber_.load()->onSubscribe(this->ref_from_this(this));
     }
 
     void onCompleteImpl() override {

--- a/yarpl/include/yarpl/flowable/Subscriber.h
+++ b/yarpl/include/yarpl/flowable/Subscriber.h
@@ -43,14 +43,14 @@ class BaseSubscriber : public Subscriber<T> {
   // methods SHOULD ensure that these are invoked as well.
   void onSubscribe(Reference<Subscription> subscription) final override {
     DCHECK(subscription);
-    CHECK(!subscription_);
+    CHECK(!subscription_.load());
 
 #ifdef DEBUG
     DCHECK(!gotOnSubscribe_.exchange(true))
         << "Already subscribed to BaseSubscriber";
 #endif
 
-    subscription_ = std::move(subscription);
+    subscription_.exchange(subscription);
     KEEP_REF_TO_THIS();
     onSubscribeImpl();
   }

--- a/yarpl/test/ReferenceTest.cpp
+++ b/yarpl/test/ReferenceTest.cpp
@@ -86,14 +86,14 @@ TEST(ReferenceTest, Atomic) {
   auto a = yarpl::make_ref<MyRefcounted>(1);
   AtomicReference<MyRefcounted> b = a;
   EXPECT_EQ(2u, a->count());
-  EXPECT_EQ(2u, b->count()); // b and a point to same object
+  EXPECT_EQ(3u, b.load()->count()); // b and a point to same object
   EXPECT_EQ(1, a->i);
-  EXPECT_EQ(1, b->i);
+  EXPECT_EQ(1, b.load()->i);
 
   auto c = yarpl::make_ref<MyRefcounted>(2);
   {
     auto a_copy = b.exchange(c);
-    EXPECT_EQ(2, b->i);
+    EXPECT_EQ(2, b.load()->i);
     EXPECT_EQ(2u, a->count());
     EXPECT_EQ(2u, a_copy->count());
     EXPECT_EQ(1, a_copy->i);
@@ -101,15 +101,15 @@ TEST(ReferenceTest, Atomic) {
   EXPECT_EQ(1u, a->count()); // a_copy destroyed
 
   EXPECT_EQ(2u, c->count());
-  EXPECT_EQ(2u, b->count()); // b and c point to same object
+  EXPECT_EQ(3u, b.load()->count()); // b and c point to same object
 }
 
 TEST(ReferenceTest, Construction) {
   AtomicReference<MyRefcounted> a{yarpl::make_ref<MyRefcounted>(1)};
-  EXPECT_EQ(1u, a->count());
-  EXPECT_EQ(1, a->i);
+  EXPECT_EQ(2u, a.load()->count());
+  EXPECT_EQ(1, a.load()->i);
 
   AtomicReference<MyRefcounted> b = yarpl::make_ref<MyRefcounted>(2);
-  EXPECT_EQ(1u, b->count());
-  EXPECT_EQ(2, b->i);
+  EXPECT_EQ(2u, b.load()->count());
+  EXPECT_EQ(2, b.load()->i);
 }


### PR DESCRIPTION
Update AtomicReference to be threadsafe. Uses an approach similar to how std::shared_ptr behaves. 