### PR TITLE
Implement fragmentation for requests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,7 @@ add_library(
   rsocket/statemachine/StreamStateMachineBase.h
   rsocket/statemachine/StreamsFactory.cpp
   rsocket/statemachine/StreamsFactory.h
+  rsocket/statemachine/StreamFragmentAccumulator.h
   rsocket/statemachine/StreamsWriter.h
   rsocket/transports/tcp/TcpConnectionAcceptor.cpp
   rsocket/transports/tcp/TcpConnectionAcceptor.h

--- a/rsocket/framing/FrameSerializer_v1_0.cpp
+++ b/rsocket/framing/FrameSerializer_v1_0.cpp
@@ -57,13 +57,12 @@ static void serializeMetadataInto(
     return;
   }
 
-  // Use signed int because the first bit in metadata length is reserved.
-  if (metadata->length() > kMaxMetadataLength) {
-    CHECK(false) << "Metadata is too big to serialize";
-  }
-
   // metadata length field not included in the medatadata length
-  uint32_t metadataLength = static_cast<uint32_t>(metadata->length());
+  uint32_t metadataLength =
+      static_cast<uint32_t>(metadata->computeChainDataLength());
+  CHECK_LT(metadataLength, kMaxMetadataLength)
+      << "Metadata is too big to serialize";
+
   appender.write(static_cast<uint8_t>(metadataLength >> 16)); // first byte
   appender.write(
       static_cast<uint8_t>((metadataLength >> 8) & 0xFF)); // second byte

--- a/rsocket/internal/Common.cpp
+++ b/rsocket/internal/Common.cpp
@@ -5,6 +5,7 @@
 #include <folly/Random.h>
 #include <folly/String.h>
 #include <folly/io/IOBuf.h>
+#include <algorithm>
 #include <random>
 
 namespace rsocket {
@@ -42,6 +43,26 @@ static const char* getTerminatingSignalErrorMessage(int terminatingSignal) {
     default:
       return "stream interrupted";
   }
+}
+
+folly::StringPiece toString(StreamType t) {
+  switch (t) {
+    case StreamType::REQUEST_RESPONSE:
+      return "REQUEST_RESPONSE";
+    case StreamType::STREAM:
+      return "STREAM";
+    case StreamType::CHANNEL:
+      return "CHANNEL";
+    case StreamType::FNF:
+      return "FNF";
+    default:
+      DCHECK(false);
+      return "(invalid StreamType)";
+  }
+}
+
+std::ostream& operator<<(std::ostream& os, StreamType t) {
+  return os << toString(t);
 }
 
 std::ostream& operator<<(std::ostream& os, RSocketMode mode) {
@@ -149,6 +170,6 @@ std::ostream& operator<<(
 }
 
 std::string hexDump(folly::StringPiece s) {
-  return folly::hexDump(s.data(), s.size());
+  return folly::hexDump(s.data(), std::min(0xFFUL, s.size()));
 }
 } // reactivesocket

--- a/rsocket/internal/Common.h
+++ b/rsocket/internal/Common.h
@@ -63,6 +63,9 @@ enum class StreamType {
   FNF,
 };
 
+folly::StringPiece toString(StreamType);
+std::ostream& operator<<(std::ostream&, StreamType);
+
 enum class RequestOriginator {
   LOCAL,
   REMOTE,

--- a/rsocket/statemachine/RSocketStateMachine.h
+++ b/rsocket/statemachine/RSocketStateMachine.h
@@ -13,6 +13,7 @@
 #include "rsocket/framing/FrameProcessor.h"
 #include "rsocket/internal/Common.h"
 #include "rsocket/internal/KeepaliveTimer.h"
+#include "rsocket/statemachine/StreamFragmentAccumulator.h"
 #include "rsocket/statemachine/StreamState.h"
 #include "rsocket/statemachine/StreamsFactory.h"
 #include "rsocket/statemachine/StreamsWriter.h"
@@ -161,6 +162,13 @@ class RSocketStateMachine final
   DuplexConnection* getConnection();
 
  private:
+  template <typename WriteInitialFrame>
+  void writeFragmented(
+      WriteInitialFrame,
+      StreamId const,
+      FrameFlags const,
+      Payload payload);
+
   void connect(std::shared_ptr<FrameTransport>);
 
   /// Terminate underlying connection and connect new connection
@@ -231,6 +239,12 @@ class RSocketStateMachine final
   void handleStreamFrame(StreamId, FrameType, std::unique_ptr<folly::IOBuf>);
   void handleUnknownStream(StreamId, FrameType, std::unique_ptr<folly::IOBuf>);
 
+  void
+  setupRequestStream(StreamId streamId, uint32_t requestN, Payload payload);
+  void
+  setupRequestChannel(StreamId streamId, uint32_t requestN, Payload payload);
+  void setupRequestResponse(StreamId streamId, Payload payload);
+
   void closeStreams(StreamCompletionSignal);
   void closeFrameTransport(folly::exception_wrapper);
 
@@ -244,10 +258,13 @@ class RSocketStateMachine final
       StreamType streamType,
       uint32_t initialRequestN,
       Payload payload) override;
+
   void writeRequestN(Frame_REQUEST_N&&) override;
   void writeCancel(Frame_CANCEL&&) override;
 
   void writePayload(Frame_PAYLOAD&&) override;
+
+  // TODO: writeFragmentedError
   void writeError(Frame_ERROR&&) override;
 
   void onStreamClosed(StreamId streamId, StreamCompletionSignal signal)
@@ -277,6 +294,11 @@ class RSocketStateMachine final
 
   /// Per-stream frame buffer between the state machine and the FrameTransport.
   StreamState streamState_;
+
+  /// Accumulates the REQUEST payloads for new incoming streams which haven't
+  ///  been seen before (and therefore have no backing state machine in
+  /// streamState_ yet), and are fragmented
+  std::unordered_map<StreamId, StreamFragmentAccumulator> streamFragments_;
 
   // Manages all state needed for warm/cold resumption.
   std::shared_ptr<ResumeManager> resumeManager_;

--- a/rsocket/statemachine/StreamFragmentAccumulator.h
+++ b/rsocket/statemachine/StreamFragmentAccumulator.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "rsocket/Payload.h"
+#include "rsocket/framing/Frame.h"
+#include "rsocket/framing/FrameHeader.h"
+
+namespace rsocket {
+
+struct StreamFragmentAccumulator {
+  FrameHeader header;
+  uint32_t requestN{0};
+  Payload fragments;
+
+  StreamFragmentAccumulator(StreamFragmentAccumulator const&) = delete;
+  StreamFragmentAccumulator(StreamFragmentAccumulator&&) = default;
+
+  StreamFragmentAccumulator() {}
+
+  explicit StreamFragmentAccumulator(
+      Frame_REQUEST_Base const& frame,
+      Payload payload)
+      : StreamFragmentAccumulator(
+            frame.header_,
+            frame.requestN_,
+            std::move(payload)) {}
+
+  explicit StreamFragmentAccumulator(
+      Frame_REQUEST_RESPONSE const& frame,
+      Payload payload)
+      : StreamFragmentAccumulator(frame.header_, 0, std::move(payload)) {}
+
+ private:
+  explicit StreamFragmentAccumulator(
+      FrameHeader const& fh,
+      uint32_t requestN,
+      Payload payload)
+      : header(fh), requestN(requestN) {
+    addPayload(std::move(payload));
+  }
+
+ public:
+  void addPayload(Payload p) {
+    if (p.metadata) {
+      if (!fragments.metadata) {
+        fragments.metadata = std::move(p.metadata);
+      } else {
+        fragments.metadata->prev()->appendChain(std::move(p.metadata));
+      }
+    }
+
+    if (p.data) {
+      if (!fragments.data) {
+        fragments.data = std::move(p.data);
+      } else {
+        fragments.data->prev()->appendChain(std::move(p.data));
+      }
+    }
+  }
+
+  Payload consumePayload() {
+    return std::move(fragments);
+  }
+
+  bool anyFragments() const {
+    return fragments.data || fragments.metadata;
+  }
+};
+
+} /* namespace rsocket */

--- a/rsocket/statemachine/StreamState.h
+++ b/rsocket/statemachine/StreamState.h
@@ -25,8 +25,18 @@ class StreamState {
 
   std::deque<std::unique_ptr<folly::IOBuf>> moveOutputPendingFrames();
 
-  std::unordered_map<StreamId, std::shared_ptr<StreamStateMachineBase>>
-      streams_;
+  struct StreamStateElem {
+    StreamStateElem(std::shared_ptr<StreamStateMachineBase> sm)
+        : stateMachine(std::move(sm)) {}
+
+    StreamStateElem(StreamStateElem const&) = delete;
+    StreamStateElem(StreamStateElem&&) = default;
+
+    StreamFragmentAccumulator fragmentAccumulator;
+    std::shared_ptr<StreamStateMachineBase> stateMachine;
+  };
+
+  std::unordered_map<StreamId, StreamStateElem> streams_;
 
  private:
   /// Called to update stats when outputFrames_ is about to be cleared.

--- a/rsocket/statemachine/StreamStateMachineBase.h
+++ b/rsocket/statemachine/StreamStateMachineBase.h
@@ -2,9 +2,10 @@
 
 #pragma once
 
-#include <memory>
 #include <folly/ExceptionWrapper.h>
+#include <memory>
 #include "rsocket/internal/Common.h"
+#include "rsocket/statemachine/StreamFragmentAccumulator.h"
 
 namespace folly {
 class IOBuf;

--- a/yarpl/include/yarpl/single/SingleTestObserver.h
+++ b/yarpl/include/yarpl/single/SingleTestObserver.h
@@ -149,7 +149,10 @@ class SingleTestObserver : public yarpl::single::SingleObserver<T> {
       throw std::runtime_error("Did not receive terminal event.");
     }
     if (e_) {
-      throw std::runtime_error("Received onError instead of onSuccess");
+      std::stringstream ss;
+      ss << "Received onError instead of onSuccess";
+      ss << " (error was " << e_ << ")";
+      throw std::runtime_error(ss.str());
     }
   }
 


### PR DESCRIPTION
WIP implementation of fragmented requests for RSocket. Allows payloads > 16MB to be sent. Should be efficient and not copy large payloads, if IOBuf refcounting is working correctly under the hood. Should not incur much extra overhead if a payload is not fragmented (aside from a cheap check to see if any fragments for the current stream already exist; should be no more expensive than `if(pointer == null)`).

Test implemented:
 - Request/Response

Tests not implemented yet:
 - Request Stream
 - Request Channel

Existing testsuite should pass. 