### PR TITLE
client: respond to KEEPALIVE(RESPOND) frame

### DIFF
--- a/rsocket/statemachine/RSocketStateMachine.cpp
+++ b/rsocket/statemachine/RSocketStateMachine.cpp
@@ -530,8 +530,7 @@ void RSocketStateMachine::onKeepAliveFrame(
     }
   } else {
     if (keepAliveRespond) {
-      closeWithError(Frame_ERROR::connectionError(
-          "client received keepalive with respond flag"));
+      sendKeepalive(FrameFlags::EMPTY_, std::move(data));
     } else if (keepaliveTimer_) {
       keepaliveTimer_->keepaliveReceived();
     }


### PR DESCRIPTION
Client sends KEEPALIVE(EMPTY) in this case.

## Motivation and Context

This change is required for the rsocket-cpp client to be able to
work with current rsocket-java and rsocket-kotlin servers, which
do send KEEPALIVE(RESPOND) to the client.

## How Has This Been Tested

Tested with rsocket-cpp, rsocket-kotlin and rsocket-java servers.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
