### PR TITLE
Build with clang-6.0 instead of clang-4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,22 +37,18 @@ addons:
 
 matrix:
   include:
-    # Set COMPILER environment variable instead of CC or CXX because the latter
-    # are overriden by Travis. Setting the compiler in Travis doesn't work
-    # either because it strips version.
-
-    - env: COMPILER=clang-4.0
+    - env: COMPILER_EVAL="CC=clang-6.0 CXX=clang++-6.0"
       addons:
         apt:
           sources:
             - *common_srcs
-            - llvm-toolchain-trusty-4.0
+            - llvm-toolchain-trusty-6.0
           packages:
             - *common_deps
-            - clang-4.0
+            - clang-6.0
             - libstdc++-4.9-dev
 
-    - env: COMPILER=gcc-5
+    - env: COMPILER_EVAL="CC=gcc-5 CXX=g++-5"
       addons:
         apt:
           sources:
@@ -61,7 +57,7 @@ matrix:
             - *common_deps
             - g++-5
 
-    - env: COMPILER=gcc-6
+    - env: COMPILER_EVAL="CC=gcc-6 CXX=g++-6"
       addons:
         apt:
           sources:
@@ -93,11 +89,12 @@ before_script:
   # Install lcov to coveralls conversion + upload tool.
   - gem install coveralls-lcov
   - lcov --version
+  - eval "$COMPILER_EVAL"
 
 script:
   - mkdir build
   - cd build
-  - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DRSOCKET_CC=$COMPILER
+  - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE
           -DRSOCKET_ASAN=$ASAN -DRSOCKET_INSTALL_DEPS=True
           -DRSOCKET_BUILD_WITH_COVERAGE=ON ..
   - make -j4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,5 @@
 cmake_minimum_required(VERSION 3.2)
 
-# The RSOCKET_CC CMake variable specifies the C compiler, e.g. gcc-4.9.
-# The C++ compiler name is obtained by replacing "gcc" with "g++" and "clang"
-# with "clang++"". If RSOCKET_CC is not given, the compiler is detected
-# automatically.
-if (RSOCKET_CC)
-  set(ENV{CC} ${RSOCKET_CC})
-  if (${RSOCKET_CC} MATCHES clang)
-    string(REPLACE clang clang++ CXX ${RSOCKET_CC})
-  else ()
-    string(REPLACE gcc g++ CXX ${RSOCKET_CC})
-  endif ()
-  set(ENV{CXX} ${CXX})
-endif ()
-
 project(ReactiveSocket)
 
 # CMake modules.


### PR DESCRIPTION
folly does not compile with versions of clang older than 6.0 these days.

Also set CC and CXX in the environment so that folly and gmock get built
with the intended compiler instead of being compiled with the default
system compiler (gcc 4.8.4 on Ubuntu trusty).  folly no longer compiles
with gcc 4.8 either.