### PR TITLE
add BUILD_TCK_TESTS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ endif ()
 option(BUILD_BENCHMARKS "Build benchmarks" ON)
 option(BUILD_EXAMPLES "Build examples" ON)
 option(BUILD_TESTS "Build tests" ON)
+option(BUILD_TCK_TESTS "Build TCK tests" ON)
 
 enable_testing()
 
@@ -416,6 +417,7 @@ endif()
 # TCK Drivers
 ########################################
 
+if(BUILD_TCK_TESTS)
 add_executable(
   tckclient
   rsocket/tck-test/client.cpp
@@ -466,6 +468,8 @@ if (NOT EXISTS ${CMAKE_SOURCE_DIR}/${TCK_DRIVERS_JAR})
   message(STATUS "Downloading ${TCK_DRIVERS_URL}")
   file(DOWNLOAD ${TCK_DRIVERS_URL} ${CMAKE_SOURCE_DIR}/${TCK_DRIVERS_JAR})
 endif ()
+
+endif () # BUILD_TCK_TESTS
 
 ########################################
 # Examples


### PR DESCRIPTION
with BUILD_TCK_TESTS option introduced, it's easy to accelerate build for release. 

```
cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DBUILD_TCK_TESTS=OFF ..
```