### PR TITLE
Fix up public build

### DIFF
--- a/rsocket/examples/resumption/ColdResumption_Client.cpp
+++ b/rsocket/examples/resumption/ColdResumption_Client.cpp
@@ -22,8 +22,7 @@ typedef std::map<std::string, std::shared_ptr<Subscriber<Payload>>> HelloSubscri
 
 namespace {
 
-class HelloSubscriber : public virtual Refcounted,
-                        public Subscriber<Payload> {
+class HelloSubscriber : public Subscriber<Payload> {
  public:
   void request(int n) {
     while (!subscription_) {

--- a/rsocket/examples/resumption/WarmResumption_Client.cpp
+++ b/rsocket/examples/resumption/WarmResumption_Client.cpp
@@ -21,8 +21,7 @@ DEFINE_int32(port, 9898, "host:port to connect to");
 
 namespace {
 
-class HelloSubscriber : public virtual yarpl::Refcounted,
-                        public yarpl::flowable::Subscriber<Payload> {
+class HelloSubscriber : public yarpl::flowable::Subscriber<Payload> {
  public:
   void request(int n) {
     LOG(INFO) << "... requesting " << n;

--- a/rsocket/tck-test/BaseSubscriber.h
+++ b/rsocket/tck-test/BaseSubscriber.h
@@ -10,7 +10,7 @@
 namespace rsocket {
 namespace tck {
 
-class BaseSubscriber : public virtual yarpl::Refcounted {
+class BaseSubscriber {
  public:
   virtual void request(int n) = 0;
   virtual void cancel() = 0;

--- a/rsocket/tck-test/MarbleProcessor.h
+++ b/rsocket/tck-test/MarbleProcessor.h
@@ -14,9 +14,8 @@ class MarbleProcessor {
  public:
   explicit MarbleProcessor(const std::string /* marble */);
 
-  std::tuple<int64_t, bool> run(
-      std::shared_ptr<yarpl::flowable::Subscriber<rsocket::Payload>>
-          subscriber,
+  void run(
+      yarpl::flowable::Subscriber<rsocket::Payload>& subscriber,
       int64_t requested);
 
   void run(std::shared_ptr<yarpl::single::SingleObserver<rsocket::Payload>>

--- a/rsocket/tck-test/server.cpp
+++ b/rsocket/tck-test/server.cpp
@@ -88,8 +88,7 @@ class ServerResponder : public RSocketResponder {
     } else {
       auto marbleProcessor = std::make_shared<tck::MarbleProcessor>(it->second);
       auto lambda = [marbleProcessor](
-          std::shared_ptr<yarpl::flowable::Subscriber<rsocket::Payload>> subscriber,
-          int64_t requested) mutable {
+          auto& subscriber, int64_t requested) mutable {
         return marbleProcessor->run(subscriber, requested);
       };
       return Flowable<rsocket::Payload>::create(std::move(lambda));

--- a/yarpl/CMakeLists.txt
+++ b/yarpl/CMakeLists.txt
@@ -76,6 +76,7 @@ add_library(
         include/yarpl/flowable/Subscription.h
         include/yarpl/flowable/TestSubscriber.h
         src/yarpl/flowable/sources/Subscription.cpp
+        src/yarpl/flowable/sources/Flowables.cpp
         # Observable public API
         include/yarpl/Observable.h
         include/yarpl/observable/Observable.h
@@ -142,8 +143,6 @@ if (BUILD_TESTS)
     test/FlowableTest.cpp
     test/FlowableFlatMapTest.cpp
     test/Observable_test.cpp
-    test/RefcountedTest.cpp
-    test/ReferenceTest.cpp
     test/SubscribeObserveOnTests.cpp
     test/Single_test.cpp
     test/FlowableSubscriberTest.cpp

--- a/yarpl/examples/FlowableExamples.cpp
+++ b/yarpl/examples/FlowableExamples.cpp
@@ -97,10 +97,9 @@ void FlowableExamples::run() {
   Flowables::range(1, 11)->take(3)->subscribe(printer<int64_t>());
 
   auto flowable = Flowable<int>::create([total = 0](
-      std::shared_ptr<Subscriber<int>> subscriber, int64_t requested) mutable {
-    subscriber->onNext(12345678);
-    subscriber->onError(std::runtime_error("error"));
-    return std::make_tuple(int64_t{1}, false);
+      auto& subscriber, int64_t requested) mutable {
+    subscriber.onNext(12345678);
+    subscriber.onError(std::runtime_error("error"));
   });
 
   auto subscriber = Subscribers::create<int>(


### PR DESCRIPTION
Recent internal changes haven't kept the examples dir or CMakeLists up to date, fixes them up so it'll build on Travis and `make` doesn't fail.