### PR TITLE
Fix MarbleProcessor's fall through switch cases

### DIFF
--- a/rsocket/tck-test/MarbleProcessor.cpp
+++ b/rsocket/tck-test/MarbleProcessor.cpp
@@ -83,20 +83,19 @@ void MarbleProcessor::run(
     yarpl::flowable::Subscriber<rsocket::Payload>& subscriber,
     int64_t requested) {
   canSend_ += requested;
-  if (index_ > marble_.size()) {
-    return;
-  }
 
-  while (true) {
+  while (canSend_ > 0 && index_ < marble_.size()) {
     const auto c = marble_[index_];
     switch (c) {
       case '#':
         LOG(INFO) << "Sending onError";
         subscriber.onError(std::runtime_error("Marble Error"));
+        break;
       case '|':
         LOG(INFO) << "Sending onComplete";
         subscriber.onComplete();
-      default: {
+        break;
+      default:
         if (canSend_ > 0) {
           Payload payload;
           const auto it = argMap_.find(folly::to<std::string>(c));
@@ -115,7 +114,7 @@ void MarbleProcessor::run(
           subscriber.onNext(std::move(payload));
           canSend_--;
         }
-      }
+        break;
     }
     index_++;
   }


### PR DESCRIPTION
The build of RSocket fails in this Ubuntu 18.04 Docker environment.
The reason is the fall through switch statements.

```
/home/rsocket-cpp/rsocket/tck-test/MarbleProcessor.cpp:95:33: warning: this statement may fall through [-Wimplicit-fallthrough=]
         subscriber.onError(std::runtime_error("Marble Error"));
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/rsocket-cpp/rsocket/tck-test/MarbleProcessor.cpp:96:7: note: here
       case '|':
       ^~~~
/home/rsocket-cpp/rsocket/tck-test/MarbleProcessor.cpp:98:30: warning: this statement may fall through [-Wimplicit-fallthrough=]
         subscriber.onComplete();
         ~~~~~~~~~~~~~~~~~~~~~^~
/home/rsocket-cpp/rsocket/tck-test/MarbleProcessor.cpp:99:7: note: here
       default: {
```

As long as the marble_ has more items and more messages are expected from the subscriber, 
it will continue publishing to the subscriber. 