### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ C++ implementation of [RSocket](https://rsocket.io)
 Install `folly`:
 
 ```
-brew install --HEAD folly
+brew install folly
 ```
 
 # Building and running tests


### PR DESCRIPTION
Installing HEAD is not needed for Folly.
Better to install the latest release `brew install folly`