### PR TITLE
Flowable<T>::makeFlowable

### DIFF
--- a/yarpl/CMakeLists.txt
+++ b/yarpl/CMakeLists.txt
@@ -149,6 +149,7 @@ if (BUILD_TESTS)
     test/MocksTest.cpp
     test/FlowableTest.cpp
     test/FlowableFlatMapTest.cpp
+    test/FlowableMakeFlowableTest.cpp
     test/Observable_test.cpp
     test/PublishProcessorTest.cpp
     test/SubscribeObserveOnTests.cpp

--- a/yarpl/include/yarpl/flowable/Flowable.h
+++ b/yarpl/include/yarpl/flowable/Flowable.h
@@ -181,6 +181,9 @@ class Flowable : public yarpl::enable_get_ref {
     return Flowable<T>::create(std::move(lambda));
   }
 
+  template <typename OnSubscribe>
+  static std::shared_ptr<Flowable<T>> makeFlowable(OnSubscribe function);
+
   template <typename TGenerator>
   static std::shared_ptr<Flowable<T>> fromGenerator(TGenerator generator);
 
@@ -393,6 +396,13 @@ template <typename T>
 template <typename OnSubscribe, typename>
 std::shared_ptr<Flowable<T>> Flowable<T>::fromPublisher(OnSubscribe function) {
   return internal::flowableFromSubscriber<T>(std::move(function));
+}
+
+template <typename T>
+template <typename OnSubscribe>
+std::shared_ptr<Flowable<T>> Flowable<T>::makeFlowable(OnSubscribe function) {
+  return std::make_shared<MakeFlowableOperator<T, OnSubscribe>>(
+      std::move(function));
 }
 
 template <typename T>

--- a/yarpl/test/FlowableMakeFlowableTest.cpp
+++ b/yarpl/test/FlowableMakeFlowableTest.cpp
@@ -1,0 +1,122 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "yarpl/Flowable.h"
+#include <gtest/gtest.h>
+#include <type_traits>
+#include <vector>
+#include "yarpl/flowable/TestSubscriber.h"
+#include "yarpl/test_utils/Mocks.h"
+
+namespace yarpl {
+namespace flowable {
+
+namespace {
+
+// until proper CallbackSubscription lands
+template <typename OnReq, typename OnCancel>
+struct TmpCallbackSubscription : Subscription {
+  OnReq req_;
+  OnCancel cancel_;
+
+  TmpCallbackSubscription(OnReq r, OnCancel c)
+      : req_(std::move(r)), cancel_(std::move(c)) {}
+
+  void cancel() override {
+    cancel_();
+  }
+
+  void request(int64_t req) override {
+    req_(req);
+  }
+};
+
+template <typename OnReq, typename OnCancel>
+auto makeCallbackSub(OnReq r, OnCancel c) {
+  return std::make_shared<TmpCallbackSubscription<OnReq, OnCancel>>(
+      std::move(r), std::move(c));
+}
+
+template <typename OnReq>
+auto makeCallbackSub(OnReq r) {
+  return makeCallbackSub(r, []() {});
+}
+
+std::shared_ptr<Flowable<int>> makeRange(int max = 10000) {
+  struct State {
+    int i;
+    int max;
+    State(int i, int max) : i{i}, max{max} {}
+  };
+
+  return Flowable<int>::makeFlowable([max](auto subscriber) {
+    auto state = std::make_shared<State>(0, max);
+    return makeCallbackSub([=](int64_t req) {
+      while (req--) {
+        subscriber->onNext(state->i++);
+        if (state->i == state->max) {
+          subscriber->onComplete();
+          break;
+        }
+      }
+    });
+  });
+}
+
+} // namespace
+
+TEST(MakeFlowableTest, TestTakeLimited) {
+  auto flowable = makeRange();
+  auto ts = std::make_shared<TestSubscriber<int>>(5);
+  flowable->subscribe(ts);
+  ts->awaitValueCount(5);
+  EXPECT_EQ(ts->values().size(), 5UL);
+  EXPECT_EQ(ts->values(), (std::vector<int>{0, 1, 2, 3, 4}));
+  EXPECT_TRUE(!ts->isComplete()); // subscriber only ran out of credits, range
+                                  // hasn't ran out though
+}
+
+TEST(MakeFlowableTest, TestTakeOpZero) {
+  auto flowable = makeRange()->take(0);
+  auto ts = std::make_shared<TestSubscriber<int>>();
+  flowable->subscribe(ts);
+
+  ts->awaitTerminalEvent();
+  EXPECT_EQ(ts->getValueCount(), 0);
+  EXPECT_TRUE(ts->isComplete()); // take should terminate the subscriber
+}
+
+TEST(MakeFlowableTest, TestTakeOpFinite) {
+  auto flowable = makeRange()->take(3);
+  auto ts = std::make_shared<TestSubscriber<int>>();
+  flowable->subscribe(ts);
+
+  ts->awaitTerminalEvent();
+  EXPECT_EQ(ts->getValueCount(), 3);
+  EXPECT_EQ(ts->values(), (std::vector<int>{0, 1, 2}));
+  EXPECT_TRUE(ts->isComplete());
+}
+
+TEST(MakeFlowableTest, TestFiniteRange) {
+  auto flowable = makeRange(3);
+  auto ts = std::make_shared<TestSubscriber<int>>();
+  flowable->subscribe(ts);
+
+  ts->awaitTerminalEvent();
+  EXPECT_EQ(ts->getValueCount(), 3);
+  EXPECT_EQ(ts->values(), (std::vector<int>{0, 1, 2}));
+  EXPECT_TRUE(ts->isComplete());
+}
+
+TEST(MakeFlowableTest, ErrorFlowable) {
+  auto flowable = Flowable<int>::makeFlowable(
+      [](auto sub) { sub->onError(std::runtime_exception{"foo"}); });
+
+  auto ts = std::make_shared<TestSubscriber<int>>();
+  flowable->subscribe(ts);
+  ts->awaitTerminalEvent();
+  EXPECT_TRUE(ts->isError());
+  EXPECT_TRUE(ts->errorMessage(), "foo");
+}
+
+} // namespace flowable
+} // namespace yarpl

