### PR TITLE
yarlpl: Fix compilation with newer GCC

### DIFF
--- a/yarpl/Refcounted.h
+++ b/yarpl/Refcounted.h
@@ -42,7 +42,7 @@ std::shared_ptr<T> atomic_exchange(
   auto refptr = ar->ref.lock();
   auto old = std::move(*refptr);
   *refptr = std::move(r);
-  return std::move(old);
+  return old;
 }
 
 template <typename T>


### PR DESCRIPTION
Refcounted.h:45:23: error: moving a local object in a return statement
prevents copy elision [-Werror=pessimizing-move]
   45 |   return std::move(old);
