### PR TITLE
Export rsocket, yarpl CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ endif ()
 
 option(BUILD_BENCHMARKS "Build benchmarks" ON)
 option(BUILD_EXAMPLES "Build examples" ON)
+option(BUILD_TESTS "Build tests" ON)
 
 enable_testing()
 
@@ -186,9 +187,6 @@ include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
 include_directories(SYSTEM ${GFLAGS_INCLUDE_DIR})
 include_directories(SYSTEM ${GLOG_INCLUDE_DIR})
 
-include_directories(${CMAKE_SOURCE_DIR})
-
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/reactivestreams/include)
 include_directories(${GMOCK_SOURCE_DIR}/googlemock/include)
 include_directories(${GMOCK_SOURCE_DIR}/googletest/include)
 
@@ -307,6 +305,14 @@ add_library(
   rsocket/transports/tcp/TcpDuplexConnection.cpp
   rsocket/transports/tcp/TcpDuplexConnection.h)
 
+target_include_directories(
+    ReactiveSocket
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:include>
+)
+
+
 target_link_libraries(ReactiveSocket
     PUBLIC yarpl ${GFLAGS_LIBRARY} ${GLOG_LIBRARY}
     INTERFACE ${EXTRA_LINK_FLAGS})
@@ -317,9 +323,21 @@ target_compile_options(
 
 enable_testing()
 
-install(TARGETS ReactiveSocket DESTINATION lib)
+install(TARGETS ReactiveSocket EXPORT rsocket-exports DESTINATION lib)
 install(DIRECTORY rsocket DESTINATION include FILES_MATCHING PATTERN "*.h")
+install(EXPORT rsocket-exports NAMESPACE rsocket:: DESTINATION lib/cmake/rsocket)
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    cmake/rsocket-config.cmake.in
+    rsocket-config.cmake
+    INSTALL_DESTINATION lib/cmake/rsocket
+)
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/rsocket-config.cmake
+    DESTINATION lib/cmake/rsocket
+)
 
+if(BUILD_TESTS)
 add_executable(
   tests
   rsocket/test/ColdResumptionTest.cpp
@@ -398,6 +416,7 @@ add_test(
   NAME FrameFuzzerTests
   COMMAND ./scripts/frame_fuzzer_test.sh
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+endif()
 
 ########################################
 # TCK Drivers

--- a/cmake/rsocket-config.cmake.in
+++ b/cmake/rsocket-config.cmake.in
@@ -1,0 +1,12 @@
+# Copyright (c) 2018, Facebook, Inc.
+# All rights reserved.
+
+@PACKAGE_INIT@
+
+if(NOT TARGET rsocket::ReactiveSocket)
+    include("${PACKAGE_PREFIX_DIR}/lib/cmake/rsocket/rsocket-exports.cmake")
+endif()
+
+if (NOT rsocket_FIND_QUIETLY)
+    message(STATUS "Found rsocket: ${PACKAGE_PREFIX_DIR}")
+endif()

--- a/yarpl/CMakeLists.txt
+++ b/yarpl/CMakeLists.txt
@@ -1,8 +1,4 @@
 cmake_minimum_required (VERSION 3.2)
-
-# To debug the project, set the build type.
-set(CMAKE_BUILD_TYPE Debug)
-
 project (yarpl)
 
 # CMake Config
@@ -57,9 +53,6 @@ message("glog include_dir <${GLOG_INCLUDE_DIR}> lib <${GLOG_LIBRARY}>")
 
 include_directories(SYSTEM ${GLOG_INCLUDE_DIR})
 
-message("including ${CMAKE_CURRENT_SOURCE_DIR}")
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-
 # library source
 add_library(
         yarpl
@@ -109,11 +102,12 @@ add_library(
         # utils
         utils/credits.h
         utils/credits.cpp)
-
 target_include_directories(
-        yarpl
-        PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../" # allow include paths such as "yarpl/observable.h"
-        )
+    yarpl
+    PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>
+    $<INSTALL_INTERFACE:include>
+)
 
 message("yarpl source dir: ${CMAKE_CURRENT_SOURCE_DIR}")
 
@@ -122,8 +116,23 @@ target_link_libraries(
   PUBLIC Folly::folly ${GLOG_LIBRARY}
   INTERFACE ${EXTRA_LINK_FLAGS})
 
-install(TARGETS yarpl DESTINATION lib)
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    cmake/yarpl-config.cmake.in
+    yarpl-config.cmake
+    INSTALL_DESTINATION lib/cmake/yarpl
+)
+install(TARGETS yarpl EXPORT yarpl-exports DESTINATION lib)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION include FILES_MATCHING PATTERN "*.h")
+install(
+    EXPORT yarpl-exports
+    NAMESPACE yarpl::
+    DESTINATION lib/cmake/yarpl
+)
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/yarpl-config.cmake
+    DESTINATION lib/cmake/yarpl
+)
 
 # RSocket's tests also has dependency on this library
 add_library(

--- a/yarpl/cmake/yarpl-config.cmake.in
+++ b/yarpl/cmake/yarpl-config.cmake.in
@@ -1,0 +1,13 @@
+# Copyright (c) 2018, Facebook, Inc.
+# All rights reserved.
+
+@PACKAGE_INIT@
+
+if(NOT TARGET yarpl::yarpl)
+    include("${PACKAGE_PREFIX_DIR}/lib/cmake/yarpl/yarpl-exports.cmake")
+endif()
+
+set(YARPL_LIBRARIES yarpl::yarpl)
+if (NOT yarpl_FIND_QUIETLY)
+    message(STATUS "Found YARPL: ${PACKAGE_PREFIX_DIR}")
+endif()


### PR DESCRIPTION
Summary:
* Adds a flag to skip building tests.
* Exports rsocket::ReactiveSocket and yarpl::yarpl targets, so that downstream
  packages can pick them up with a find_package(rsocket) or a find_package(yarpl)

fbthrift perf examples need this to compile properly.

Reviewed By: phoad

Differential Revision: D13312594