--- a/yarpl/test/FlowableSubscriberTest.cpp
+++ b/yarpl/test/FlowableSubscriberTest.cpp
@@ -47,7 +47,7 @@ TEST(FlowableSubscriberTest, TestKeepRefToThisIsDisabled) {
   {
     InSequence s;
     EXPECT_CALL(*subscriber, onSubscribeImpl()).Times(1).WillOnce(Invoke([&] {
-      EXPECT_EQ(1UL, subscriber.use_count());
+      EXPECT_EQ(1L, subscriber.use_count());
     }));
   }
 
@@ -63,7 +63,7 @@ TEST(FlowableSubscriberTest, TestKeepRefToThisIsEnabled) {
   {
     InSequence s;
     EXPECT_CALL(*subscriber, onSubscribeImpl()).Times(1).WillOnce(Invoke([&] {
-      EXPECT_EQ(2UL, subscriber.use_count());
+      EXPECT_EQ(2L, subscriber.use_count());
     }));
   }
 

--- a/yarpl/test/FlowableTest.cpp
+++ b/yarpl/test/FlowableTest.cpp
@@ -831,11 +831,11 @@ TEST(FlowableTest, ConcatWithMultipleTest) {
 TEST(FlowableTest, ConcatWithExceptionTest) {
   auto first = Flowable<>::range(1, 2);
   auto second = Flowable<>::range(5, 2);
-  auto third = Flowable<long>::error(std::runtime_error("error"));
+  auto third = Flowable<int64_t>::error(std::runtime_error("error"));
 
   auto combined = first->concatWith(second)->concatWith(third);
 
-  auto subscriber = std::make_shared<TestSubscriber<long>>();
+  auto subscriber = std::make_shared<TestSubscriber<int64_t>>();
   combined->subscribe(subscriber);
 
   EXPECT_EQ(subscriber->values(), std::vector<int64_t>({1, 2, 5, 6}));
@@ -852,7 +852,7 @@ TEST(FlowableTest, ConcatWithFlowControlTest) {
   auto thirdFourth = third->concatWith(fourth);
   auto combined = firstSecond->concatWith(thirdFourth);
 
-  auto subscriber = std::make_shared<TestSubscriber<long>>(0);
+  auto subscriber = std::make_shared<TestSubscriber<int64_t>>(0);
   combined->subscribe(subscriber);
   EXPECT_EQ(subscriber->values(), std::vector<int64_t>{});
 
@@ -871,7 +871,7 @@ TEST(FlowableTest, ConcatWithCancel) {
   auto second = Flowable<>::range(5, 2);
 
   auto combined = first->concatWith(second);
-  auto subscriber = std::make_shared<TestSubscriber<long>>(0);
+  auto subscriber = std::make_shared<TestSubscriber<int64_t>>(0);
 
   MockFunction<void()> checkpoint;
   EXPECT_CALL(checkpoint, Call());


### PR DESCRIPTION
Easier and less bugprone way of making a flowable out of an invokable which directly takes a Subscriber. It's much harder to forget how to do flow control when the object being called *is* the subscription, which captures the provided subscriber.